### PR TITLE
feat: revamp server MQTT for UltraNodeV5

### DIFF
--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -21,12 +21,8 @@ class Settings:
     API_BEARER = os.getenv("API_BEARER", "")
     MANIFEST_HMAC_SECRET = os.getenv("MANIFEST_HMAC_SECRET", "")
 
-    MQTT_COMPAT_PUBLISH_BOTH = os.getenv("MQTT_COMPAT_PUBLISH_BOTH", "1") == "1"
-    # legacy/global topics
-    LEGACY_TOPIC_COLOR  = os.getenv("LEGACY_TOPIC_COLOR", "strip/cmd/color")
-    LEGACY_TOPIC_EFFECT = os.getenv("LEGACY_TOPIC_EFFECT", "strip/cmd/effect")
-    LEGACY_TOPIC_SPACEY = os.getenv("LEGACY_TOPIC_SPACEY", "strip/cmd/spacey")
-    LEGACY_TOPIC_OTA    = os.getenv("LEGACY_TOPIC_OTA",    "strip/cmd/ota")
+    # ------------------------------------------------------------------
+    # Device registry ---------------------------------------------------
 
     # registry of houses/rooms/nodes as JSON
     DEFAULT_REGISTRY = [
@@ -41,8 +37,8 @@ class Settings:
                         {
                             "id": "del-sur-kitchen-node1",
                             "name": "Kitchen Node",
-                            "kind": "rgb",
-                            "modules": ["color", "effect", "brightness", "motion", "ota"],
+                            "kind": "ultranode",
+                            "modules": ["ws", "white", "sensor", "ota"],
                         }
                     ],
                 },
@@ -53,8 +49,8 @@ class Settings:
                         {
                             "id": "del-sur-room-1-node1",
                             "name": "Room 1 Node",
-                            "kind": "rgb",
-                            "modules": ["color", "effect", "brightness", "motion", "ota"],
+                            "kind": "ultranode",
+                            "modules": ["ws", "white", "sensor", "ota"],
                         }
                     ],
                 },
@@ -71,8 +67,8 @@ class Settings:
                         {
                             "id": "sdsu-kitchen-node1",
                             "name": "Kitchen Node",
-                            "kind": "rgb",
-                            "modules": ["color", "effect", "brightness", "motion", "ota"],
+                            "kind": "ultranode",
+                            "modules": ["ws", "white", "sensor", "ota"],
                         }
                     ],
                 },
@@ -83,8 +79,8 @@ class Settings:
                         {
                             "id": "sdsu-room-1-node1",
                             "name": "Room 1 Node",
-                            "kind": "rgb",
-                            "modules": ["color", "effect", "brightness", "motion", "ota"],
+                            "kind": "ultranode",
+                            "modules": ["ws", "white", "sensor", "ota"],
                         }
                     ],
                 },

--- a/Server/app/device_registry.json
+++ b/Server/app/device_registry.json
@@ -10,12 +10,11 @@
           {
             "id": "del-sur-kitchen-node1",
             "name": "Kitchen Node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           }
@@ -28,24 +27,22 @@
           {
             "id": "del-sur-room-1-node1",
             "name": "Room 1 Node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           },
           {
             "id": "node",
             "name": "node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           }
@@ -64,12 +61,11 @@
           {
             "id": "sdsu-kitchen-node1",
             "name": "Kitchen Node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           }
@@ -82,12 +78,11 @@
           {
             "id": "sdsu-room-1-node1",
             "name": "Room 1 Node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           }

--- a/Server/app/mqtt_bus.py
+++ b/Server/app/mqtt_bus.py
@@ -1,16 +1,12 @@
 import threading
 import json
+from typing import Optional, List, Dict
 import paho.mqtt.client as paho
 from .config import settings
 from . import registry
 
-# New per-node topics (clean naming)
-# lights/{id}/cmd/{color,effect,spacey,white,brightness,ota}
-def topic_node(id_: str, leaf: str) -> str:
-    return f"lights/{id_}/cmd/{leaf}"
-
-def topic_status(id_: str, leaf: str) -> str:
-    return f"lights/{id_}/status/{leaf}"
+def topic_cmd(node_id: str, path: str) -> str:
+    return f"ul/{node_id}/cmd/{path}"
 
 class MqttBus:
     def __init__(self):
@@ -19,55 +15,52 @@ class MqttBus:
         self.thread = threading.Thread(target=self.client.loop_forever, daemon=True)
         self.thread.start()
 
-    def pub(self, topic: str, payload: str, qos: int = 1, retain: bool = True):
-        self.client.publish(topic, payload=payload, qos=qos, retain=retain)
+    def pub(self, topic: str, payload: Dict[str, object]):
+        self.client.publish(topic, payload=json.dumps(payload), qos=1, retain=False)
 
-    # --------- Compatibility helpers ----------
-    def send_color(self, node_id: str, r: int, g: int, b: int):
-        msg_legacy = f"{r},{g},{b}"
-        msg = json.dumps({"r": int(r), "g": int(g), "b": int(b)})
-        if settings.MQTT_COMPAT_PUBLISH_BOTH:
-            self.pub(settings.LEGACY_TOPIC_COLOR, msg_legacy, retain=True)
-        self.pub(topic_node(node_id, "color"), msg, retain=True)
+    # ---- WS strip commands ----
+    def ws_set(self, node_id: str, strip: int, effect: Optional[str] = None,
+               color: Optional[List[int]] = None, brightness: Optional[int] = None):
+        msg: Dict[str, object] = {"strip": int(strip)}
+        if effect:
+            msg["effect"] = effect
+        if color:
+            msg["color"] = [int(x) for x in color]
+        if brightness is not None:
+            msg["brightness"] = int(brightness)
+        self.pub(topic_cmd(node_id, "ws/set"), msg)
 
-    def send_effect(self, node_id: str, name: str):
-        msg = json.dumps({"name": name})
-        if settings.MQTT_COMPAT_PUBLISH_BOTH:
-            self.pub(settings.LEGACY_TOPIC_EFFECT, name, retain=True)
-        self.pub(topic_node(node_id, "effect"), msg, retain=True)
+    def ws_power(self, node_id: str, strip: int, on: bool):
+        msg = {"strip": int(strip), "on": bool(on)}
+        self.pub(topic_cmd(node_id, "ws/power"), msg)
 
-    def send_spacey(self, node_id: str, c1: str, c2: str, c3: str):
-        # c1,c2,c3 are "r,g,b"
-        msg = json.dumps({"c1": c1, "c2": c2, "c3": c3})
-        if settings.MQTT_COMPAT_PUBLISH_BOTH:
-            self.pub(settings.LEGACY_TOPIC_SPACEY, f"{c1}|{c2}|{c3}", retain=True)
-        self.pub(topic_node(node_id, "spacey"), msg, retain=True)
+    # ---- White channel commands ----
+    def white_set(self, node_id: str, channel: int, effect: Optional[str] = None,
+                  brightness: Optional[int] = None):
+        msg: Dict[str, object] = {"channel": int(channel)}
+        if effect:
+            msg["effect"] = effect
+        if brightness is not None:
+            msg["brightness"] = int(brightness)
+        self.pub(topic_cmd(node_id, "white/set"), msg)
 
-    def send_brightness(self, node_id: str, level: int):
-        # 0-255
-        msg = json.dumps({"level": int(level)})
-        self.pub(topic_node(node_id, "brightness"), msg, retain=True)
+    def white_power(self, node_id: str, channel: int, on: bool):
+        msg = {"channel": int(channel), "on": bool(on)}
+        self.pub(topic_cmd(node_id, "white/power"), msg)
 
-    def send_white(self, node_id: str, level: int):
-        # level 0-255 for simple white strips
-        msg = json.dumps({"level": int(level)})
-        self.pub(topic_node(node_id, "white"), msg, retain=True)
+    # ---- Sensor commands ----
+    def sensor_cooldown(self, node_id: str, seconds: int):
+        msg = {"seconds": int(seconds)}
+        self.pub(topic_cmd(node_id, "sensor/cooldown"), msg)
 
-    def send_ota(self, node_id: str, url: str, retain: bool = False):
-        msg = json.dumps({"now": url})
-        if settings.MQTT_COMPAT_PUBLISH_BOTH:
-            self.pub(settings.LEGACY_TOPIC_OTA, url, retain=retain)
-        self.pub(topic_node(node_id, "ota"), msg, retain=retain)
-
-    def send_motion(self, node_id: str, enabled: bool):
-        msg = json.dumps({"enabled": bool(enabled)})
-        self.pub(topic_node(node_id, "motion"), msg, retain=True)
+    # ---- OTA ----
+    def ota_check(self, node_id: str):
+        self.pub(topic_cmd(node_id, "ota/check"), {})
 
     def all_off(self):
-        """Turn off all known nodes regardless of location."""
-        # Broadcast-style: set RGB to 0 and brightness to 0 for each node
+        """Turn off all known nodes."""
         for _, _, n in registry.iter_nodes():
             nid = n["id"]
-            self.send_color(nid, 0, 0, 0)
-            self.send_brightness(nid, 0)
-            self.send_effect(nid, "static")  # ensure static black holds
+            for i in range(4):
+                self.ws_power(nid, i, False)
+                self.white_power(nid, i, False)

--- a/Server/app/registry.py
+++ b/Server/app/registry.py
@@ -93,7 +93,7 @@ def add_node(
     house_id: str,
     room_id: str,
     name: str,
-    kind: str = "rgb",
+    kind: str = "ultranode",
     modules: Optional[list[str]] = None,
 ) -> Node:
     """Create and attach a new node under ``house_id``/``room_id``."""
@@ -101,7 +101,7 @@ def add_node(
     if not room:
         raise KeyError("room not found")
     node = {"id": slugify(name), "name": name, "kind": kind}
-    node["modules"] = modules or ["color", "effect", "brightness", "motion", "ota"]
+    node["modules"] = modules or ["ws", "white", "sensor", "ota"]
     room.setdefault("nodes", []).append(node)
     save_registry()
     return node

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -1,20 +1,18 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import JSONResponse
 from .mqtt_bus import MqttBus
-from .config import settings
 from . import registry
 
 router = APIRouter()
-BUS: MqttBus | None = None
+BUS: Optional[MqttBus] = None
 
 def get_bus() -> MqttBus:
     global BUS
-    if BUS is None: BUS = MqttBus()
+    if BUS is None:
+        BUS = MqttBus()
     return BUS
 
 def _valid_node(node_id: str) -> Dict[str, Any]:
-    """Return node dict for ``node_id`` or raise 404."""
     _, _, node = registry.find_node(node_id)
     if node:
         return node
@@ -24,7 +22,6 @@ def _valid_node(node_id: str) -> Dict[str, Any]:
 def api_all_off():
     get_bus().all_off()
     return {"ok": True}
-
 
 @router.post("/api/house/{house_id}/rooms")
 def api_add_room(house_id: str, payload: Dict[str, str]):
@@ -37,13 +34,12 @@ def api_add_room(house_id: str, payload: Dict[str, str]):
         raise HTTPException(404, "Unknown house")
     return {"ok": True, "room": room}
 
-
 @router.post("/api/house/{house_id}/room/{room_id}/nodes")
 def api_add_node(house_id: str, room_id: str, payload: Dict[str, Any]):
     name = str(payload.get("name", "")).strip()
     if not name:
         raise HTTPException(400, "missing name")
-    kind = str(payload.get("kind", "rgb"))
+    kind = str(payload.get("kind", "ultranode"))
     modules = payload.get("modules")
     try:
         node = registry.add_node(house_id, room_id, name, kind, modules)
@@ -51,52 +47,52 @@ def api_add_node(house_id: str, room_id: str, payload: Dict[str, Any]):
         raise HTTPException(404, "Unknown room")
     return {"ok": True, "node": node}
 
-@router.post("/api/node/{node_id}/color")
-def api_node_color(node_id: str, payload: Dict[str, int]):
-    _valid_node(node_id)
-    r = int(payload.get("r", 0)); g = int(payload.get("g", 0)); b = int(payload.get("b", 0))
-    get_bus().send_color(node_id, r, g, b)
-    return {"ok": True, "node": node_id, "published": {"r": r, "g": g, "b": b}}
+# ---- Node command APIs -------------------------------------------------
 
-@router.post("/api/node/{node_id}/effect")
-def api_node_effect(node_id: str, payload: Dict[str, str]):
+@router.post("/api/node/{node_id}/ws/set")
+def api_ws_set(node_id: str, payload: Dict[str, Any]):
     _valid_node(node_id)
-    name = str(payload.get("name", "static")).strip().lower()
-    get_bus().send_effect(node_id, name)
-    return {"ok": True, "node": node_id, "effect": name}
+    strip = int(payload.get("strip", 0))
+    effect = payload.get("effect")
+    color = payload.get("color")
+    brightness = payload.get("brightness")
+    get_bus().ws_set(node_id, strip, effect, color, brightness)
+    return {"ok": True}
 
-@router.post("/api/node/{node_id}/spacey")
-def api_node_spacey(node_id: str, payload: Dict[str, list]):
+@router.post("/api/node/{node_id}/ws/power")
+def api_ws_power(node_id: str, payload: Dict[str, Any]):
     _valid_node(node_id)
-    def clamp255(x): return max(0, min(255, int(x)))
-    c1 = payload.get("c1", [128,0,255])
-    c2 = payload.get("c2", [0,128,255])
-    c3 = payload.get("c3", [255,64,0])
-    a = ",".join(str(clamp255(x)) for x in c1)
-    b = ",".join(str(clamp255(x)) for x in c2)
-    c = ",".join(str(clamp255(x)) for x in c3)
-    get_bus().send_spacey(node_id, a, b, c)
-    return {"ok": True, "node": node_id}
+    strip = int(payload.get("strip", 0))
+    on = bool(payload.get("on", True))
+    get_bus().ws_power(node_id, strip, on)
+    return {"ok": True}
 
-@router.post("/api/node/{node_id}/brightness")
-def api_node_brightness(node_id: str, payload: Dict[str, int]):
+@router.post("/api/node/{node_id}/white/set")
+def api_white_set(node_id: str, payload: Dict[str, Any]):
     _valid_node(node_id)
-    level = max(0, min(255, int(payload.get("level", 0))))
-    get_bus().send_brightness(node_id, level)
-    return {"ok": True, "node": node_id, "brightness": level}
+    channel = int(payload.get("channel", 0))
+    effect = payload.get("effect")
+    brightness = payload.get("brightness")
+    get_bus().white_set(node_id, channel, effect, brightness)
+    return {"ok": True}
 
-
-@router.post("/api/node/{node_id}/motion")
-def api_node_motion(node_id: str, payload: Dict[str, bool]):
+@router.post("/api/node/{node_id}/white/power")
+def api_white_power(node_id: str, payload: Dict[str, Any]):
     _valid_node(node_id)
-    enabled = bool(payload.get("enabled", False))
-    get_bus().send_motion(node_id, enabled)
-    return {"ok": True, "node": node_id, "enabled": enabled}
+    channel = int(payload.get("channel", 0))
+    on = bool(payload.get("on", True))
+    get_bus().white_power(node_id, channel, on)
+    return {"ok": True}
 
-@router.post("/api/node/{node_id}/ota")
-def api_node_ota(node_id: str, payload: Dict[str, str]):
+@router.post("/api/node/{node_id}/sensor/cooldown")
+def api_sensor_cooldown(node_id: str, payload: Dict[str, Any]):
     _valid_node(node_id)
-    url = str(payload.get("url","")).strip()
-    if not url: raise HTTPException(400, "missing url")
-    get_bus().send_ota(node_id, url, retain=False)
-    return {"ok": True, "node": node_id, "published": {"now": url}}
+    seconds = int(payload.get("seconds", 60))
+    get_bus().sensor_cooldown(node_id, seconds)
+    return {"ok": True, "seconds": seconds}
+
+@router.post("/api/node/{node_id}/ota/check")
+def api_ota_check(node_id: str):
+    _valid_node(node_id)
+    get_bus().ota_check(node_id)
+    return {"ok": True}

--- a/Server/app/templates/modules/ota.html
+++ b/Server/app/templates/modules/ota.html
@@ -1,11 +1,8 @@
 <section class="glass rounded-2xl p-6">
   <h3 class="text-lg font-semibold mb-3">OTA Update</h3>
-  <div class="flex gap-3">
-    <input id="otaUrl" type="text" placeholder="https://lights.example/firmware/{{ node.id }}/latest.bin" class="flex-1 p-2 bg-slate-900 rounded-lg border border-slate-700">
-    <button id="btnOTA" class="px-5 py-2 pill bg-amber-500 hover:bg-amber-400 text-white">Trigger OTA</button>
-  </div>
+  <button id="btnCheck" class="px-5 py-2 pill bg-amber-500 hover:bg-amber-400 text-white">Check Now</button>
 </section>
 <script>
 async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
-document.getElementById('btnOTA').onclick=async()=>{const url=document.getElementById('otaUrl').value;if(!url){alert('Enter OTA URL');return;}await post(`/api/node/{{ node.id }}/ota`,{url});};
+document.getElementById('btnCheck').onclick=async()=>{await post(`/api/node/{{ node.id }}/ota/check`,{});};
 </script>

--- a/Server/app/templates/modules/sensor.html
+++ b/Server/app/templates/modules/sensor.html
@@ -1,0 +1,14 @@
+<section class="glass rounded-2xl p-6">
+  <h3 class="text-lg font-semibold mb-3">Sensor Cooldown</h3>
+  <div class="flex gap-3">
+    <input id="cooldown" type="number" min="10" max="3600" value="60" class="p-2 bg-slate-900 rounded-lg border border-slate-700">
+    <button id="btnCooldown" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
+  </div>
+</section>
+<script>
+async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+const cd=document.getElementById('cooldown');
+document.getElementById('btnCooldown').onclick=async()=>{
+  await post(`/api/node/{{ node.id }}/sensor/cooldown`,{seconds:parseInt(cd.value)});
+};
+</script>

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -1,0 +1,38 @@
+<section class="glass rounded-2xl p-6">
+  <h3 class="text-lg font-semibold mb-3">White Channel</h3>
+  <div class="mb-2">
+    <label class="text-xs opacity-70">Channel</label>
+    <select id="wChannel" class="p-1 rounded bg-slate-900 border border-slate-700">
+      {% for i in range(4) %}
+      <option value="{{ i }}">{{ i }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="text-xs opacity-70">Effect</label>
+    <input id="wEffect" type="text" value="solid" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
+    <label class="text-xs opacity-70 block mt-2">Brightness</label>
+    <input id="wBri" type="range" min="0" max="255" value="255" class="w-full">
+  </div>
+  <div class="flex gap-2">
+    <button id="wSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
+    <button id="wOn" class="px-4 py-2 pill bg-green-600 hover:bg-green-500 text-white">On</button>
+    <button id="wOff" class="px-4 py-2 pill bg-red-600 hover:bg-red-500 text-white">Off</button>
+  </div>
+</section>
+<script>
+async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+const ch=document.getElementById('wChannel');
+const eff=document.getElementById('wEffect');
+const bri=document.getElementById('wBri');
+
+document.getElementById('wSet').onclick=async()=>{
+  await post(`/api/node/{{ node.id }}/white/set`,{channel:parseInt(ch.value), effect:eff.value.trim(), brightness:parseInt(bri.value)});
+};
+document.getElementById('wOn').onclick=async()=>{
+  await post(`/api/node/{{ node.id }}/white/power`,{channel:parseInt(ch.value), on:true});
+};
+document.getElementById('wOff').onclick=async()=>{
+  await post(`/api/node/{{ node.id }}/white/power`,{channel:parseInt(ch.value), on:false});
+};
+</script>

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -1,0 +1,47 @@
+<section class="glass rounded-2xl p-6">
+  <h3 class="text-lg font-semibold mb-3">WS Strip Control</h3>
+  <div class="mb-2">
+    <label class="text-xs opacity-70">Strip</label>
+    <select id="wsStrip" class="p-1 rounded bg-slate-900 border border-slate-700">
+      {% for i in range(4) %}
+      <option value="{{ i }}">{{ i }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="flex items-center gap-4 mb-3">
+    <input id="wsColor" type="color" value="#ffffff" class="w-16 h-16 border-0 rounded-full">
+    <div class="flex-1">
+      <label class="text-xs opacity-70">Effect</label>
+      <input id="wsEffect" type="text" value="solid" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
+      <label class="text-xs opacity-70 block mt-2">Brightness</label>
+      <input id="wsBri" type="range" min="0" max="255" value="255" class="w-full">
+    </div>
+  </div>
+  <div class="flex gap-2">
+    <button id="wsSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
+    <button id="wsOn" class="px-4 py-2 pill bg-green-600 hover:bg-green-500 text-white">On</button>
+    <button id="wsOff" class="px-4 py-2 pill bg-red-600 hover:bg-red-500 text-white">Off</button>
+  </div>
+</section>
+<script>
+function hexToRgb(hex){hex=hex.replace('#','');if(hex.length===3)hex=hex.split('').map(x=>x+x).join('');const num=parseInt(hex,16);return[(num>>16)&255,(num>>8)&255,num&255];}
+async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+const wsStrip=document.getElementById('wsStrip');
+const wsEffect=document.getElementById('wsEffect');
+const wsColor=document.getElementById('wsColor');
+const wsBri=document.getElementById('wsBri');
+
+document.getElementById('wsSet').onclick=async()=>{
+  const strip=parseInt(wsStrip.value);
+  const eff=wsEffect.value.trim();
+  const color=hexToRgb(wsColor.value);
+  const bri=parseInt(wsBri.value);
+  await post(`/api/node/{{ node.id }}/ws/set`,{strip, effect:eff, color, brightness:bri});
+};
+document.getElementById('wsOn').onclick=async()=>{
+  await post(`/api/node/{{ node.id }}/ws/power`,{strip:parseInt(wsStrip.value), on:true});
+};
+document.getElementById('wsOff').onclick=async()=>{
+  await post(`/api/node/{{ node.id }}/ws/power`,{strip:parseInt(wsStrip.value), on:false});
+};
+</script>


### PR DESCRIPTION
## Summary
- replace legacy MQTT helpers with UltraNodeV5 command topics
- expose new REST APIs for ws/white/sensor/ota commands
- add node UI modules for strip, white channel, sensor cooldown, and OTA check

## Testing
- `python -m py_compile app/config.py app/registry.py app/mqtt_bus.py app/routes_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0e61f5d14832691e9f67830c07f6a