### PR TITLE
feat: revamp server MQTT for UltraNodeV5

### DIFF
--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -21,12 +21,8 @@ class Settings:
     API_BEARER = os.getenv("API_BEARER", "")
     MANIFEST_HMAC_SECRET = os.getenv("MANIFEST_HMAC_SECRET", "")
 
-    MQTT_COMPAT_PUBLISH_BOTH = os.getenv("MQTT_COMPAT_PUBLISH_BOTH", "1") == "1"
-    # legacy/global topics
-    LEGACY_TOPIC_COLOR  = os.getenv("LEGACY_TOPIC_COLOR", "strip/cmd/color")
-    LEGACY_TOPIC_EFFECT = os.getenv("LEGACY_TOPIC_EFFECT", "strip/cmd/effect")
-    LEGACY_TOPIC_SPACEY = os.getenv("LEGACY_TOPIC_SPACEY", "strip/cmd/spacey")
-    LEGACY_TOPIC_OTA    = os.getenv("LEGACY_TOPIC_OTA",    "strip/cmd/ota")
+    # ------------------------------------------------------------------
+    # Device registry ---------------------------------------------------
 
     # registry of houses/rooms/nodes as JSON
     DEFAULT_REGISTRY = [
@@ -41,8 +37,8 @@ class Settings:
                         {
                             "id": "del-sur-kitchen-node1",
                             "name": "Kitchen Node",
-                            "kind": "rgb",
-                            "modules": ["color", "effect", "brightness", "motion", "ota"],
+                            "kind": "ultranode",
+                            "modules": ["ws", "white", "sensor", "ota"],
                         }
                     ],
                 },
@@ -53,8 +49,8 @@ class Settings:
                         {
                             "id": "del-sur-room-1-node1",
                             "name": "Room 1 Node",
-                            "kind": "rgb",
-                            "modules": ["color", "effect", "brightness", "motion", "ota"],
+                            "kind": "ultranode",
+                            "modules": ["ws", "white", "sensor", "ota"],
                         }
                     ],
                 },
@@ -71,8 +67,8 @@ class Settings:
                         {
                             "id": "sdsu-kitchen-node1",
                             "name": "Kitchen Node",
-                            "kind": "rgb",
-                            "modules": ["color", "effect", "brightness", "motion", "ota"],
+                            "kind": "ultranode",
+                            "modules": ["ws", "white", "sensor", "ota"],
                         }
                     ],
                 },
@@ -83,8 +79,8 @@ class Settings:
                         {
                             "id": "sdsu-room-1-node1",
                             "name": "Room 1 Node",
-                            "kind": "rgb",
-                            "modules": ["color", "effect", "brightness", "motion", "ota"],
+                            "kind": "ultranode",
+                            "modules": ["ws", "white", "sensor", "ota"],
                         }
                     ],
                 },

--- a/Server/app/device_registry.json
+++ b/Server/app/device_registry.json
@@ -10,12 +10,11 @@
           {
             "id": "del-sur-kitchen-node1",
             "name": "Kitchen Node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           }
@@ -28,24 +27,22 @@
           {
             "id": "del-sur-room-1-node1",
             "name": "Room 1 Node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           },
           {
             "id": "node",
             "name": "node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           }
@@ -64,12 +61,11 @@
           {
             "id": "sdsu-kitchen-node1",
             "name": "Kitchen Node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           }
@@ -82,12 +78,11 @@
           {
             "id": "sdsu-room-1-node1",
             "name": "Room 1 Node",
-            "kind": "rgb",
+            "kind": "ultranode",
             "modules": [
-              "color",
-              "effect",
-              "brightness",
-              "motion",
+              "ws",
+              "white",
+              "sensor",
               "ota"
             ]
           }

--- a/Server/app/effects.py
+++ b/Server/app/effects.py
@@ -1,0 +1,14 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+def _load_effects(rel: str) -> list[str]:
+    path = ROOT / rel
+    if not path.exists():
+        return []
+    text = path.read_text()
+    return re.findall(r'\{"([a-zA-Z0-9_]+)"', text)
+
+WS_EFFECTS = set(_load_effects("UltraNodeV5/components/ul_ws_engine/effects_ws/registry.c"))
+WHITE_EFFECTS = set(_load_effects("UltraNodeV5/components/ul_white_engine/effects_white/registry.c"))

--- a/Server/app/registry.py
+++ b/Server/app/registry.py
@@ -93,7 +93,7 @@ def add_node(
     house_id: str,
     room_id: str,
     name: str,
-    kind: str = "rgb",
+    kind: str = "ultranode",
     modules: Optional[list[str]] = None,
 ) -> Node:
     """Create and attach a new node under ``house_id``/``room_id``."""
@@ -101,7 +101,7 @@ def add_node(
     if not room:
         raise KeyError("room not found")
     node = {"id": slugify(name), "name": name, "kind": kind}
-    node["modules"] = modules or ["color", "effect", "brightness", "motion", "ota"]
+    node["modules"] = modules or ["ws", "white", "sensor", "ota"]
     room.setdefault("nodes", []).append(node)
     save_registry()
     return node

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -3,9 +3,11 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from .config import settings
 from . import registry
+from .effects import WS_EFFECTS, WHITE_EFFECTS
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
+
 
 @router.get("/", response_class=HTMLResponse)
 def home(request: Request):
@@ -71,5 +73,12 @@ def node_page(request: Request, node_id: str):
         subtitle = None
     return templates.TemplateResponse(
         "node.html",
-        {"request": request, "node": node, "title": title, "subtitle": subtitle},
+        {
+            "request": request,
+            "node": node,
+            "title": title,
+            "subtitle": subtitle,
+            "ws_effects": WS_EFFECTS,
+            "white_effects": WHITE_EFFECTS,
+        },
     )

--- a/Server/app/templates/modules/ota.html
+++ b/Server/app/templates/modules/ota.html
@@ -1,11 +1,8 @@
 <section class="glass rounded-2xl p-6">
   <h3 class="text-lg font-semibold mb-3">OTA Update</h3>
-  <div class="flex gap-3">
-    <input id="otaUrl" type="text" placeholder="https://lights.example/firmware/{{ node.id }}/latest.bin" class="flex-1 p-2 bg-slate-900 rounded-lg border border-slate-700">
-    <button id="btnOTA" class="px-5 py-2 pill bg-amber-500 hover:bg-amber-400 text-white">Trigger OTA</button>
-  </div>
+  <button id="btnCheck" class="px-5 py-2 pill bg-amber-500 hover:bg-amber-400 text-white">Check Now</button>
 </section>
 <script>
 async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
-document.getElementById('btnOTA').onclick=async()=>{const url=document.getElementById('otaUrl').value;if(!url){alert('Enter OTA URL');return;}await post(`/api/node/{{ node.id }}/ota`,{url});};
+document.getElementById('btnCheck').onclick=async()=>{await post(`/api/node/{{ node.id }}/ota/check`,{});};
 </script>

--- a/Server/app/templates/modules/sensor.html
+++ b/Server/app/templates/modules/sensor.html
@@ -1,0 +1,14 @@
+<section class="glass rounded-2xl p-6">
+  <h3 class="text-lg font-semibold mb-3">Sensor Cooldown</h3>
+  <div class="flex gap-3">
+    <input id="cooldown" type="number" min="10" max="3600" value="60" class="p-2 bg-slate-900 rounded-lg border border-slate-700">
+    <button id="btnCooldown" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
+  </div>
+</section>
+<script>
+async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+const cd=document.getElementById('cooldown');
+document.getElementById('btnCooldown').onclick=async()=>{
+  await post(`/api/node/{{ node.id }}/sensor/cooldown`,{seconds:parseInt(cd.value)});
+};
+</script>

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -1,0 +1,62 @@
+<section class="glass rounded-2xl p-6">
+  <h3 class="text-lg font-semibold mb-3">White Channel</h3>
+  <div class="mb-2">
+    <label class="text-xs opacity-70">Channel</label>
+    <select id="wChannel" class="p-1 rounded bg-slate-900 border border-slate-700">
+      {% for i in range(4) %}
+      <option value="{{ i }}">{{ i }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="text-xs opacity-70">Effect</label>
+    <select id="wEffect" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
+      <option value="" selected disabled>Select effect</option>
+      {% for eff in white_effects %}
+      <option value="{{ eff }}">{{ eff }}</option>
+      {% endfor %}
+    </select>
+    <div id="wParams" class="mt-2 space-y-1"></div>
+    <button id="wAddParam" class="mt-1 text-xs px-2 py-1 bg-slate-800 rounded">+ Param</button>
+    <label class="text-xs opacity-70 block mt-2">Brightness</label>
+    <input id="wBri" type="range" min="0" max="255" value="255" class="w-full">
+  </div>
+  <div class="flex gap-2">
+    <button id="wSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
+    <button id="wOn" class="px-4 py-2 pill bg-green-600 hover:bg-green-500 text-white">On</button>
+    <button id="wOff" class="px-4 py-2 pill bg-red-600 hover:bg-red-500 text-white">Off</button>
+  </div>
+</section>
+<script>
+async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+const ch=document.getElementById('wChannel');
+const eff=document.getElementById('wEffect');
+const bri=document.getElementById('wBri');
+const wParams=document.getElementById('wParams');
+const wAddParam=document.getElementById('wAddParam');
+
+function addParamRow(container){const row=document.createElement('div');row.className='flex gap-2';row.innerHTML=`<input type="text" placeholder="key" pattern="[a-zA-Z0-9_]+" class="flex-1 p-1 bg-slate-900 rounded border border-slate-700"><input type="number" placeholder="value" step="1" class="flex-1 p-1 bg-slate-900 rounded border border-slate-700">`;container.appendChild(row);}
+function collectParams(container){const obj={};let ok=true;container.querySelectorAll('div').forEach(r=>{const k=r.children[0].value.trim();const v=Number(r.children[1].value);if(!k&&r.children[1].value==='')return;if(!k||Number.isNaN(v)){ok=false;return;}obj[k]=v;});return ok?obj:null;}
+wAddParam.onclick=()=>addParamRow(wParams);
+eff.onchange=()=>{wParams.innerHTML='';};
+
+document.getElementById('wSet').onclick=async()=>{
+  const channel=parseInt(ch.value,10);
+  if(Number.isNaN(channel)){alert('Invalid channel');return;}
+  const effect=eff.value.trim();
+  if(!effect){alert('Select an effect');return;}
+  const brightness=parseInt(bri.value,10);
+  if(Number.isNaN(brightness)){alert('Invalid brightness');return;}
+  const params=collectParams(wParams);
+  if(params===null){alert('Invalid parameters');return;}
+  const msg={channel, effect, brightness};
+  if(Object.keys(params).length)msg.params=params;
+  await post(`/api/node/{{ node.id }}/white/set`,msg);
+};
+document.getElementById('wOn').onclick=async()=>{
+  const channel=parseInt(ch.value,10);if(Number.isNaN(channel)){alert('Invalid channel');return;}await post(`/api/node/{{ node.id }}/white/power`,{channel,on:true});
+};
+document.getElementById('wOff').onclick=async()=>{
+  const channel=parseInt(ch.value,10);if(Number.isNaN(channel)){alert('Invalid channel');return;}await post(`/api/node/{{ node.id }}/white/power`,{channel,on:false});
+};
+</script>

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -1,0 +1,68 @@
+<section class="glass rounded-2xl p-6">
+  <h3 class="text-lg font-semibold mb-3">WS Strip Control</h3>
+  <div class="mb-2">
+    <label class="text-xs opacity-70">Strip</label>
+    <select id="wsStrip" class="p-1 rounded bg-slate-900 border border-slate-700">
+      {% for i in range(4) %}
+      <option value="{{ i }}">{{ i }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="flex items-start gap-4 mb-3">
+    <input id="wsColor" type="color" value="#ffffff" class="w-16 h-16 border-0 rounded-full">
+    <div class="flex-1">
+      <label class="text-xs opacity-70">Effect</label>
+      <select id="wsEffect" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
+        <option value="" selected disabled>Select effect</option>
+        {% for eff in ws_effects %}
+        <option value="{{ eff }}">{{ eff }}</option>
+        {% endfor %}
+      </select>
+      <div id="wsParams" class="mt-2 space-y-1"></div>
+      <button id="wsAddParam" class="mt-1 text-xs px-2 py-1 bg-slate-800 rounded">+ Param</button>
+      <label class="text-xs opacity-70 block mt-2">Brightness</label>
+      <input id="wsBri" type="range" min="0" max="255" value="255" class="w-full">
+    </div>
+  </div>
+  <div class="flex gap-2">
+    <button id="wsSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
+    <button id="wsOn" class="px-4 py-2 pill bg-green-600 hover:bg-green-500 text-white">On</button>
+    <button id="wsOff" class="px-4 py-2 pill bg-red-600 hover:bg-red-500 text-white">Off</button>
+  </div>
+</section>
+<script>
+function hexToRgb(hex){hex=hex.replace('#','');if(hex.length===3)hex=hex.split('').map(x=>x+x).join('');const num=parseInt(hex,16);return[(num>>16)&255,(num>>8)&255,num&255];}
+async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+const wsStrip=document.getElementById('wsStrip');
+const wsEffect=document.getElementById('wsEffect');
+const wsColor=document.getElementById('wsColor');
+const wsBri=document.getElementById('wsBri');
+const wsParams=document.getElementById('wsParams');
+const wsAddParam=document.getElementById('wsAddParam');
+
+function addParamRow(container){const row=document.createElement('div');row.className='flex gap-2';row.innerHTML=`<input type="text" placeholder="key" pattern="[a-zA-Z0-9_]+" class="flex-1 p-1 bg-slate-900 rounded border border-slate-700"><input type="number" placeholder="value" step="1" class="flex-1 p-1 bg-slate-900 rounded border border-slate-700">`;container.appendChild(row);}
+function collectParams(container){const obj={};let ok=true;container.querySelectorAll('div').forEach(r=>{const k=r.children[0].value.trim();const v=Number(r.children[1].value);if(!k&&r.children[1].value==='')return;if(!k||Number.isNaN(v)){ok=false;return;}obj[k]=v;});return ok?obj:null;}
+wsAddParam.onclick=()=>addParamRow(wsParams);
+wsEffect.onchange=()=>{wsParams.innerHTML='';};
+
+document.getElementById('wsSet').onclick=async()=>{
+  const strip=parseInt(wsStrip.value,10);
+  if(Number.isNaN(strip)){alert('Invalid strip');return;}
+  const eff=wsEffect.value.trim();
+  if(!eff){alert('Select an effect');return;}
+  const color=hexToRgb(wsColor.value);
+  const bri=parseInt(wsBri.value,10);
+  if(Number.isNaN(bri)){alert('Invalid brightness');return;}
+  const params=collectParams(wsParams);
+  if(params===null){alert('Invalid parameters');return;}
+  const msg={strip, effect:eff, color, brightness:bri};
+  if(Object.keys(params).length)msg.params=params;
+  await post(`/api/node/{{ node.id }}/ws/set`,msg);
+};
+document.getElementById('wsOn').onclick=async()=>{
+  const s=parseInt(wsStrip.value,10);if(Number.isNaN(s)){alert('Invalid strip');return;}await post(`/api/node/{{ node.id }}/ws/power`,{strip:s,on:true});
+};
+document.getElementById('wsOff').onclick=async()=>{
+  const s=parseInt(wsStrip.value,10);if(Number.isNaN(s)){alert('Invalid strip');return;}await post(`/api/node/{{ node.id }}/ws/power`,{strip:s,on:false});
+};
+</script>


### PR DESCRIPTION
## Summary
- replace legacy MQTT helpers with UltraNodeV5 command topics
- expose new REST APIs for ws/white/sensor/ota commands
- add node UI modules for strip, white channel, sensor cooldown, and OTA check
- allow choosing registered effects with custom parameters for ws and white
- validate effect selections and parameters in UI and API

## Testing
- `python -m py_compile app/config.py app/registry.py app/mqtt_bus.py app/routes_api.py app/routes_pages.py app/effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0e61f5d14832691e9f67830c07f6a