### PR TITLE
feat: add effect parameter registry and ui

### DIFF
--- a/Server/app/effects.py
+++ b/Server/app/effects.py
@@ -12,3 +12,41 @@ def _load_effects(rel: str) -> list[str]:
 
 WS_EFFECTS = set(_load_effects("UltraNodeV5/components/ul_ws_engine/effects_ws/registry.c"))
 WHITE_EFFECTS = set(_load_effects("UltraNodeV5/components/ul_white_engine/effects_white/registry.c"))
+
+# Effect parameter metadata used by the web UI to render effect-specific
+# controls.  Each entry maps an effect name to a list of parameter
+# descriptors.  Supported descriptor ``type`` values are ``color`` (render a
+# color picker), ``slider`` (render an ``input[type=range]``) and ``toggle``
+# (render a checkbox).  Sliders accept ``min``, ``max`` and ``value`` keys for
+# range configuration.
+
+WS_PARAM_DEFS = {
+    "solid": [{"id": "color", "type": "color"}],
+    "breathe": [{"id": "period", "type": "slider", "min": 10, "max": 500, "value": 120}],
+    "rainbow": [
+        {"id": "period", "type": "slider", "min": 10, "max": 500, "value": 50},
+        {"id": "reverse", "type": "toggle"},
+    ],
+    "twinkle": [{"id": "period", "type": "slider", "min": 10, "max": 500, "value": 50}],
+    "theater_chase": [
+        {"id": "period", "type": "slider", "min": 10, "max": 500, "value": 50},
+        {"id": "reverse", "type": "toggle"},
+    ],
+    "wipe": [
+        {"id": "period", "type": "slider", "min": 10, "max": 500, "value": 50},
+        {"id": "reverse", "type": "toggle"},
+    ],
+    "gradient_scroll": [
+        {"id": "period", "type": "slider", "min": 10, "max": 500, "value": 50},
+        {"id": "reverse", "type": "toggle"},
+    ],
+}
+
+WHITE_PARAM_DEFS = {
+    "graceful_on": [{"id": "period", "type": "slider", "min": 10, "max": 500, "value": 200}],
+    "graceful_off": [{"id": "period", "type": "slider", "min": 10, "max": 500, "value": 200}],
+    "motion_swell": [{"id": "period", "type": "slider", "min": 10, "max": 500, "value": 200}],
+    "day_night_curve": [{"id": "period", "type": "slider", "min": 10, "max": 500, "value": 200}],
+    "blink": [{"id": "period", "type": "slider", "min": 10, "max": 500, "value": 200}],
+}
+

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -63,8 +63,13 @@ def api_ws_set(node_id: str, payload: Dict[str, Any]):
     if effect not in WS_EFFECTS:
         raise HTTPException(400, "invalid effect")
     color = payload.get("color")
-    if not (isinstance(color, list) and len(color) == 3 and all(isinstance(c, int) and 0 <= c <= 255 for c in color)):
-        raise HTTPException(400, "invalid color")
+    if color is not None:
+        if not (
+            isinstance(color, list)
+            and len(color) == 3
+            and all(isinstance(c, int) and 0 <= c <= 255 for c in color)
+        ):
+            raise HTTPException(400, "invalid color")
     try:
         brightness = int(payload.get("brightness"))
     except Exception:

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -3,7 +3,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from .config import settings
 from . import registry
-from .effects import WS_EFFECTS, WHITE_EFFECTS
+from .effects import WS_EFFECTS, WHITE_EFFECTS, WS_PARAM_DEFS, WHITE_PARAM_DEFS
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
@@ -80,5 +80,7 @@ def node_page(request: Request, node_id: str):
             "subtitle": subtitle,
             "ws_effects": WS_EFFECTS,
             "white_effects": WHITE_EFFECTS,
+            "ws_param_defs": WS_PARAM_DEFS,
+            "white_param_defs": WHITE_PARAM_DEFS,
         },
     )

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -16,8 +16,7 @@
       <option value="{{ eff }}">{{ eff }}</option>
       {% endfor %}
     </select>
-    <div id="wParams" class="mt-2 space-y-1"></div>
-    <button id="wAddParam" class="mt-1 text-xs px-2 py-1 bg-slate-800 rounded">+ Param</button>
+    <div id="wParams" class="mt-2 space-y-2"></div>
     <label class="text-xs opacity-70 block mt-2">Brightness</label>
     <input id="wBri" type="range" min="0" max="255" value="255" class="w-full">
   </div>
@@ -29,16 +28,16 @@
 </section>
 <script>
 async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+const WHITE_PARAM_DEFS={{ white_param_defs|tojson }};
 const ch=document.getElementById('wChannel');
 const eff=document.getElementById('wEffect');
 const bri=document.getElementById('wBri');
 const wParams=document.getElementById('wParams');
-const wAddParam=document.getElementById('wAddParam');
 
-function addParamRow(container){const row=document.createElement('div');row.className='flex gap-2';row.innerHTML=`<input type="text" placeholder="key" pattern="[a-zA-Z0-9_]+" class="flex-1 p-1 bg-slate-900 rounded border border-slate-700"><input type="number" placeholder="value" step="1" class="flex-1 p-1 bg-slate-900 rounded border border-slate-700">`;container.appendChild(row);}
-function collectParams(container){const obj={};let ok=true;container.querySelectorAll('div').forEach(r=>{const k=r.children[0].value.trim();const v=Number(r.children[1].value);if(!k&&r.children[1].value==='')return;if(!k||Number.isNaN(v)){ok=false;return;}obj[k]=v;});return ok?obj:null;}
-wAddParam.onclick=()=>addParamRow(wParams);
-eff.onchange=()=>{wParams.innerHTML='';};
+function renderParams(){wParams.innerHTML='';const defs=WHITE_PARAM_DEFS[eff.value]||[];defs.forEach(d=>{let wrapper=document.createElement('div');wrapper.dataset.id=d.id;if(d.type==='slider'){const label=document.createElement('label');label.className='text-xs opacity-70';label.textContent=d.id;const input=document.createElement('input');input.type='range';input.min=d.min;input.max=d.max;input.value=d.value;input.id='wParam_'+d.id;wrapper.appendChild(label);wrapper.appendChild(input);}else if(d.type==='toggle'){const label=document.createElement('label');label.className='flex items-center gap-2';const input=document.createElement('input');input.type='checkbox';input.id='wParam_'+d.id;label.appendChild(input);label.appendChild(document.createTextNode(d.id));wrapper.appendChild(label);}wParams.appendChild(wrapper);});}
+eff.onchange=renderParams;
+
+function collectParams(){const defs=WHITE_PARAM_DEFS[eff.value]||[];const params={};defs.forEach(d=>{const el=document.getElementById('wParam_'+d.id);if(d.type==='slider'){params[d.id]=Number(el.value);}else if(d.type==='toggle'){params[d.id]=el.checked;}});return params;}
 
 document.getElementById('wSet').onclick=async()=>{
   const channel=parseInt(ch.value,10);
@@ -47,8 +46,7 @@ document.getElementById('wSet').onclick=async()=>{
   if(!effect){alert('Select an effect');return;}
   const brightness=parseInt(bri.value,10);
   if(Number.isNaN(brightness)){alert('Invalid brightness');return;}
-  const params=collectParams(wParams);
-  if(params===null){alert('Invalid parameters');return;}
+  const params=collectParams();
   const msg={channel, effect, brightness};
   if(Object.keys(params).length)msg.params=params;
   await post(`/api/node/{{ node.id }}/white/set`,msg);

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -8,21 +8,17 @@
       {% endfor %}
     </select>
   </div>
-  <div class="flex items-start gap-4 mb-3">
-    <input id="wsColor" type="color" value="#ffffff" class="w-16 h-16 border-0 rounded-full">
-    <div class="flex-1">
-      <label class="text-xs opacity-70">Effect</label>
-      <select id="wsEffect" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
-        <option value="" selected disabled>Select effect</option>
-        {% for eff in ws_effects %}
-        <option value="{{ eff }}">{{ eff }}</option>
-        {% endfor %}
-      </select>
-      <div id="wsParams" class="mt-2 space-y-1"></div>
-      <button id="wsAddParam" class="mt-1 text-xs px-2 py-1 bg-slate-800 rounded">+ Param</button>
-      <label class="text-xs opacity-70 block mt-2">Brightness</label>
-      <input id="wsBri" type="range" min="0" max="255" value="255" class="w-full">
-    </div>
+  <div class="mb-3">
+    <label class="text-xs opacity-70">Effect</label>
+    <select id="wsEffect" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
+      <option value="" selected disabled>Select effect</option>
+      {% for eff in ws_effects %}
+      <option value="{{ eff }}">{{ eff }}</option>
+      {% endfor %}
+    </select>
+    <div id="wsParams" class="mt-2 space-y-2"></div>
+    <label class="text-xs opacity-70 block mt-2">Brightness</label>
+    <input id="wsBri" type="range" min="0" max="255" value="255" class="w-full">
   </div>
   <div class="flex gap-2">
     <button id="wsSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
@@ -31,34 +27,20 @@
   </div>
 </section>
 <script>
+const WS_PARAM_DEFS={{ ws_param_defs|tojson }};
 function hexToRgb(hex){hex=hex.replace('#','');if(hex.length===3)hex=hex.split('').map(x=>x+x).join('');const num=parseInt(hex,16);return[(num>>16)&255,(num>>8)&255,num&255];}
 async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
 const wsStrip=document.getElementById('wsStrip');
 const wsEffect=document.getElementById('wsEffect');
-const wsColor=document.getElementById('wsColor');
 const wsBri=document.getElementById('wsBri');
 const wsParams=document.getElementById('wsParams');
-const wsAddParam=document.getElementById('wsAddParam');
 
-function addParamRow(container){const row=document.createElement('div');row.className='flex gap-2';row.innerHTML=`<input type="text" placeholder="key" pattern="[a-zA-Z0-9_]+" class="flex-1 p-1 bg-slate-900 rounded border border-slate-700"><input type="number" placeholder="value" step="1" class="flex-1 p-1 bg-slate-900 rounded border border-slate-700">`;container.appendChild(row);}
-function collectParams(container){const obj={};let ok=true;container.querySelectorAll('div').forEach(r=>{const k=r.children[0].value.trim();const v=Number(r.children[1].value);if(!k&&r.children[1].value==='')return;if(!k||Number.isNaN(v)){ok=false;return;}obj[k]=v;});return ok?obj:null;}
-wsAddParam.onclick=()=>addParamRow(wsParams);
-wsEffect.onchange=()=>{wsParams.innerHTML='';};
+function renderParams(){wsParams.innerHTML='';const defs=WS_PARAM_DEFS[wsEffect.value]||[];defs.forEach(d=>{let wrapper=document.createElement('div');wrapper.dataset.id=d.id;if(d.type==='color'){const input=document.createElement('input');input.type='color';input.id='wsParam_'+d.id;input.value='#ffffff';wrapper.appendChild(input);}else if(d.type==='slider'){const label=document.createElement('label');label.className='text-xs opacity-70';label.textContent=d.id;const input=document.createElement('input');input.type='range';input.min=d.min;input.max=d.max;input.value=d.value;input.id='wsParam_'+d.id;wrapper.appendChild(label);wrapper.appendChild(input);}else if(d.type==='toggle'){const label=document.createElement('label');label.className='flex items-center gap-2';const input=document.createElement('input');input.type='checkbox';input.id='wsParam_'+d.id;label.appendChild(input);label.appendChild(document.createTextNode(d.id));wrapper.appendChild(label);}wsParams.appendChild(wrapper);});}
+wsEffect.onchange=renderParams;
 
-document.getElementById('wsSet').onclick=async()=>{
-  const strip=parseInt(wsStrip.value,10);
-  if(Number.isNaN(strip)){alert('Invalid strip');return;}
-  const eff=wsEffect.value.trim();
-  if(!eff){alert('Select an effect');return;}
-  const color=hexToRgb(wsColor.value);
-  const bri=parseInt(wsBri.value,10);
-  if(Number.isNaN(bri)){alert('Invalid brightness');return;}
-  const params=collectParams(wsParams);
-  if(params===null){alert('Invalid parameters');return;}
-  const msg={strip, effect:eff, color, brightness:bri};
-  if(Object.keys(params).length)msg.params=params;
-  await post(`/api/node/{{ node.id }}/ws/set`,msg);
-};
+function collectParams(){const defs=WS_PARAM_DEFS[wsEffect.value]||[];const params={};let color=null;defs.forEach(d=>{const el=document.getElementById('wsParam_'+d.id);if(d.type==='color'){color=hexToRgb(el.value);}else if(d.type==='slider'){params[d.id]=Number(el.value);}else if(d.type==='toggle'){params[d.id]=el.checked;}});return{params,color};}
+
+document.getElementById('wsSet').onclick=async()=>{const strip=parseInt(wsStrip.value,10);if(Number.isNaN(strip)){alert('Invalid strip');return;}const eff=wsEffect.value.trim();if(!eff){alert('Select an effect');return;}const bri=parseInt(wsBri.value,10);if(Number.isNaN(bri)){alert('Invalid brightness');return;}const {params,color}=collectParams();const msg={strip,effect:eff,brightness:bri};if(color)msg.color=color;if(Object.keys(params).length)msg.params=params;await post(`/api/node/{{ node.id }}/ws/set`,msg);};
 document.getElementById('wsOn').onclick=async()=>{
   const s=parseInt(wsStrip.value,10);if(Number.isNaN(s)){alert('Invalid strip');return;}await post(`/api/node/{{ node.id }}/ws/power`,{strip:s,on:true});
 };


### PR DESCRIPTION
## Summary
- add parameter metadata for WS and white effects
- expose effect params to templates
- render effect-specific toggles, sliders, and color pickers
- allow WS `set` commands without a color payload

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b10d3ca6208326b914fa7b9f12d916