### PR TITLE
Add web interface for controlling UltraNodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/NewServer/app.py
+++ b/NewServer/app.py
@@ -1,0 +1,76 @@
+import json
+import os
+
+from flask import Flask, render_template, request, jsonify
+import paho.mqtt.client as mqtt
+
+MQTT_BROKER = os.getenv("MQTT_BROKER", "localhost")
+NODE_ID = os.getenv("ULTRALIGHT_NODE", "node123")
+
+client = mqtt.Client()
+client.connect(MQTT_BROKER)
+client.loop_start()
+
+app = Flask(__name__)
+
+
+def publish(topic, payload):
+    client.publish(f"ul/{NODE_ID}/{topic}", json.dumps(payload), qos=1)
+
+
+@app.route("/")
+def index():
+    ws_effects = [
+        "solid",
+        "triple_wave",
+        "breathe",
+        "rainbow",
+        "twinkle",
+        "theater_chase",
+        "wipe",
+        "gradient_scroll",
+    ]
+    white_effects = [
+        "graceful_on",
+        "graceful_off",
+        "motion_swell",
+        "day_night_curve",
+        "blink",
+    ]
+    return render_template(
+        "index.html", effects_ws=ws_effects, effects_white=white_effects
+    )
+
+
+@app.route("/api/ws/set", methods=["POST"])
+def api_ws_set():
+    publish("cmd/ws/set", request.json)
+    return jsonify(status="ok")
+
+
+@app.route("/api/ws/power", methods=["POST"])
+def api_ws_power():
+    publish("cmd/ws/power", request.json)
+    return jsonify(status="ok")
+
+
+@app.route("/api/white/set", methods=["POST"])
+def api_white_set():
+    publish("cmd/white/set", request.json)
+    return jsonify(status="ok")
+
+
+@app.route("/api/white/power", methods=["POST"])
+def api_white_power():
+    publish("cmd/white/power", request.json)
+    return jsonify(status="ok")
+
+
+@app.route("/api/ota/check", methods=["POST"])
+def api_ota_check():
+    publish("cmd/ota/check", {})
+    return jsonify(status="ok")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/NewServer/requirements.txt
+++ b/NewServer/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+paho-mqtt

--- a/NewServer/static/main.js
+++ b/NewServer/static/main.js
@@ -1,0 +1,108 @@
+const stripConfigs = {
+  0: {strip: 0, effect: 'solid', hex: '#ffffff'},
+  1: {strip: 1, effect: 'solid', hex: '#ffffff'},
+  2: {strip: 2, effect: 'solid', hex: '#ffffff'},
+  3: {strip: 3, effect: 'solid', hex: '#ffffff'},
+};
+
+function sendJSON(url, data) {
+  fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+function renderParams(card) {
+  const effect = card.querySelector('.ws-effect').value;
+  const paramsDiv = card.querySelector('.ws-params');
+  paramsDiv.innerHTML = '';
+  if (effect === 'solid') {
+    const input = document.createElement('input');
+    input.type = 'color';
+    input.value = '#ffffff';
+    input.className = 'form-control form-control-color ws-color';
+    paramsDiv.appendChild(input);
+  } else if (effect === 'triple_wave') {
+    for (let i = 0; i < 3; i++) {
+      const row = document.createElement('div');
+      row.className = 'row g-2 align-items-center mb-2';
+      row.innerHTML = `
+        <div class="col"><input type="color" class="form-control form-control-color wave-color" value="#ff0000"></div>
+        <div class="col"><input type="number" step="0.1" class="form-control wave-freq" placeholder="freq"></div>
+        <div class="col"><input type="number" step="0.1" class="form-control wave-vel" placeholder="velocity"></div>`;
+      paramsDiv.appendChild(row);
+    }
+  }
+}
+
+function initWSCard(card) {
+  const strip = Number(card.dataset.strip);
+  card.querySelector('.ws-effect').addEventListener('change', () => renderParams(card));
+  renderParams(card);
+
+  card.querySelector('.ws-apply').addEventListener('click', () => {
+    const effect = card.querySelector('.ws-effect').value;
+    const brightness = Number(card.querySelector('.ws-brightness').value);
+    const payload = { strip, effect, brightness };
+    if (effect === 'solid') {
+      payload.hex = card.querySelector('.ws-color').value;
+    } else if (effect === 'triple_wave') {
+      const waves = [];
+      card.querySelectorAll('.ws-params .row').forEach(row => {
+        const hex = row.querySelector('.wave-color').value;
+        const freq = parseFloat(row.querySelector('.wave-freq').value) || 0;
+        const velocity = parseFloat(row.querySelector('.wave-vel').value) || 0;
+        waves.push({ hex, freq, velocity });
+      });
+      payload.waves = waves;
+    }
+    stripConfigs[strip] = payload;
+    sendJSON('/api/ws/set', payload);
+  });
+
+  card.querySelector('.ws-power-on').addEventListener('click', () => {
+    sendJSON('/api/ws/power', { strip, on: true });
+  });
+  card.querySelector('.ws-power-off').addEventListener('click', () => {
+    sendJSON('/api/ws/power', { strip, on: false });
+  });
+}
+
+document.querySelectorAll('#ws-strips .card-body').forEach(initWSCard);
+
+function initWhiteCard(card) {
+  const channel = Number(card.dataset.channel);
+  card.querySelector('.white-apply').addEventListener('click', () => {
+    const effect = card.querySelector('.white-effect').value;
+    const brightness = Number(card.querySelector('.white-brightness').value);
+    sendJSON('/api/white/set', { channel, effect, brightness });
+  });
+  card.querySelector('.white-power-on').addEventListener('click', () => {
+    sendJSON('/api/white/power', { channel, on: true });
+  });
+  card.querySelector('.white-power-off').addEventListener('click', () => {
+    sendJSON('/api/white/power', { channel, on: false });
+  });
+}
+
+document.querySelectorAll('#white-channels .card-body').forEach(initWhiteCard);
+
+// OTA check
+const otaBtn = document.getElementById('ota-check');
+otaBtn.addEventListener('click', () => {
+  sendJSON('/api/ota/check', {});
+});
+
+// Master brightness
+const master = document.getElementById('master-brightness');
+master.addEventListener('input', () => {
+  const b = Number(master.value);
+  for (let i = 0; i < 4; i++) {
+    const cfg = stripConfigs[i];
+    if (cfg) {
+      const payload = { ...cfg, brightness: b };
+      sendJSON('/api/ws/set', payload);
+    }
+  }
+});

--- a/NewServer/static/style.css
+++ b/NewServer/static/style.css
@@ -1,0 +1,3 @@
+body {
+  font-family: Arial, sans-serif;
+}

--- a/NewServer/templates/index.html
+++ b/NewServer/templates/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>UltraNode Controller</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+  <h1 class="mb-4">UltraNode Controller</h1>
+
+  <div class="mb-4">
+    <label for="master-brightness" class="form-label">Master Brightness</label>
+    <input type="range" class="form-range" min="0" max="255" value="128" id="master-brightness">
+  </div>
+
+  <h2>WS Strips</h2>
+  <div id="ws-strips" class="row">
+    {% for strip in range(4) %}
+    <div class="col-md-6">
+      <div class="card mb-3">
+        <div class="card-header">Strip {{strip}}</div>
+        <div class="card-body" data-strip="{{strip}}">
+          <div class="mb-3">
+            <label class="form-label">Brightness</label>
+            <input type="range" class="form-range ws-brightness" min="0" max="255" value="128">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Effect</label>
+            <select class="form-select ws-effect">
+              {% for eff in effects_ws %}
+              <option value="{{ eff }}">{{ eff }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="ws-params"></div>
+          <div class="btn-group">
+            <button class="btn btn-primary ws-apply">Apply</button>
+            <button class="btn btn-success ws-power-on">On</button>
+            <button class="btn btn-secondary ws-power-off">Off</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <h2>White Channels</h2>
+  <div id="white-channels" class="row">
+    {% for chan in range(4) %}
+    <div class="col-md-6">
+      <div class="card mb-3">
+        <div class="card-header">Channel {{chan}}</div>
+        <div class="card-body" data-channel="{{chan}}">
+          <div class="mb-3">
+            <label class="form-label">Brightness</label>
+            <input type="range" class="form-range white-brightness" min="0" max="255" value="128">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Effect</label>
+            <select class="form-select white-effect">
+              {% for eff in effects_white %}
+              <option value="{{ eff }}">{{ eff }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="btn-group">
+            <button class="btn btn-primary white-apply">Apply</button>
+            <button class="btn btn-success white-power-on">On</button>
+            <button class="btn btn-secondary white-power-off">Off</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="mt-4">
+    <button id="ota-check" class="btn btn-warning">Check OTA</button>
+  </div>
+</div>
+
+<script src="{{ url_for('static', filename='main.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build Flask-based server that publishes MQTT commands for WS and white LED strips
- add Bootstrap UI with dynamic effect controls, per-strip power toggles, and OTA trigger
- include master brightness slider and tailored inputs for solid and triple_wave effects

## Testing
- `python -m py_compile NewServer/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b14bd807ec832680c2d67e0e8b6112