### PR TITLE
Enable DMA for WS2812 strip to reduce flicker

### DIFF
--- a/UltraNodeV5/components/ul_ws_engine/ul_ws_engine.c
+++ b/UltraNodeV5/components/ul_ws_engine/ul_ws_engine.c
@@ -140,10 +140,13 @@ static void init_strip(int idx, int gpio, int pixels, bool enabled) {
         .clk_src = RMT_CLK_SRC_DEFAULT,
         .resolution_hz = 10 * 1000 * 1000, // 10MHz
         .mem_block_symbols = 0,
+        .flags.with_dma = true,
     };
     ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &s_strips[idx].handle));
     s_strips[idx].pixels = pixels;
-    s_strips[idx].frame = (uint8_t*)heap_caps_malloc(pixels*3, MALLOC_CAP_8BIT);
+    // Allocate DMA-capable memory so RMT can access the frame buffer without
+    // CPU intervention, reducing flicker during refreshes
+    s_strips[idx].frame = (uint8_t*)heap_caps_malloc(pixels * 3, MALLOC_CAP_8BIT | MALLOC_CAP_DMA);
     memset(s_strips[idx].frame, 0, pixels*3);
     // defaults
     int n=0; const ws_effect_t* tbl = ul_ws_get_effects(&n);


### PR DESCRIPTION
## Summary
- Enable RMT DMA and DMA-capable frame buffer for WS2812 driver

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf-tools` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68b15ca40348832689c3e16f448684db