### PR TITLE
Adapt UltraNodeV5c3 for single-core ESP32-C3

### DIFF
--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -1,5 +1,12 @@
 menu "UltraLights Configuration"
 
+menu "System"
+    config UL_CORE_COUNT
+        int "CPU core count"
+        range 1 2
+        default 2
+endmenu
+
 menu "Node / Network"
     config UL_NODE_ID
         string "Node ID"

--- a/UltraNodeV5/sdkconfig
+++ b/UltraNodeV5/sdkconfig
@@ -435,6 +435,12 @@ CONFIG_PARTITION_TABLE_MD5=y
 #
 
 #
+# System
+#
+CONFIG_UL_CORE_COUNT=2
+# end of System
+
+#
 # Node / Network
 #
 CONFIG_UL_NODE_ID="node"

--- a/UltraNodeV5/sdkconfig.defaults
+++ b/UltraNodeV5/sdkconfig.defaults
@@ -1,3 +1,6 @@
+# ---- System ----
+CONFIG_UL_CORE_COUNT=2
+
 # ---- Node / Network ----
 CONFIG_UL_NODE_ID="node01"
 CONFIG_UL_WIFI_SSID="YourSSID"

--- a/UltraNodeV5c3/components/ul_mqtt/ul_mqtt.c
+++ b/UltraNodeV5c3/components/ul_mqtt/ul_mqtt.c
@@ -249,9 +249,8 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 
 void ul_mqtt_start(void)
 {
-    // MQTT runs at modest priority. The esp-mqtt library does not expose
-    // an explicit core assignment, but its task defaults to core 0 keeping
-    // core 1 free for time-critical LED driving.
+    // MQTT runs at modest priority. On the ESP32-C3 all tasks share the
+    // single core, so no explicit core assignment is needed.
     esp_mqtt_client_config_t cfg = {
         .broker.address.uri = CONFIG_UL_MQTT_URI,
         .credentials.username = CONFIG_UL_MQTT_USER,

--- a/UltraNodeV5c3/components/ul_ota/CMakeLists.txt
+++ b/UltraNodeV5c3/components/ul_ota/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "ul_ota.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES esp_https_ota esp_http_client mbedtls nvs_flash ul_core ul_mqtt)
+                       REQUIRES esp_https_ota esp_http_client mbedtls nvs_flash ul_core ul_mqtt ul_task)

--- a/UltraNodeV5c3/components/ul_ota/ul_ota.c
+++ b/UltraNodeV5c3/components/ul_ota/ul_ota.c
@@ -5,6 +5,7 @@
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "ul_task.h"
 #include <string.h>
 #include "esp_crt_bundle.h"
 
@@ -20,8 +21,8 @@ static void ota_task(void*)
 
 void ul_ota_start(void)
 {
-    // Periodic OTA checks running on the single core
-    xTaskCreate(ota_task, "ota_task", 6144, NULL, 4, NULL);
+    // Periodic OTA checks pinned to core 0 when multiple cores are available
+    ul_task_create(ota_task, "ota_task", 6144, NULL, 4, NULL, 0);
 }
 
 static esp_err_t _http_client_init_cb(esp_http_client_handle_t http_client)

--- a/UltraNodeV5c3/components/ul_ota/ul_ota.c
+++ b/UltraNodeV5c3/components/ul_ota/ul_ota.c
@@ -20,8 +20,8 @@ static void ota_task(void*)
 
 void ul_ota_start(void)
 {
-    // OTA runs on core 0 to keep core 1 free for LED timing
-    xTaskCreatePinnedToCore(ota_task, "ota_task", 6144, NULL, 4, NULL, 0);
+    // Periodic OTA checks running on the single core
+    xTaskCreate(ota_task, "ota_task", 6144, NULL, 4, NULL);
 }
 
 static esp_err_t _http_client_init_cb(esp_http_client_handle_t http_client)

--- a/UltraNodeV5c3/components/ul_sensors/CMakeLists.txt
+++ b/UltraNodeV5c3/components/ul_sensors/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "ul_sensors.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES driver esp_timer ul_mqtt)
+                       REQUIRES driver esp_timer ul_mqtt ul_task)

--- a/UltraNodeV5c3/components/ul_sensors/ul_sensors.c
+++ b/UltraNodeV5c3/components/ul_sensors/ul_sensors.c
@@ -93,8 +93,8 @@ static void sensors_task(void*)
 
 void ul_sensors_start(void)
 {
-    // Pin sensor processing to core 0 so core 1 can be dedicated to LED work
-    xTaskCreatePinnedToCore(sensors_task, "sensors", 4096, NULL, 5, NULL, 0);
+    // Sensor processing runs at a modest priority on the single core
+    xTaskCreate(sensors_task, "sensors", 4096, NULL, 5, NULL);
 }
 
 void ul_sensors_set_cooldown(int seconds)

--- a/UltraNodeV5c3/components/ul_sensors/ul_sensors.c
+++ b/UltraNodeV5c3/components/ul_sensors/ul_sensors.c
@@ -7,6 +7,7 @@
 #include "esp_log.h"
 #include "ul_mqtt.h"
 #include "esp_rom_sys.h"
+#include "ul_task.h"
 
 static const char* TAG = "ul_sensors";
 
@@ -93,8 +94,8 @@ static void sensors_task(void*)
 
 void ul_sensors_start(void)
 {
-    // Sensor processing runs at a modest priority on the single core
-    xTaskCreate(sensors_task, "sensors", 4096, NULL, 5, NULL);
+    // Sensor processing pinned to core 0 when multiple cores are present
+    ul_task_create(sensors_task, "sensors", 4096, NULL, 5, NULL, 0);
 }
 
 void ul_sensors_set_cooldown(int seconds)

--- a/UltraNodeV5c3/components/ul_task/CMakeLists.txt
+++ b/UltraNodeV5c3/components/ul_task/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "ul_task.c"
+                       INCLUDE_DIRS "include")

--- a/UltraNodeV5c3/components/ul_task/include/ul_task.h
+++ b/UltraNodeV5c3/components/ul_task/include/ul_task.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern uint8_t ul_core_count;
+
+void ul_set_core_count(uint8_t count);
+
+BaseType_t ul_task_create(TaskFunction_t task_func,
+                          const char *name,
+                          const uint32_t stack_depth,
+                          void *params,
+                          UBaseType_t priority,
+                          TaskHandle_t *task_handle,
+                          BaseType_t core_id);
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5c3/components/ul_task/ul_task.c
+++ b/UltraNodeV5c3/components/ul_task/ul_task.c
@@ -1,0 +1,22 @@
+#include "ul_task.h"
+
+uint8_t ul_core_count = portNUM_PROCESSORS;
+
+void ul_set_core_count(uint8_t count) {
+    ul_core_count = count;
+}
+
+BaseType_t ul_task_create(TaskFunction_t task_func,
+                          const char *name,
+                          const uint32_t stack_depth,
+                          void *params,
+                          UBaseType_t priority,
+                          TaskHandle_t *task_handle,
+                          BaseType_t core_id) {
+    if (ul_core_count > 1) {
+        return xTaskCreatePinnedToCore(task_func, name, stack_depth, params,
+                                       priority, task_handle, core_id);
+    }
+    return xTaskCreate(task_func, name, stack_depth, params,
+                       priority, task_handle);
+}

--- a/UltraNodeV5c3/components/ul_task/ul_task.c
+++ b/UltraNodeV5c3/components/ul_task/ul_task.c
@@ -1,6 +1,7 @@
+#include "sdkconfig.h"
 #include "ul_task.h"
 
-uint8_t ul_core_count = portNUM_PROCESSORS;
+uint8_t ul_core_count = CONFIG_UL_CORE_COUNT;
 
 void ul_set_core_count(uint8_t count) {
     ul_core_count = count;

--- a/UltraNodeV5c3/components/ul_white_engine/CMakeLists.txt
+++ b/UltraNodeV5c3/components/ul_white_engine/CMakeLists.txt
@@ -2,4 +2,4 @@ idf_component_register(SRCS "ul_white_engine.c" "effects_white/registry.c"
                             "effects_white/graceful_on.c" "effects_white/graceful_off.c" "effects_white/breathe.c"
                             "effects_white/motion_swell.c" "effects_white/day_night_curve.c" "effects_white/blink.c"
                        INCLUDE_DIRS "include" "effects_white"
-                       REQUIRES json driver esp_timer ul_common_effects)
+                       REQUIRES json driver esp_timer ul_common_effects ul_task)

--- a/UltraNodeV5c3/components/ul_white_engine/ul_white_engine.c
+++ b/UltraNodeV5c3/components/ul_white_engine/ul_white_engine.c
@@ -3,6 +3,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/ledc.h"
+#include "ul_task.h"
 #include "esp_timer.h"
 #include "esp_log.h"
 #include "string.h"
@@ -116,9 +117,10 @@ void ul_white_engine_start(void)
 #else
     ch_init(3, false, 0, 0, 0);
 #endif
-    // Run at slightly lower priority than the pixel refresh task so frame
-    // updates remain smooth on the single core.
-    xTaskCreate(white_task, "white200hz", 4096, NULL, 23, NULL);
+    // Run at slightly lower priority than the pixel refresh task; on
+    // multi-core targets this pins to core 1 so core 0 can handle network
+    // traffic.
+    ul_task_create(white_task, "white200hz", 4096, NULL, 23, NULL, 1);
 }
 
 static white_ch_t* get_ch(int ch) {

--- a/UltraNodeV5c3/components/ul_white_engine/ul_white_engine.c
+++ b/UltraNodeV5c3/components/ul_white_engine/ul_white_engine.c
@@ -116,10 +116,9 @@ void ul_white_engine_start(void)
 #else
     ch_init(3, false, 0, 0, 0);
 #endif
-    // Execute on the same core as the WS2812 engine but slightly lower
-    // priority so the pixel refresh always wins. Core 0 remains free for
-    // networking and other tasks.
-    xTaskCreatePinnedToCore(white_task, "white200hz", 4096, NULL, 23, NULL, 1);
+    // Run at slightly lower priority than the pixel refresh task so frame
+    // updates remain smooth on the single core.
+    xTaskCreate(white_task, "white200hz", 4096, NULL, 23, NULL);
 }
 
 static white_ch_t* get_ch(int ch) {

--- a/UltraNodeV5c3/components/ul_ws_engine/CMakeLists.txt
+++ b/UltraNodeV5c3/components/ul_ws_engine/CMakeLists.txt
@@ -3,4 +3,4 @@ idf_component_register(SRCS "ul_ws_engine.c" "effects_ws/registry.c"
                             "effects_ws/twinkle.c" "effects_ws/theater_chase.c" "effects_ws/wipe.c"
                             "effects_ws/gradient_scroll.c" "effects_ws/triple_wave.c"
                        INCLUDE_DIRS "include" "effects_ws"
-                       REQUIRES json led_strip driver esp_timer ul_common_effects)
+                       REQUIRES json led_strip driver esp_timer ul_common_effects ul_task)

--- a/UltraNodeV5c3/components/ul_ws_engine/ul_ws_engine.c
+++ b/UltraNodeV5c3/components/ul_ws_engine/ul_ws_engine.c
@@ -245,8 +245,8 @@ void ul_ws_engine_start(void)
     init_strip(1, 0, 0, false);
 #endif
     s_refresh_sem = xSemaphoreCreateBinary();
-    xTaskCreatePinnedToCore(led_refresh_task, "ws_refresh", 2048, NULL, 24, NULL, 1);
-    xTaskCreatePinnedToCore(ws_task, "ws60fps", 6144, NULL, 23, NULL, 1);
+    xTaskCreate(led_refresh_task, "ws_refresh", 2048, NULL, 24, NULL);
+    xTaskCreate(ws_task, "ws60fps", 6144, NULL, 23, NULL);
     if (s_refresh_sem) xSemaphoreGive(s_refresh_sem);
 }
 

--- a/UltraNodeV5c3/components/ul_ws_engine/ul_ws_engine.c
+++ b/UltraNodeV5c3/components/ul_ws_engine/ul_ws_engine.c
@@ -3,6 +3,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"
+#include "ul_task.h"
 #include "esp_log.h"
 #include "led_strip.h"
 #include "led_strip_spi.h"
@@ -245,8 +246,10 @@ void ul_ws_engine_start(void)
     init_strip(1, 0, 0, false);
 #endif
     s_refresh_sem = xSemaphoreCreateBinary();
-    xTaskCreate(led_refresh_task, "ws_refresh", 2048, NULL, 24, NULL);
-    xTaskCreate(ws_task, "ws60fps", 6144, NULL, 23, NULL);
+    // Pixel refresh tasks pin to core 1 on multi-core targets to free core 0
+    // for networking and other work.
+    ul_task_create(led_refresh_task, "ws_refresh", 2048, NULL, 24, NULL, 1);
+    ul_task_create(ws_task, "ws60fps", 6144, NULL, 23, NULL, 1);
     if (s_refresh_sem) xSemaphoreGive(s_refresh_sem);
 }
 

--- a/UltraNodeV5c3/main/Kconfig.projbuild
+++ b/UltraNodeV5c3/main/Kconfig.projbuild
@@ -1,5 +1,12 @@
 menu "UltraLights Configuration"
 
+menu "System"
+    config UL_CORE_COUNT
+        int "CPU core count"
+        range 1 2
+        default 1
+endmenu
+
 menu "Node / Network"
     config UL_NODE_ID
         string "Node ID"

--- a/UltraNodeV5c3/main/app_main.c
+++ b/UltraNodeV5c3/main/app_main.c
@@ -28,7 +28,7 @@ void app_main(void)
 
     ul_mqtt_start();
 
-    ul_ws_engine_start();    // 60 FPS core-pinned
+    ul_ws_engine_start();    // 60 FPS LED engine
     ul_white_engine_start(); // 200 Hz smoothing
 
     ul_sensors_start();

--- a/UltraNodeV5c3/sdkconfig
+++ b/UltraNodeV5c3/sdkconfig
@@ -500,6 +500,12 @@ CONFIG_PARTITION_TABLE_MD5=y
 #
 
 #
+# System
+#
+CONFIG_UL_CORE_COUNT=1
+# end of System
+
+#
 # Node / Network
 #
 CONFIG_UL_NODE_ID="node"

--- a/UltraNodeV5c3/sdkconfig.defaults
+++ b/UltraNodeV5c3/sdkconfig.defaults
@@ -1,3 +1,6 @@
+# ---- System ----
+CONFIG_UL_CORE_COUNT=1
+
 # ---- Node / Network ----
 CONFIG_UL_NODE_ID="node01"
 CONFIG_UL_WIFI_SSID="YourSSID"


### PR DESCRIPTION
## Summary
- replace dual-core task pinning with standard `xTaskCreate` for ESP32-C3 single-core operation
- update related comments to note single-core scheduling

## Testing
- ❌ `idf.py build` *(command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b22f2388e883269aa939a7f9aff111