### PR TITLE
Assign separate SPI buses for dual WS channels

### DIFF
--- a/UltraNodeV5/components/ul_ws_engine/ul_ws_engine.c
+++ b/UltraNodeV5/components/ul_ws_engine/ul_ws_engine.c
@@ -143,7 +143,7 @@ static void init_strip(int idx, int gpio, int pixels, bool enabled) {
     };
     led_strip_spi_config_t spi_config = {
         .clk_src = SPI_CLK_SRC_DEFAULT,
-        .spi_bus = SPI2_HOST,
+        .spi_bus = idx == 0 ? SPI2_HOST : SPI3_HOST,
         .flags = {
             .with_dma = true,
         },

--- a/UltraNodeV5c3/components/ul_ws_engine/ul_ws_engine.c
+++ b/UltraNodeV5c3/components/ul_ws_engine/ul_ws_engine.c
@@ -143,7 +143,7 @@ static void init_strip(int idx, int gpio, int pixels, bool enabled) {
     };
     led_strip_spi_config_t spi_config = {
         .clk_src = SPI_CLK_SRC_DEFAULT,
-        .spi_bus = SPI2_HOST,
+        .spi_bus = idx == 0 ? SPI2_HOST : SPI3_HOST,
         .flags = {
             .with_dma = true,
         },


### PR DESCRIPTION
## Summary
- use different SPI bus for each WS strip to prevent double initialization crash
- mirror change for ESP32-C3 variant

## Testing
- ⚠️ `idf.py build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b242b069ac8326bfe85cde67a40b73