### PR TITLE
Add nginx reverse proxy and certificate deployment scripts

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,0 +1,34 @@
+# Nginx Reverse Proxy and Certificate Deployment
+
+This directory contains helper scripts and configuration for running the `NewServer` Flask app behind an HTTPS reverse proxy and embedding the resulting SSL certificate into the `UltraNodeV5` firmware.
+
+## Setup Nginx and Let's Encrypt
+
+1. Run the setup script with your domain and email:
+   ```bash
+   ./setup_nginx_certbot.sh example.com admin@example.com
+   ```
+   - Installs nginx and certbot.
+   - Copies the sample site config to `/etc/nginx/sites-available/newserver.conf` and enables it.
+   - Requests a Let's Encrypt certificate for `example.com` and configures nginx to use it.
+
+2. Ensure the `NewServer` Flask app is running locally on port 5000.
+
+## Deploy certificate to firmware
+
+After a certificate has been issued, copy it into the firmware tree and generate C header files:
+
+```bash
+./deploy_cert_to_firmware.sh example.com
+```
+
+The PEM files and generated headers are placed in `UltraNodeV5/main/certs/`.
+
+Include the headers in your firmware code to establish secure connections.
+
+## Nginx config
+
+- `sites-available/newserver.conf` – base nginx configuration that proxies requests to the Flask app.
+- `sites-enabled/newserver.conf` – symlink to the enabled site.
+
+Edit `newserver.conf` to adjust additional nginx settings if needed.

--- a/nginx/deploy_cert_to_firmware.sh
+++ b/nginx/deploy_cert_to_firmware.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+DOMAIN=$1
+if [ -z "$DOMAIN" ]; then
+    echo "Usage: $0 <domain>"
+    exit 1
+fi
+
+CERT_DIR=/etc/letsencrypt/live/$DOMAIN
+FIRMWARE_DIR="$(dirname "$0")/../UltraNodeV5/main/certs"
+
+mkdir -p "$FIRMWARE_DIR"
+
+cp "$CERT_DIR/fullchain.pem" "$FIRMWARE_DIR/server.crt"
+cp "$CERT_DIR/privkey.pem" "$FIRMWARE_DIR/server.key"
+
+# Convert to C headers for embedding in firmware
+xxd -i "$FIRMWARE_DIR/server.crt" > "$FIRMWARE_DIR/server_crt.h"
+xxd -i "$FIRMWARE_DIR/server.key" > "$FIRMWARE_DIR/server_key.h"
+
+echo "Certificates copied to $FIRMWARE_DIR and converted to headers."

--- a/nginx/setup_nginx_certbot.sh
+++ b/nginx/setup_nginx_certbot.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+DOMAIN=$1
+EMAIL=$2
+
+if [ -z "$DOMAIN" ] || [ -z "$EMAIL" ]; then
+    echo "Usage: $0 <domain> <email>"
+    exit 1
+fi
+
+sudo apt update
+sudo apt install -y nginx certbot python3-certbot-nginx
+
+# Copy nginx config and enable site
+sudo mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+sudo cp "$(dirname "$0")/sites-available/newserver.conf" /etc/nginx/sites-available/newserver.conf
+sudo ln -sf /etc/nginx/sites-available/newserver.conf /etc/nginx/sites-enabled/newserver.conf
+sudo sed -i "s/your_domain/$DOMAIN/g" /etc/nginx/sites-available/newserver.conf
+
+sudo nginx -t
+sudo systemctl reload nginx
+
+# Obtain certificate and enable HTTPS
+sudo certbot --nginx -d "$DOMAIN" -m "$EMAIL" --non-interactive --agree-tos --redirect

--- a/nginx/sites-available/newserver.conf
+++ b/nginx/sites-available/newserver.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+    server_name your_domain;
+
+    location / {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# Certbot will create a TLS-enabled server block for port 443.

--- a/nginx/sites-enabled/newserver.conf
+++ b/nginx/sites-enabled/newserver.conf
@@ -1,0 +1,1 @@
+../sites-available/newserver.conf


### PR DESCRIPTION
## Summary
- add nginx reverse proxy config for NewServer and helper scripts
- document setup for certbot and copying certificates into UltraNodeV5 firmware

## Testing
- `bash -n nginx/setup_nginx_certbot.sh`
- `bash -n nginx/deploy_cert_to_firmware.sh`
- `pytest`
- `python -m py_compile NewServer/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b25619928083269726fb9d6262c319