### PR TITLE
feat: dynamic node UI based on status

### DIFF
--- a/NewServer/mqtt.py
+++ b/NewServer/mqtt.py
@@ -1,0 +1,45 @@
+import json
+import os
+import threading
+
+import paho.mqtt.client as mqtt
+
+MQTT_BROKER = os.getenv("MQTT_BROKER", "localhost")
+NODE_ID = os.getenv("ULTRALIGHT_NODE", "node")
+
+_status_event = threading.Event()
+_status_payload = {}
+
+
+def _on_connect(client, userdata, flags, rc):
+    client.subscribe(f"ul/{NODE_ID}/evt/status")
+
+
+def _on_message(client, userdata, msg):
+    global _status_payload
+    if msg.topic == f"ul/{NODE_ID}/evt/status":
+        try:
+            _status_payload = json.loads(msg.payload.decode())
+        except json.JSONDecodeError:
+            _status_payload = {}
+        _status_event.set()
+
+
+client = mqtt.Client()
+client.on_connect = _on_connect
+client.on_message = _on_message
+client.connect(MQTT_BROKER)
+client.loop_start()
+
+
+def publish(topic: str, payload: dict) -> None:
+    client.publish(f"ul/{NODE_ID}/{topic}", json.dumps(payload), qos=1)
+
+
+def request_status(timeout: float = 2.0) -> dict:
+    """Request a status snapshot from the node via MQTT."""
+    _status_event.clear()
+    publish("cmd/status", {})
+    if _status_event.wait(timeout):
+        return _status_payload
+    return {}

--- a/NewServer/requirements.txt
+++ b/NewServer/requirements.txt
@@ -1,2 +1,4 @@
-Flask
+fastapi
+uvicorn
 paho-mqtt
+jinja2

--- a/NewServer/runServer.sh
+++ b/NewServer/runServer.sh
@@ -28,4 +28,4 @@ fi
 
 gnome-terminal -- bash -c "mosquitto_sub -t \"#\" -v; exec bash" &
 
-exec uvicorn app.main:app "${OPTS[@]}"
+exec uvicorn app:app "${OPTS[@]}"

--- a/NewServer/static/main.js
+++ b/NewServer/static/main.js
@@ -1,9 +1,4 @@
-const stripConfigs = {
-  0: {strip: 0, effect: 'solid', hex: '#ffffff'},
-  1: {strip: 1, effect: 'solid', hex: '#ffffff'},
-  2: {strip: 2, effect: 'solid', hex: '#ffffff'},
-  3: {strip: 3, effect: 'solid', hex: '#ffffff'},
-};
+const stripConfigs = {};
 
 function sendJSON(url, data) {
   fetch(url, {
@@ -38,6 +33,7 @@ function renderParams(card) {
 
 function initWSCard(card) {
   const strip = Number(card.dataset.strip);
+  stripConfigs[strip] = { strip, effect: 'solid', hex: '#ffffff' };
   card.querySelector('.ws-effect').addEventListener('change', () => renderParams(card));
   renderParams(card);
 
@@ -98,11 +94,8 @@ otaBtn.addEventListener('click', () => {
 const master = document.getElementById('master-brightness');
 master.addEventListener('input', () => {
   const b = Number(master.value);
-  for (let i = 0; i < 4; i++) {
-    const cfg = stripConfigs[i];
-    if (cfg) {
-      const payload = { ...cfg, brightness: b };
-      sendJSON('/api/ws/set', payload);
-    }
-  }
+  Object.values(stripConfigs).forEach(cfg => {
+    const payload = { ...cfg, brightness: b };
+    sendJSON('/api/ws/set', payload);
+  });
 });

--- a/NewServer/static/wifi.svg
+++ b/NewServer/static/wifi.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="none" stroke="#555" stroke-width="2" d="M2.1 8.9a15 15 0 0 1 19.8 0"/>
+  <path fill="none" stroke="#555" stroke-width="2" d="M5.6 12.4a9 9 0 0 1 12.8 0"/>
+  <path fill="none" stroke="#555" stroke-width="2" d="M9.1 15.9a3 3 0 0 1 5.8 0"/>
+  <circle cx="12" cy="20" r="1.5" fill="#555"/>
+</svg>

--- a/NewServer/templates/index.html
+++ b/NewServer/templates/index.html
@@ -4,20 +4,28 @@
   <meta charset="UTF-8">
   <title>UltraNode Controller</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', path='style.css') }}">
 </head>
 <body class="bg-light">
 <div class="container py-4">
   <h1 class="mb-4">UltraNode Controller</h1>
+
+  {% if wifi_strength is not none %}
+  <div class="d-flex align-items-center mb-4">
+    <img src="{{ url_for('static', path='wifi.svg') }}" alt="WiFi" width="24" height="24" class="me-2">
+    <span>Signal: {{ wifi_strength }}% ({{ wifi_rssi }} dBm)</span>
+  </div>
+  {% endif %}
 
   <div class="mb-4">
     <label for="master-brightness" class="form-label">Master Brightness</label>
     <input type="range" class="form-range" min="0" max="255" value="128" id="master-brightness">
   </div>
 
+  {% if ws_count %}
   <h2>WS Strips</h2>
   <div id="ws-strips" class="row">
-    {% for strip in range(4) %}
+    {% for strip in range(ws_count) %}
     <div class="col-md-6">
       <div class="card mb-3">
         <div class="card-header">Strip {{strip}}</div>
@@ -45,10 +53,12 @@
     </div>
     {% endfor %}
   </div>
+  {% endif %}
 
+  {% if white_count %}
   <h2>White Channels</h2>
   <div id="white-channels" class="row">
-    {% for chan in range(4) %}
+    {% for chan in range(white_count) %}
     <div class="col-md-6">
       <div class="card mb-3">
         <div class="card-header">Channel {{chan}}</div>
@@ -75,12 +85,21 @@
     </div>
     {% endfor %}
   </div>
+  {% endif %}
+
+  {% if sensors %}
+  <h2>Motion Sensors</h2>
+  <div>
+    <p>PIR sensor: {{ 'enabled' if sensors.pir_enabled else 'disabled' }}</p>
+    <p>Ultrasonic sensor: {{ 'enabled' if sensors.ultra_enabled else 'disabled' }}</p>
+  </div>
+  {% endif %}
 
   <div class="mt-4">
     <button id="ota-check" class="btn btn-warning">Check OTA</button>
   </div>
 </div>
 
-<script src="{{ url_for('static', filename='main.js') }}"></script>
+<script src="{{ url_for('static', path='main.js') }}"></script>
 </body>
 </html>

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -113,6 +113,12 @@ Registered effects: `graceful_on`, `graceful_off`, `motion_swell`, `day_night_cu
 
 The node publishes its current state to `ul/<node-id>/evt/status` after every accepted command. The JSON payload contains details about each strip and channel. The `color` field is meaningful only when the corresponding strip effect is `solid`.
 
+Top level fields:
+
+- `node` – node identifier
+- `uptime_s` – uptime in seconds
+- `wifi_rssi` – current WiFi signal strength in dBm
+
 ## Publishing from Python
 
 Example using `paho-mqtt`:


### PR DESCRIPTION
## Summary
- modularize FastAPI server with MQTT helper
- fetch node status via MQTT to tailor WS/white/sensor controls
- add ESP32 `cmd/status` handler reporting active devices and WiFi RSSI
- show WiFi signal with cute icon on landing page

## Testing
- `python -m py_compile NewServer/app.py NewServer/mqtt.py`
- `idf.py -C UltraNodeV5 build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b25eba6b148326b9769677c8c06fa7