### PR TITLE
Refactor ws engine for modular effect parameters

### DIFF
--- a/UltraNodeV5/components/ul_ws_engine/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_ws_engine/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(SRCS "ul_ws_engine.c" "effects_ws/registry.c" 
                             "effects_ws/solid.c" "effects_ws/breathe.c" "effects_ws/rainbow.c"
                             "effects_ws/twinkle.c" "effects_ws/theater_chase.c" "effects_ws/wipe.c"
-                            "effects_ws/gradient_scroll.c" "effects_ws/triple_wave.c"
+                            "effects_ws/gradient_scroll.c" "effects_ws/triple_wave.c" "effects_ws/flash.c"
                        INCLUDE_DIRS "include" "effects_ws"
                        REQUIRES json led_strip driver esp_timer ul_common_effects ul_task)

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/effect.h
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/effect.h
@@ -1,9 +1,13 @@
 #pragma once
 #include <stdint.h>
+
+typedef struct cJSON cJSON;
+
 typedef struct {
     const char* name;
     void (*init)(void);
     void (*render)(uint8_t* frame_rgb, int pixels, int frame_idx);
+    void (*apply_params)(int strip, const cJSON* params);
 } ws_effect_t;
 
 const ws_effect_t* ul_ws_get_effects(int* count);

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/flash.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/flash.c
@@ -1,0 +1,27 @@
+#include "effect.h"
+#include "ul_ws_engine.h"
+#include "cJSON.h"
+
+static uint8_t s_color1[2][3];
+static uint8_t s_color2[2][3];
+
+void flash_init(void) { }
+
+void flash_apply_params(int strip, const cJSON* params) {
+    if (strip < 0 || strip > 1) return;
+    if (!params || !cJSON_IsArray(params) || cJSON_GetArraySize(params) < 6) return;
+    for (int i = 0; i < 3; ++i) {
+        s_color1[strip][i] = (uint8_t)cJSON_GetArrayItem(params, i)->valueint;
+        s_color2[strip][i] = (uint8_t)cJSON_GetArrayItem(params, i+3)->valueint;
+    }
+}
+
+void flash_render(uint8_t* frame_rgb, int pixels, int frame_idx) {
+    int strip = ul_ws_effect_current_strip();
+    uint8_t* c = ((frame_idx / 10) % 2) ? s_color2[strip] : s_color1[strip];
+    for (int i = 0; i < pixels; ++i) {
+        frame_rgb[3*i+0] = c[0];
+        frame_rgb[3*i+1] = c[1];
+        frame_rgb[3*i+2] = c[2];
+    }
+}

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/registry.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/registry.c
@@ -1,6 +1,6 @@
 #include "effect.h"
 
-void solid_init(void);        void solid_render(uint8_t*,int,int);
+void solid_init(void);        void solid_render(uint8_t*,int,int);        void solid_apply_params(int,const cJSON*);
 void breathe_init(void);      void breathe_render(uint8_t*,int,int);
 void rainbow_init(void);      void rainbow_render(uint8_t*,int,int);
 void twinkle_init(void);      void twinkle_render(uint8_t*,int,int);
@@ -8,17 +8,19 @@ void theater_chase_init(void);void theater_chase_render(uint8_t*,int,int);
 void wipe_init(void);         void wipe_render(uint8_t*,int,int);
 void noise_init(void);        void noise_render(uint8_t*,int,int);
 void gradient_scroll_init(void);void gradient_scroll_render(uint8_t*,int,int);
-void triple_wave_init(void);  void triple_wave_render(uint8_t*,int,int);
+void triple_wave_init(void);  void triple_wave_render(uint8_t*,int,int);   void triple_wave_apply_params(int,const cJSON*);
+void flash_init(void);        void flash_render(uint8_t*,int,int);        void flash_apply_params(int,const cJSON*);
 
 static const ws_effect_t effects[] = {
-    {"solid", solid_init, solid_render},
-    {"breathe", breathe_init, breathe_render},
-    {"rainbow", rainbow_init, rainbow_render},
-    {"twinkle", twinkle_init, twinkle_render},
-    {"theater_chase", theater_chase_init, theater_chase_render},
-    {"wipe", wipe_init, wipe_render},
-    {"gradient_scroll", gradient_scroll_init, gradient_scroll_render},
-    {"triple_wave", triple_wave_init, triple_wave_render},
+    {"solid", solid_init, solid_render, solid_apply_params},
+    {"breathe", breathe_init, breathe_render, NULL},
+    {"rainbow", rainbow_init, rainbow_render, NULL},
+    {"twinkle", twinkle_init, twinkle_render, NULL},
+    {"theater_chase", theater_chase_init, theater_chase_render, NULL},
+    {"wipe", wipe_init, wipe_render, NULL},
+    {"gradient_scroll", gradient_scroll_init, gradient_scroll_render, NULL},
+    {"triple_wave", triple_wave_init, triple_wave_render, triple_wave_apply_params},
+    {"flash", flash_init, flash_render, flash_apply_params},
 };
 
 const ws_effect_t* ul_ws_get_effects(int* count) {

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/solid.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/solid.c
@@ -1,6 +1,25 @@
 #include "effect.h"
+#include "ul_ws_engine.h"
+#include "cJSON.h"
+
 void solid_init(void) { (void)0; }
+
+void solid_apply_params(int strip, const cJSON* params) {
+    if (!params || !cJSON_IsArray(params) || cJSON_GetArraySize(params) < 3) return;
+    int r = cJSON_GetArrayItem(params, 0)->valueint;
+    int g = cJSON_GetArrayItem(params, 1)->valueint;
+    int b = cJSON_GetArrayItem(params, 2)->valueint;
+    ul_ws_set_solid_rgb(strip, (uint8_t)r, (uint8_t)g, (uint8_t)b);
+}
+
 void solid_render(uint8_t* frame_rgb, int pixels, int frame_idx) {
     (void)frame_idx;
-    for(int i=0;i<pixels;i++){frame_rgb[3*i+0]=255;frame_rgb[3*i+1]=0;frame_rgb[3*i+2]=0;}
+    int strip = ul_ws_effect_current_strip();
+    uint8_t r, g, b;
+    ul_ws_get_solid_rgb(strip, &r, &g, &b);
+    for (int i = 0; i < pixels; ++i) {
+        frame_rgb[3*i+0] = r;
+        frame_rgb[3*i+1] = g;
+        frame_rgb[3*i+2] = b;
+    }
 }

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/triple_wave.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/triple_wave.c
@@ -1,26 +1,48 @@
 #include "effect.h"
 #include "ul_ws_engine.h"
+#include "cJSON.h"
 #include <math.h>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
 
-void triple_wave_init(void) {
-    // no-op
+typedef struct {
+    uint8_t r, g, b;
+    float freq;
+    float velocity;
+} wave_cfg_t;
+
+static wave_cfg_t s_waves[2][3];
+
+void triple_wave_init(void) { }
+
+void triple_wave_apply_params(int strip, const cJSON* params) {
+    if (strip < 0 || strip > 1) return;
+    if (!params || !cJSON_IsArray(params) || cJSON_GetArraySize(params) != 3) return;
+    for (int i = 0; i < 3; ++i) {
+        cJSON* jw = cJSON_GetArrayItem(params, i);
+        cJSON* jhex = cJSON_GetObjectItem(jw, "hex");
+        cJSON* jfreq = cJSON_GetObjectItem(jw, "freq");
+        cJSON* jvel = cJSON_GetObjectItem(jw, "velocity");
+        if (!jhex || !cJSON_IsString(jhex) || !jfreq || !cJSON_IsNumber(jfreq) || !jvel || !cJSON_IsNumber(jvel)) {
+            continue;
+        }
+        ul_ws_hex_to_rgb(jhex->valuestring, &s_waves[strip][i].r, &s_waves[strip][i].g, &s_waves[strip][i].b);
+        s_waves[strip][i].freq = (float)jfreq->valuedouble;
+        s_waves[strip][i].velocity = (float)jvel->valuedouble;
+    }
 }
 
 void triple_wave_render(uint8_t* frame_rgb, int pixels, int frame_idx) {
     int strip = ul_ws_effect_current_strip();
-    const ul_ws_wave_cfg_t* waves = ul_ws_triple_wave_get(strip);
-    if (!waves) return;
-
+    const wave_cfg_t* waves = s_waves[strip];
     for (int i = 0; i < pixels; ++i) {
         float pos = (float)i / (float)pixels;
         float r = 0.0f, g = 0.0f, b = 0.0f;
         for (int w = 0; w < 3; ++w) {
             float phase = 2.0f * (float)M_PI * (waves[w].freq * pos + frame_idx * waves[w].velocity);
-            float s = (sinf(phase) + 1.0f) * 0.5f; // 0..1
+            float s = (sinf(phase) + 1.0f) * 0.5f;
             r += s * waves[w].r;
             g += s * waves[w].g;
             b += s * waves[w].b;
@@ -33,4 +55,3 @@ void triple_wave_render(uint8_t* frame_rgb, int pixels, int frame_idx) {
         frame_rgb[3*i+2] = (uint8_t)b;
     }
 }
-

--- a/UltraNodeV5/components/ul_ws_engine/include/ul_ws_engine.h
+++ b/UltraNodeV5/components/ul_ws_engine/include/ul_ws_engine.h
@@ -12,20 +12,12 @@ void ul_ws_apply_json(cJSON* root);
 // Control API
 bool ul_ws_set_effect(int strip, const char* name);     // returns true if found
 void ul_ws_set_solid_rgb(int strip, uint8_t r, uint8_t g, uint8_t b);
+void ul_ws_get_solid_rgb(int strip, uint8_t* r, uint8_t* g, uint8_t* b);
 void ul_ws_set_brightness(int strip, uint8_t bri);      // 0..255
 void ul_ws_power(int strip, bool on);
 
 // Utility: convert "#RRGGBB" string to RGB components
 bool ul_ws_hex_to_rgb(const char* hex, uint8_t* r, uint8_t* g, uint8_t* b);
-
-typedef struct {
-    uint8_t r, g, b;
-    float freq;
-    float velocity;
-} ul_ws_wave_cfg_t;
-
-void ul_ws_triple_wave_set(int strip, const ul_ws_wave_cfg_t waves[3]);
-const ul_ws_wave_cfg_t* ul_ws_triple_wave_get(int strip);
 
 // Status API
 typedef struct {


### PR DESCRIPTION
## Summary
- support effect-specific parameter arrays and global speed field
- modularize WS effects with new apply_params hook
- add example `flash` effect and update MQTT docs for new payload format

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e23f999083268b7b86388c5ac795