### PR TITLE
feat: add fixed triple wave effect

### DIFF
--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/triple_wave.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/triple_wave.c
@@ -6,74 +6,45 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-#define MAX_WAVES 3
+#define NUM_WAVES 3
 
 typedef struct {
     uint8_t r, g, b;
-    float freq;
-    float velocity;
+    float wavelength;
+    float frequency;
 } wave_cfg_t;
 
-static wave_cfg_t s_waves[2][MAX_WAVES];
-static int s_wave_count[2];
+/* Fixed configuration for the three color waves */
+static const wave_cfg_t s_waves[NUM_WAVES] = {
+    {255, 0,   0, 30.0f, 0.10f}, // red wave
+    {0,   255, 0, 45.0f, 0.07f}, // green wave
+    {0,   0, 255, 60.0f, 0.05f}  // blue wave
+};
 
 void triple_wave_init(void) {
-    for (int s = 0; s < 2; ++s) {
-        s_wave_count[s] = 0;
-        for (int w = 0; w < MAX_WAVES; ++w) {
-            s_waves[s][w] = (wave_cfg_t){0};
-        }
-    }
+    // no initialization required
 }
 
 void triple_wave_apply_params(int strip, const cJSON* params) {
-    if (strip < 0 || strip > 1) return;
-    if (!params || !cJSON_IsArray(params)) return;
-
-    int elems = cJSON_GetArraySize(params);
-    int count = elems / 5;
-    if (count > MAX_WAVES) count = MAX_WAVES;
-    s_wave_count[strip] = count;
-
-    for (int i = 0; i < count; ++i) {
-        int idx = i * 5;
-        cJSON* jr = cJSON_GetArrayItem(params, idx);
-        cJSON* jg = cJSON_GetArrayItem(params, idx + 1);
-        cJSON* jb = cJSON_GetArrayItem(params, idx + 2);
-        cJSON* jfreq = cJSON_GetArrayItem(params, idx + 3);
-        cJSON* jvel = cJSON_GetArrayItem(params, idx + 4);
-        if (!jr || !jg || !jb || !jfreq || !jvel ||
-            !cJSON_IsNumber(jr) || !cJSON_IsNumber(jg) ||
-            !cJSON_IsNumber(jb) || !cJSON_IsNumber(jfreq) ||
-            !cJSON_IsNumber(jvel)) {
-            continue;
-        }
-        s_waves[strip][i].r = (uint8_t)jr->valuedouble;
-        s_waves[strip][i].g = (uint8_t)jg->valuedouble;
-        s_waves[strip][i].b = (uint8_t)jb->valuedouble;
-        s_waves[strip][i].freq = (float)jfreq->valuedouble;
-        s_waves[strip][i].velocity = (float)jvel->valuedouble;
-    }
+    (void)strip;
+    (void)params; // effect has fixed parameters
 }
 
 void triple_wave_render(uint8_t* frame_rgb, int pixels, int frame_idx) {
-    int strip = ul_ws_effect_current_strip();
-    int count = s_wave_count[strip];
-    const wave_cfg_t* waves = s_waves[strip];
     for (int i = 0; i < pixels; ++i) {
-        float pos = (float)i / (float)pixels;
         float r = 0.0f, g = 0.0f, b = 0.0f;
-        for (int w = 0; w < count; ++w) {
-            float phase = 2.0f * (float)M_PI * (waves[w].freq * pos + frame_idx * waves[w].velocity);
-            float s = (sinf(phase) + 1.0f) * 0.5f;
-            r += s * waves[w].r;
-            g += s * waves[w].g;
-            b += s * waves[w].b;
+        for (int w = 0; w < NUM_WAVES; ++w) {
+            float pos = (float)i / s_waves[w].wavelength;
+            float phase = 2.0f * (float)M_PI * (pos + frame_idx * s_waves[w].frequency);
+            float intensity = (sinf(phase) + 1.0f) * 0.5f; // 0..1
+            r += intensity * s_waves[w].r;
+            g += intensity * s_waves[w].g;
+            b += intensity * s_waves[w].b;
         }
         if (r > 255.0f) r = 255.0f;
         if (g > 255.0f) g = 255.0f;
         if (b > 255.0f) b = 255.0f;
-        frame_rgb[3*i] = (uint8_t)r;
+        frame_rgb[3*i]   = (uint8_t)r;
         frame_rgb[3*i+1] = (uint8_t)g;
         frame_rgb[3*i+2] = (uint8_t)b;
     }

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -36,7 +36,7 @@ The contents of `params` depend on the chosen effect:
 
 * `rainbow` – one integer `[wavelength]` controlling the color cycle in pixels
 * `solid` – RGB `[r,g,b]` values
-* `triple_wave` – up to three waves; each wave uses five values in the order `[r,g,b,freq,velocity]`
+* `triple_wave` – fixed blend of three colored sine waves; `params` should be an empty array
 * `flash` – six integers `[r1,g1,b1,r2,g2,b2]`
 
 Example – set strip 1 to a green solid color:
@@ -51,7 +51,7 @@ Example – set strip 1 to a green solid color:
 }
 ```
 
-Example – triple wave with three colored sine waves:
+Example – triple wave combining red, green, and blue waves:
 
 ```json
 {
@@ -59,11 +59,7 @@ Example – triple wave with three colored sine waves:
   "effect": "triple_wave",
   "brightness": 200,
   "speed": 0.5,
-  "params": [
-    255, 0, 0, 1.0, 0.1,
-    0, 255, 0, 2.0, 0.15,
-    0, 0, 255, 0.5, 0.2
-  ]
+  "params": []
 }
 ```
 


### PR DESCRIPTION
## Summary
- replace triple wave effect with fixed red, green and blue sine waves
- document new triple wave effect and its parameters

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f52fa4488326853505ed4c29e86c