### PR TITLE
Add ESP32-C3 compatibility option

### DIFF
--- a/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
+++ b/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
@@ -10,6 +10,12 @@
 #include "effects_white/effect.h"
 #include "cJSON.h"
 
+#if CONFIG_UL_IS_ESP32C3
+#define UL_LEDC_SPEED_MODE LEDC_LOW_SPEED_MODE
+#else
+#define UL_LEDC_SPEED_MODE LEDC_HIGH_SPEED_MODE
+#endif
+
 static const char* TAG = "ul_white";
 
 typedef struct {
@@ -35,7 +41,7 @@ static const white_effect_t* find_eff(const char* name) {
 static void setup_ledc_channel(int ch, int gpio, int freq_hz)
 {
     ledc_timer_config_t tcfg = {
-        .speed_mode = LEDC_HIGH_SPEED_MODE,
+        .speed_mode = UL_LEDC_SPEED_MODE,
         .timer_num = LEDC_TIMER_0,
         .duty_resolution = LEDC_TIMER_12_BIT,
         .freq_hz = freq_hz,
@@ -44,7 +50,7 @@ static void setup_ledc_channel(int ch, int gpio, int freq_hz)
     ledc_timer_config(&tcfg);
     ledc_channel_config_t ccfg = {
         .gpio_num = gpio,
-        .speed_mode = LEDC_HIGH_SPEED_MODE,
+        .speed_mode = UL_LEDC_SPEED_MODE,
         .channel = ch,
         .intr_type = LEDC_INTR_DISABLE,
         .timer_sel = LEDC_TIMER_0,
@@ -87,8 +93,8 @@ static void white_task(void*)
             v = s_ch[i].brightness;
             if (!s_ch[i].power) v = 0;
             int duty = (v * ((1<<12)-1)) / 255;
-            ledc_set_duty(LEDC_HIGH_SPEED_MODE, s_ch[i].ledc_ch, duty);
-            ledc_update_duty(LEDC_HIGH_SPEED_MODE, s_ch[i].ledc_ch);
+            ledc_set_duty(UL_LEDC_SPEED_MODE, s_ch[i].ledc_ch, duty);
+            ledc_update_duty(UL_LEDC_SPEED_MODE, s_ch[i].ledc_ch);
         }
         vTaskDelayUntil(&last_wake, period_ticks);
     }

--- a/UltraNodeV5/components/ul_ws_engine/ul_ws_engine.c
+++ b/UltraNodeV5/components/ul_ws_engine/ul_ws_engine.c
@@ -99,7 +99,12 @@ static void init_strip(int idx, int gpio, int pixels, bool enabled) {
     };
     led_strip_spi_config_t spi_config = {
         .clk_src = SPI_CLK_SRC_DEFAULT,
-        .spi_bus = idx == 0 ? SPI2_HOST : SPI3_HOST,
+        .spi_bus = 
+#if CONFIG_UL_IS_ESP32C3
+            SPI2_HOST,
+#else
+            (idx == 0 ? SPI2_HOST : SPI3_HOST),
+#endif
         .flags = {
             .with_dma = true,
         },
@@ -191,8 +196,12 @@ void ul_ws_engine_start(void)
 #else
     init_strip(0, 0, 0, false);
 #endif
+#if !CONFIG_UL_IS_ESP32C3
 #if CONFIG_UL_WS1_ENABLED
     init_strip(1, CONFIG_UL_WS1_GPIO, CONFIG_UL_WS1_PIXELS, true);
+#else
+    init_strip(1, 0, 0, false);
+#endif
 #else
     init_strip(1, 0, 0, false);
 #endif

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -5,6 +5,10 @@ menu "System"
         int "CPU core count"
         range 1 2
         default 1
+
+    config UL_IS_ESP32C3
+        bool "Target is ESP32-C3"
+        default n
 endmenu
 
 menu "Node / Network"

--- a/UltraNodeV5/sdkconfig.defaults
+++ b/UltraNodeV5/sdkconfig.defaults
@@ -1,5 +1,6 @@
 # ---- System ----
 CONFIG_UL_CORE_COUNT=1
+CONFIG_UL_IS_ESP32C3=n
 
 # ---- Node / Network ----
 CONFIG_UL_NODE_ID="node01"


### PR DESCRIPTION
## Summary
- add UL_IS_ESP32C3 menuconfig option to select ESP32-C3 target
- gate second SPI bus initialization on new option
- switch LEDC mode to low speed when building for ESP32-C3

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b523a1d7848326a291f1a6a4accb0c