### PR TITLE
Remove white power command and add solid effect

### DIFF
--- a/Server/app/mqtt_bus.py
+++ b/Server/app/mqtt_bus.py
@@ -60,10 +60,6 @@ class MqttBus:
             msg["params"] = params
         self.pub(topic_cmd(node_id, "white/set"), msg)
 
-    def white_power(self, node_id: str, channel: int, on: bool):
-        msg = {"channel": int(channel), "on": bool(on)}
-        self.pub(topic_cmd(node_id, "white/power"), msg)
-
     # ---- Sensor commands ----
     def sensor_cooldown(self, node_id: str, seconds: int):
         msg = {"seconds": int(seconds)}
@@ -79,4 +75,4 @@ class MqttBus:
             nid = n["id"]
             for i in range(4):
                 self.ws_power(nid, i, False)
-                self.white_power(nid, i, False)
+                self.white_set(nid, i, brightness=0)

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -120,19 +120,6 @@ def api_white_set(node_id: str, payload: Dict[str, Any]):
     get_bus().white_set(node_id, channel, effect, brightness, params)
     return {"ok": True}
 
-@router.post("/api/node/{node_id}/white/power")
-def api_white_power(node_id: str, payload: Dict[str, Any]):
-    _valid_node(node_id)
-    try:
-        channel = int(payload.get("channel"))
-    except Exception:
-        raise HTTPException(400, "invalid channel")
-    if not 0 <= channel < 4:
-        raise HTTPException(400, "invalid channel")
-    on = bool(payload.get("on", True))
-    get_bus().white_power(node_id, channel, on)
-    return {"ok": True}
-
 @router.post("/api/node/{node_id}/sensor/cooldown")
 def api_sensor_cooldown(node_id: str, payload: Dict[str, Any]):
     _valid_node(node_id)

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -22,8 +22,6 @@
   </div>
   <div class="flex gap-2">
     <button id="wSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
-    <button id="wOn" class="px-4 py-2 pill bg-green-600 hover:bg-green-500 text-white">On</button>
-    <button id="wOff" class="px-4 py-2 pill bg-red-600 hover:bg-red-500 text-white">Off</button>
   </div>
 </section>
 <script>
@@ -50,11 +48,5 @@ document.getElementById('wSet').onclick=async()=>{
   const msg={channel, effect, brightness};
   if(Object.keys(params).length)msg.params=params;
   await post(`/api/node/{{ node.id }}/white/set`,msg);
-};
-document.getElementById('wOn').onclick=async()=>{
-  const channel=parseInt(ch.value,10);if(Number.isNaN(channel)){alert('Invalid channel');return;}await post(`/api/node/{{ node.id }}/white/power`,{channel,on:true});
-};
-document.getElementById('wOff').onclick=async()=>{
-  const channel=parseInt(ch.value,10);if(Number.isNaN(channel)){alert('Invalid channel');return;}await post(`/api/node/{{ node.id }}/white/power`,{channel,on:false});
 };
 </script>

--- a/UltraNodeV5/components/ul_white_engine/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_white_engine/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "ul_white_engine.c" "effects_white/registry.c" "effects_white/breathe.c"
+idf_component_register(SRCS "ul_white_engine.c" "effects_white/registry.c" "effects_white/solid.c" "effects_white/breathe.c"
                        INCLUDE_DIRS "include" "effects_white"
                        REQUIRES json driver esp_timer ul_common_effects ul_task)

--- a/UltraNodeV5/components/ul_white_engine/effects_white/registry.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/registry.c
@@ -1,10 +1,15 @@
 #include "effect.h"
+#include <stddef.h>
 
 void white_breathe_init(void);
 uint8_t white_breathe_render(int frame_idx);
 void white_breathe_apply_params(int ch, const cJSON* params);
 
+void white_solid_init(void);
+uint8_t white_solid_render(int frame_idx);
+
 static const white_effect_t effects[] = {
+    {"solid", white_solid_init, white_solid_render, NULL},
     {"breathe", white_breathe_init, white_breathe_render, white_breathe_apply_params},
 };
 

--- a/UltraNodeV5/components/ul_white_engine/effects_white/solid.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/solid.c
@@ -1,0 +1,11 @@
+#include "effect.h"
+
+void white_solid_init(void) {
+    // no initialization needed
+}
+
+uint8_t white_solid_render(int frame_idx) {
+    (void)frame_idx;
+    return 255;
+}
+

--- a/UltraNodeV5/components/ul_white_engine/include/ul_white_engine.h
+++ b/UltraNodeV5/components/ul_white_engine/include/ul_white_engine.h
@@ -12,12 +12,10 @@ void ul_white_apply_json(cJSON* root);
 // Channels 0..3 (enabled by Kconfig flags). Returns false if channel not enabled.
 bool ul_white_set_effect(int ch, const char* name);
 bool ul_white_set_brightness(int ch, uint8_t bri);
-bool ul_white_power(int ch, bool on);
 
 // Status API
 typedef struct {
     bool enabled;
-    bool power;
     char effect[24];
     uint8_t brightness;   // 0..255
     int pwm_hz;

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -100,18 +100,15 @@ Example – flash between red and blue:
 ```json
 {
   "channel": <int>,
+  "brightness": <int 0-255>,
   "effect": "<name>",
-  "brightness": <int 0-255>
+  "params": [<int>, ...]
 }
 ```
 
-Registered effects: `breathe`. Optional params: `[period_ms]` to control the breath cycle length.
-
-`ul/<node-id>/cmd/white/power`
-
-```json
-{ "channel": <int>, "on": <bool> }
-```
+Registered effects: `solid` and `breathe`.
+* `solid` – static output with no parameters.
+* `breathe` – optional params: `[period_ms]` to control the breath cycle length.
 
 ### Sensor and OTA commands
 

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -69,12 +69,6 @@ async def cmd_white_set(node_id: str, payload: dict):
     return {"ok": True}
 
 
-@app.post("/api/nodes/{node_id}/white/power")
-async def cmd_white_power(node_id: str, payload: dict):
-    mqtt.publish(node_id, "white/power", payload)
-    return {"ok": True}
-
-
 @app.post("/api/nodes/{node_id}/sensor/cooldown")
 async def cmd_sensor_cooldown(node_id: str, payload: dict):
     mqtt.publish(node_id, "sensor/cooldown", payload)

--- a/webapp/static/node.js
+++ b/webapp/static/node.js
@@ -45,16 +45,6 @@ function initNodePage() {
         });
     });
 
-    document.querySelectorAll('.white .power').forEach(btn => {
-        btn.addEventListener('click', e => {
-            const container = e.target.closest('.white');
-            const channel = parseInt(container.dataset.channel);
-            const on = btn.dataset.on === 'true';
-            send('white/power', { channel: channel, on: on });
-            btn.dataset.on = (!on).toString();
-        });
-    });
-
     document.querySelectorAll('.sensor .set-cooldown').forEach(btn => {
         btn.addEventListener('click', e => {
             const container = e.target.closest('.sensor');

--- a/webapp/templates/node.html
+++ b/webapp/templates/node.html
@@ -47,7 +47,6 @@
         </select>
     </label>
     <button class="send">Send</button>
-    <button class="power" data-on="true">Power</button>
 </div>
 {% endfor %}
 


### PR DESCRIPTION
## Summary
- Drop explicit power control from white engine; channels always on and use brightness 0 for off
- Accept `{channel, brightness, effect, params}` payloads and add new `solid` effect
- Clean up server and UI to remove white power endpoints and docs
- Only initialize white channels that are enabled in Kconfig
- Include `<stddef.h>` in white effect registry so `NULL` is defined

## Testing
- `pytest`
- `cd UltraNodeV5 && idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: No matching distribution found for esp-idf)*

------
https://chatgpt.com/codex/tasks/task_e_68b61fcf20b883268270a31aeb47e0a6