### PR TITLE
feat: overhaul motion sensor logic

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
+++ b/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
@@ -83,12 +83,14 @@ static void publish_status_snapshot(void) {
     // Sensors
     ul_sensor_status_t ss; ul_sensors_get_status(&ss);
     cJSON* jsens = cJSON_CreateObject();
-    cJSON_AddNumberToObject(jsens, "cooldown_s", ss.cooldown_s);
+    cJSON_AddNumberToObject(jsens, "pir_motion_time_s", ss.pir_motion_time_s);
+    cJSON_AddNumberToObject(jsens, "sonic_motion_time_s", ss.sonic_motion_time_s);
+    cJSON_AddNumberToObject(jsens, "sonic_threshold_mm", ss.sonic_threshold_mm);
+    cJSON_AddNumberToObject(jsens, "motion_on_channel", ss.motion_on_channel);
     cJSON_AddBoolToObject(jsens, "pir_enabled", ss.pir_enabled);
     cJSON_AddBoolToObject(jsens, "ultra_enabled", ss.ultra_enabled);
     cJSON_AddBoolToObject(jsens, "pir_active", ss.pir_active);
     cJSON_AddBoolToObject(jsens, "ultra_active", ss.ultra_active);
-    cJSON_AddNumberToObject(jsens, "ultra_near_mm", ss.near_threshold_mm);
     cJSON_AddItemToObject(root, "sensors", jsens);
 
     // OTA (static fields from Kconfig)
@@ -192,6 +194,23 @@ static void handle_cmd_sensor_cooldown(cJSON* root) {
     } else { ESP_LOGW(TAG,"invalid seconds"); }
 }
 
+static void handle_cmd_sensor_motion(cJSON* root) {
+    int v;
+    if (j_is_int_in(root, "pir_motion_time", 1, 3600, &v)) {
+        ul_sensors_set_pir_motion_time(v);
+    }
+    if (j_is_int_in(root, "sonic_motion_time", 1, 3600, &v)) {
+        ul_sensors_set_sonic_motion_time(v);
+    }
+    if (j_is_int_in(root, "sonic_threshold_distance", 50, 4000, &v)) {
+        ul_sensors_set_sonic_threshold_mm(v);
+    }
+    if (j_is_int_in(root, "motion_on_channel", -1, 3, &v)) {
+        ul_sensors_set_motion_on_channel(v);
+    }
+    ul_mqtt_publish_status();
+}
+
 
 static void handle_cmd_white_set(cJSON* root) {
     ul_white_apply_json(root);
@@ -239,6 +258,8 @@ static void on_message(esp_mqtt_event_handle_t event)
             handle_cmd_ws_power(root);
         } else if (starts_with(sub, "sensor/cooldown")) {
             handle_cmd_sensor_cooldown(root);
+        } else if (starts_with(sub, "sensor/motion")) {
+            handle_cmd_sensor_motion(root);
         } else if (starts_with(sub, "ota/check")) { ul_mqtt_publish_status();
             ul_ota_check_now(true); publish_status_snapshot();
         } else if (starts_with(sub, "white/set")) { handle_cmd_white_set(root); ul_mqtt_publish_status(); } else if (starts_with(sub, "status")) { ul_mqtt_publish_status_now(); } else {

--- a/UltraNodeV5/components/ul_sensors/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_sensors/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "ul_sensors.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES driver esp_timer ul_mqtt ul_task)
+                       REQUIRES driver esp_timer ul_mqtt ul_task ul_white_engine)

--- a/UltraNodeV5/components/ul_sensors/include/ul_sensors.h
+++ b/UltraNodeV5/components/ul_sensors/include/ul_sensors.h
@@ -5,15 +5,21 @@ extern "C" {
 #endif
 
 void ul_sensors_start(void);
-void ul_sensors_set_cooldown(int seconds); // via MQTT 10..3600
+void ul_sensors_set_cooldown(int seconds); // legacy: sets both motion times
+void ul_sensors_set_pir_motion_time(int seconds);
+void ul_sensors_set_sonic_motion_time(int seconds);
+void ul_sensors_set_sonic_threshold_mm(int mm);
+void ul_sensors_set_motion_on_channel(int ch);
 
 typedef struct {
-    int cooldown_s;
+    int pir_motion_time_s;
+    int sonic_motion_time_s;
+    int sonic_threshold_mm;
+    int motion_on_channel;
     bool pir_enabled;
     bool ultra_enabled;
     bool pir_active;
     bool ultra_active;
-    int near_threshold_mm;
 } ul_sensor_status_t;
 
 void ul_sensors_get_status(ul_sensor_status_t* out);

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -94,6 +94,10 @@ menu "Sensors"
         int "Sensor cooldown (seconds)"
         range 10 3600
         default 30
+    config UL_SENSOR_POLL_MS
+        int "Sensor poll interval (ms)"
+        range 50 1000
+        default 100
 endmenu
 
 menu "WS2812 Strips"


### PR DESCRIPTION
## Summary
- add configurable motion detection timers and channel override
- expose motion settings over MQTT and update status snapshot
- allow adjusting sensor poll interval in menuconfig

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b63c22cb00832683c7dc4f59d80e84