### PR TITLE
feat: include params array and hex color support

### DIFF
--- a/Server/app/mqtt_bus.py
+++ b/Server/app/mqtt_bus.py
@@ -1,6 +1,6 @@
 import threading
 import json
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Union
 import paho.mqtt.client as paho
 from .config import settings
 from . import registry
@@ -26,16 +26,15 @@ class MqttBus:
         effect: str,
         brightness: int,
         speed: float,
-        params: Optional[List[float]] = None,
+        params: Optional[List[Union[float, str]]] = None,
     ):
         msg: Dict[str, object] = {
             "strip": int(strip),
             "effect": effect,
             "brightness": int(brightness),
             "speed": float(speed),
+            "params": params or [],
         }
-        if params:
-            msg["params"] = params
         self.pub(topic_cmd(node_id, "ws/set"), msg)
 
     def ws_power(self, node_id: str, strip: int, on: bool):
@@ -55,9 +54,8 @@ class MqttBus:
             "channel": int(channel),
             "effect": effect,
             "brightness": int(brightness),
+            "params": params or [],
         }
-        if params:
-            msg["params"] = params
         self.pub(topic_cmd(node_id, "white/set"), msg)
 
     # ---- Sensor commands ----

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -74,12 +74,17 @@ def api_ws_set(node_id: str, payload: Dict[str, Any]):
         raise HTTPException(400, "invalid speed")
     params = payload.get("params")
     if params is not None:
-        if not (
-            isinstance(params, list)
-            and all(isinstance(p, (int, float)) for p in params)
-        ):
+        if not isinstance(params, list):
             raise HTTPException(400, "invalid params")
-        params = [float(p) for p in params]
+        clean: list[object] = []
+        for p in params:
+            if isinstance(p, (int, float)):
+                clean.append(float(p))
+            elif isinstance(p, str):
+                clean.append(p)
+            else:
+                raise HTTPException(400, "invalid params")
+        params = clean
     get_bus().ws_set(node_id, strip, effect, brightness, speed, params)
     return {"ok": True}
 

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -38,6 +38,21 @@ const briEl=document.getElementById('wsBri');
 const speedEl=document.getElementById('wsSpeed');
 const paramsEl=document.getElementById('wsParams');
 
+// Throttled sender for real-time updates (max ~10 Hz)
+let lastSend=0;
+let pendingSend=null;
+function scheduleSend(){
+  const now=Date.now();
+  const delay=100-(now-lastSend);
+  if(delay<=0){
+    lastSend=now;
+    sendCmd();
+  }else{
+    clearTimeout(pendingSend);
+    pendingSend=setTimeout(()=>{lastSend=Date.now();sendCmd();},delay);
+  }
+}
+
 function renderParams(){
   paramsEl.innerHTML='';
   const defs=WS_PARAM_DEFS[effectEl.value]||[];
@@ -67,6 +82,11 @@ function renderParams(){
     wrap.appendChild(input);
     paramsEl.appendChild(wrap);
   });
+  // Attach real-time color updates for solid effect
+  if(effectEl.value==='solid'){
+    const colorInput=paramsEl.querySelector('input[type="color"]');
+    if(colorInput)colorInput.addEventListener('input',scheduleSend);
+  }
 }
 effectEl.onchange=renderParams;
 
@@ -77,8 +97,12 @@ function collectParams(){
     const input=paramsEl.querySelector(`[data-index="${idx}"]`);
     if(!input)return;
     if(d.type==='color'){
-      const rgb=hexToRgb(input.value);
-      out.push(...rgb);
+      if(effectEl.value==='solid'){
+        out.push(input.value);
+      }else{
+        const rgb=hexToRgb(input.value);
+        out.push(...rgb);
+      }
     }else if(d.type==='slider'){
       out.push(parseInt(input.value,10));
     }else{
@@ -88,19 +112,20 @@ function collectParams(){
   return out;
 }
 
-document.getElementById('wsSet').onclick=async()=>{
+function sendCmd(){
   const strip=parseInt(stripEl.value,10);
-  if(Number.isNaN(strip)){alert('Invalid strip');return;}
+  if(Number.isNaN(strip))return;
   const eff=effectEl.value.trim();
-  if(!eff){alert('Select an effect');return;}
+  if(!eff)return;
   const bri=parseInt(briEl.value,10);
-  if(Number.isNaN(bri)){alert('Invalid brightness');return;}
+  if(Number.isNaN(bri))return;
   const speed=parseInt(speedEl.value,10)/100;
   const params=collectParams();
-  const msg={strip,effect:eff,brightness:bri,speed};
-  if(params.length)msg.params=params;
-  await post(`/api/node/{{ node.id }}/ws/set`,msg);
-};
+  const msg={strip,effect:eff,brightness:bri,speed,params};
+  post(`/api/node/{{ node.id }}/ws/set`,msg);
+}
+
+document.getElementById('wsSet').onclick=sendCmd;
 
 document.getElementById('wsOn').onclick=async()=>{
   const s=parseInt(stripEl.value,10);if(Number.isNaN(s)){alert('Invalid strip');return;}await post(`/api/node/{{ node.id }}/ws/power`,{strip:s,on:true});

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/solid.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/solid.c
@@ -1,15 +1,31 @@
 #include "effect.h"
 #include "ul_ws_engine.h"
 #include "cJSON.h"
+#include <stdlib.h>
 
 void solid_init(void) { (void)0; }
 
 void solid_apply_params(int strip, const cJSON* params) {
-    if (!params || !cJSON_IsArray(params) || cJSON_GetArraySize(params) < 3) return;
-    int r = cJSON_GetArrayItem(params, 0)->valueint;
-    int g = cJSON_GetArrayItem(params, 1)->valueint;
-    int b = cJSON_GetArrayItem(params, 2)->valueint;
-    ul_ws_set_solid_rgb(strip, (uint8_t)r, (uint8_t)g, (uint8_t)b);
+    if (!params || !cJSON_IsArray(params) || cJSON_GetArraySize(params) == 0) return;
+    uint8_t r = 0, g = 0, b = 0;
+
+    const cJSON* first = cJSON_GetArrayItem(params, 0);
+    if (cJSON_IsString(first)) {
+        const char* s = first->valuestring;
+        if (s && s[0] == '#') ++s;
+        unsigned long v = strtoul(s, NULL, 16);
+        r = (v >> 16) & 0xFF;
+        g = (v >> 8) & 0xFF;
+        b = v & 0xFF;
+    } else if (cJSON_GetArraySize(params) >= 3) {
+        r = (uint8_t)cJSON_GetArrayItem(params, 0)->valueint;
+        g = (uint8_t)cJSON_GetArrayItem(params, 1)->valueint;
+        b = (uint8_t)cJSON_GetArrayItem(params, 2)->valueint;
+    } else {
+        return;
+    }
+
+    ul_ws_set_solid_rgb(strip, r, g, b);
 }
 
 void solid_render(uint8_t* frame_rgb, int pixels, int frame_idx) {


### PR DESCRIPTION
## Summary
- always include effect params in addressable strip ws/set payloads
- allow UltraNodeV5 solid effect to accept hex color codes
- publish params arrays for all ws and white commands
- send solid effect color as hex string in params and relax API validation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c275cbf5708326961258f665f61a53