### PR TITLE
Fix solid effect color params

### DIFF
--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -97,18 +97,14 @@ function collectParams(){
   defs.forEach((d,idx)=>{
     const input=inputs[idx];
     if(!input)return;
-    if(d.type==='color'){
-      if(effectEl.value==='solid'){
-        out.push(input.value);
-      }else{
+      if(d.type==='color'){
         const rgb=hexToRgb(input.value);
         out.push(...rgb);
+      }else if(d.type==='slider'){
+        out.push(parseInt(input.value,10));
+      }else{
+        out.push(parseFloat(input.value));
       }
-    }else if(d.type==='slider'){
-      out.push(parseInt(input.value,10));
-    }else{
-      out.push(parseFloat(input.value));
-    }
   });
   return out;
 }


### PR DESCRIPTION
## Summary
- convert solid effect color from hex string to RGB values when sending websocket strip commands

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2892f1d348326bd43a2eaa9a01175