### PR TITLE
Fix solid effect color params

### DIFF
--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -82,11 +82,6 @@ function renderParams(){
     wrap.appendChild(input);
     paramsEl.appendChild(wrap);
   });
-  // Attach real-time color updates for solid effect
-  if(effectEl.value==='solid'){
-    const colorInput=paramsEl.querySelector('input[type="color"]');
-    if(colorInput)colorInput.addEventListener('input',scheduleSend);
-  }
 }
 effectEl.onchange=renderParams;
 
@@ -97,18 +92,14 @@ function collectParams(){
   defs.forEach((d,idx)=>{
     const input=inputs[idx];
     if(!input)return;
-    if(d.type==='color'){
-      if(effectEl.value==='solid'){
-        out.push(input.value);
-      }else{
+      if(d.type==='color'){
         const rgb=hexToRgb(input.value);
         out.push(...rgb);
+      }else if(d.type==='slider'){
+        out.push(parseInt(input.value,10));
+      }else{
+        out.push(parseFloat(input.value));
       }
-    }else if(d.type==='slider'){
-      out.push(parseInt(input.value,10));
-    }else{
-      out.push(parseFloat(input.value));
-    }
   });
   return out;
 }
@@ -121,7 +112,11 @@ function sendCmd(){
   const bri=parseInt(briEl.value,10);
   if(Number.isNaN(bri))return;
   const speed=parseInt(speedEl.value,10)/100;
-  const params=collectParams();
+  let params=collectParams();
+  if(eff==='solid'&&params.length===0){
+    const colorInput=paramsEl.querySelector('input[type="color"]');
+    if(colorInput)params=hexToRgb(colorInput.value);
+  }
   const msg={strip,effect:eff,brightness:bri,speed,params};
   post(`/api/node/{{ node.id }}/ws/set`,msg);
 }


### PR DESCRIPTION
## Summary
- ensure solid effect color picker always sends RGB parameters in ws/set commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2892f1d348326bd43a2eaa9a01175