### PR TITLE
Allow white engine to apply params without effect field

### DIFF
--- a/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
+++ b/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
@@ -170,7 +170,7 @@ void ul_white_apply_json(cJSON* root) {
     }
 
     cJSON* jparams = cJSON_GetObjectItem(root, "params");
-    if (effect && jparams && cJSON_IsArray(jparams)) {
+    if (jparams && cJSON_IsArray(jparams)) {
         white_ch_t* c = get_ch(ch);
         if (c && c->eff && c->eff->apply_params) {
             c->eff->apply_params(ch, jparams);


### PR DESCRIPTION
## Summary
- handle `params` array even when `effect` is not specified for the white engine

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: No matching distribution found for esp-idf)*

------
https://chatgpt.com/codex/tasks/task_e_68c298620eac83268e17666b8f901052