### PR TITLE
feat: add Wi-Fi event handling

### DIFF
--- a/UltraNodeV5/components/ul_core/include/ul_core.h
+++ b/UltraNodeV5/components/ul_core/include/ul_core.h
@@ -1,11 +1,14 @@
 #pragma once
 #include "esp_err.h"
+#include <stdbool.h>
+#include "freertos/FreeRTOS.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void ul_core_wifi_start_blocking(void);
+void ul_core_wifi_start(void);
+bool ul_core_wait_for_ip(TickType_t timeout);
 void ul_core_sntp_start(void);
 const char* ul_core_get_node_id(void);
 

--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -23,7 +23,8 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
 
-    ul_core_wifi_start_blocking();
+    ul_core_wifi_start();
+    ul_core_wait_for_ip(pdMS_TO_TICKS(10000));
     ul_core_sntp_start();
 
     ul_mqtt_start();


### PR DESCRIPTION
## Summary
- add Wi-Fi event handlers and event group to manage connection attempts
- expose non-blocking Wi-Fi start API and wait_for_ip helper
- update application to use new Wi-Fi initialization flow

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f9eb53fc8326ad518ad75333d395