### PR TITLE
Add connectivity callback and manage services on network changes

### DIFF
--- a/UltraNodeV5/components/ul_core/include/ul_core.h
+++ b/UltraNodeV5/components/ul_core/include/ul_core.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "esp_err.h"
-#include <stdbool.h>
 #include "freertos/FreeRTOS.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,7 +11,10 @@ void ul_core_wifi_start(void);
 bool ul_core_wait_for_ip(TickType_t timeout);
 bool ul_core_is_connected(void);
 void ul_core_sntp_start(void);
-const char* ul_core_get_node_id(void);
+const char *ul_core_get_node_id(void);
+
+typedef void (*ul_core_conn_cb_t)(bool connected, void *ctx);
+void ul_core_register_connectivity_cb(ul_core_conn_cb_t cb, void *ctx);
 
 #ifdef __cplusplus
 }

--- a/UltraNodeV5/components/ul_core/ul_core.c
+++ b/UltraNodeV5/components/ul_core/ul_core.c
@@ -1,15 +1,15 @@
 #include "ul_core.h"
-#include "sdkconfig.h"
-#include "esp_wifi.h"
-#include "esp_log.h"
 #include "esp_event.h"
+#include "esp_log.h"
 #include "esp_netif.h"
-//#include "esp_sntp.h"
-#include <string.h>
-#include <time.h>
+#include "esp_wifi.h"
+#include "sdkconfig.h"
+// #include "esp_sntp.h"
 #include "esp_netif_sntp.h"
 #include "freertos/event_groups.h"
 #include "freertos/task.h"
+#include <string.h>
+#include <time.h>
 
 static const char *TAG = "ul_core";
 
@@ -21,107 +21,124 @@ static EventGroupHandle_t s_wifi_event_group;
 #define WIFI_MAX_RETRY 5
 #define WIFI_MAX_BACKOFF_MS 30000
 
-const char* ul_core_get_node_id(void) { return s_node_id; }
+const char *ul_core_get_node_id(void) { return s_node_id; }
 
-static void wifi_event_handler(void* arg, esp_event_base_t event_base,
-                               int32_t event_id, void* event_data)
-{
-    static int retry_num = 0;
-    static int backoff_ms = 1000;
+static ul_core_conn_cb_t s_conn_cb = NULL;
+static void *s_conn_ctx = NULL;
 
-    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
-        retry_num = 0;
-        backoff_ms = 1000;
-        esp_wifi_connect();
-    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
-        if (retry_num < WIFI_MAX_RETRY) {
-            vTaskDelay(pdMS_TO_TICKS(backoff_ms));
-            esp_wifi_connect();
-            retry_num++;
-            backoff_ms = backoff_ms * 2;
-            if (backoff_ms > WIFI_MAX_BACKOFF_MS) backoff_ms = WIFI_MAX_BACKOFF_MS;
-        } else {
-            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
-        }
-    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
-        ip_event_got_ip_t *event = (ip_event_got_ip_t*) event_data;
-        ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
-        retry_num = 0;
-        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+void ul_core_register_connectivity_cb(ul_core_conn_cb_t cb, void *ctx) {
+  s_conn_cb = cb;
+  s_conn_ctx = ctx;
+}
+
+static void wifi_event_handler(void *arg, esp_event_base_t event_base,
+                               int32_t event_id, void *event_data) {
+  static int retry_num = 0;
+  static int backoff_ms = 1000;
+
+  if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+    retry_num = 0;
+    backoff_ms = 1000;
+    esp_wifi_connect();
+  } else if (event_base == WIFI_EVENT &&
+             event_id == WIFI_EVENT_STA_DISCONNECTED) {
+    xEventGroupClearBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+    if (s_conn_cb)
+      s_conn_cb(false, s_conn_ctx);
+    if (retry_num < WIFI_MAX_RETRY) {
+      vTaskDelay(pdMS_TO_TICKS(backoff_ms));
+      esp_wifi_connect();
+      retry_num++;
+      backoff_ms = backoff_ms * 2;
+      if (backoff_ms > WIFI_MAX_BACKOFF_MS)
+        backoff_ms = WIFI_MAX_BACKOFF_MS;
+    } else {
+      xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
     }
+  } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+    ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
+    ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
+    retry_num = 0;
+    xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+    if (s_conn_cb)
+      s_conn_cb(true, s_conn_ctx);
+  }
 }
 
-void ul_core_wifi_start(void)
-{
-    s_wifi_event_group = xEventGroupCreate();
+void ul_core_wifi_start(void) {
+  s_wifi_event_group = xEventGroupCreate();
 
-    esp_netif_create_default_wifi_sta();
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+  esp_netif_create_default_wifi_sta();
+  wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+  ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
-    wifi_config_t sta_cfg = {0};
-    strncpy((char*)sta_cfg.sta.ssid, CONFIG_UL_WIFI_SSID, sizeof(sta_cfg.sta.ssid)-1);
-    strncpy((char*)sta_cfg.sta.password, CONFIG_UL_WIFI_PSK, sizeof(sta_cfg.sta.password)-1);
-    sta_cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+  wifi_config_t sta_cfg = {0};
+  strncpy((char *)sta_cfg.sta.ssid, CONFIG_UL_WIFI_SSID,
+          sizeof(sta_cfg.sta.ssid) - 1);
+  strncpy((char *)sta_cfg.sta.password, CONFIG_UL_WIFI_PSK,
+          sizeof(sta_cfg.sta.password) - 1);
+  sta_cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
 
-    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_START, &wifi_event_handler, NULL));
-    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, &wifi_event_handler, NULL));
-    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_START,
+                                             &wifi_event_handler, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(
+      WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, &wifi_event_handler, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                             &wifi_event_handler, NULL));
 
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &sta_cfg));
-    ESP_ERROR_CHECK(esp_wifi_start());
+  ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+  ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &sta_cfg));
+  ESP_ERROR_CHECK(esp_wifi_start());
 }
 
-bool ul_core_wait_for_ip(TickType_t timeout)
-{
-    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
-                                           WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
-                                           pdFALSE, pdFALSE, timeout);
-    return (bits & WIFI_CONNECTED_BIT) != 0;
+bool ul_core_wait_for_ip(TickType_t timeout) {
+  EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
+                                         WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+                                         pdFALSE, pdFALSE, timeout);
+  return (bits & WIFI_CONNECTED_BIT) != 0;
 }
 
-bool ul_core_is_connected(void)
-{
-    if (!s_wifi_event_group) return false;
-    EventBits_t bits = xEventGroupGetBits(s_wifi_event_group);
-    return (bits & WIFI_CONNECTED_BIT) != 0;
+bool ul_core_is_connected(void) {
+  if (!s_wifi_event_group)
+    return false;
+  EventBits_t bits = xEventGroupGetBits(s_wifi_event_group);
+  return (bits & WIFI_CONNECTED_BIT) != 0;
 }
 
-static void sntp_sync_task(void *arg)
-{
-    const TickType_t interval = pdMS_TO_TICKS(CONFIG_UL_SNTP_SYNC_INTERVAL_S * 1000);
-    while (1) {
-        vTaskDelay(interval);
-        while (!ul_core_is_connected()) {
-            vTaskDelay(pdMS_TO_TICKS(1000));
-        }
-        esp_err_t err = esp_netif_sntp_sync();
-        if (err != ESP_OK) {
-            ESP_LOGW(TAG, "SNTP resync failed: %s", esp_err_to_name(err));
-        }
+static void sntp_sync_task(void *arg) {
+  const TickType_t interval =
+      pdMS_TO_TICKS(CONFIG_UL_SNTP_SYNC_INTERVAL_S * 1000);
+  while (1) {
+    vTaskDelay(interval);
+    while (!ul_core_is_connected()) {
+      vTaskDelay(pdMS_TO_TICKS(1000));
     }
+    esp_err_t err = esp_netif_sntp_sync();
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "SNTP resync failed: %s", esp_err_to_name(err));
+    }
+  }
 }
 
-void ul_core_sntp_start(void)
-{
-    setenv("TZ", "PST8PDT,M3.2.0/2,M11.1.0/2", 1); // America/Los_Angeles
-    tzset();
+void ul_core_sntp_start(void) {
+  setenv("TZ", "PST8PDT,M3.2.0/2,M11.1.0/2", 1); // America/Los_Angeles
+  tzset();
 
-    esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
-    esp_netif_sntp_init(&config);
+  esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
+  esp_netif_sntp_init(&config);
 
-    // Wait until time is set (epoch > 1700000000 ~ 2023)
-    time_t now = 0;
-    struct tm timeinfo = {0};
-    int retries = 0;
-    const int max_retries = 20;
-    while (retries++ < max_retries) {
-        time(&now);
-        localtime_r(&now, &timeinfo);
-        if (now > 1700000000) break;
-        vTaskDelay(pdMS_TO_TICKS(1000));
-    }
-    ESP_LOGI(TAG, "Time sync: %ld", now);
-    xTaskCreate(sntp_sync_task, "sntp_sync", 2048, NULL, tskIDLE_PRIORITY, NULL);
+  // Wait until time is set (epoch > 1700000000 ~ 2023)
+  time_t now = 0;
+  struct tm timeinfo = {0};
+  int retries = 0;
+  const int max_retries = 20;
+  while (retries++ < max_retries) {
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    if (now > 1700000000)
+      break;
+    vTaskDelay(pdMS_TO_TICKS(1000));
+  }
+  ESP_LOGI(TAG, "Time sync: %ld", now);
+  xTaskCreate(sntp_sync_task, "sntp_sync", 2048, NULL, tskIDLE_PRIORITY, NULL);
 }

--- a/UltraNodeV5/components/ul_mqtt/include/ul_mqtt.h
+++ b/UltraNodeV5/components/ul_mqtt/include/ul_mqtt.h
@@ -8,14 +8,15 @@ extern "C" {
 #endif
 
 void ul_mqtt_start(void);
+void ul_mqtt_stop(void);
 void ul_mqtt_publish_status(void);
 void ul_mqtt_publish_status_now(void);
-void ul_mqtt_publish_motion(const char* sid, const char* state);
+void ul_mqtt_publish_motion(const char *sid, const char *state);
 bool ul_mqtt_is_ready(void);
 
 // Execute a command locally without publishing over MQTT. The path should match
 // the suffix of a normal command topic (e.g. "ws/set").
-void ul_mqtt_run_local(const char* path, const char* json);
+void ul_mqtt_run_local(const char *path, const char *json);
 
 #ifdef __cplusplus
 }

--- a/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
+++ b/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
@@ -1,356 +1,396 @@
 #include "ul_mqtt.h"
-#include "sdkconfig.h"
+#include "cJSON.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "mqtt_client.h"
+#include "sdkconfig.h"
 #include "ul_core.h"
-#include "ul_ws_engine.h"
-#include "ul_white_engine.h"
-#include "ul_sensors.h"
 #include "ul_ota.h"
+#include "ul_sensors.h"
+#include "ul_white_engine.h"
+#include "ul_ws_engine.h"
+#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
-#include <ctype.h>
-#include "cJSON.h"
-#include "esp_timer.h"
 
-static const char* TAG = "ul_mqtt";
+static const char *TAG = "ul_mqtt";
 static esp_mqtt_client_handle_t s_client = NULL;
 static bool s_ready = false;
 
 // JSON helpers (defined later)
-static bool j_is_int_in(cJSON* obj, const char* key, int minv, int maxv, int* out);
+static bool j_is_int_in(cJSON *obj, const char *key, int minv, int maxv,
+                        int *out);
 
-static int starts_with(const char* s, const char* pfx) {
-    return strncmp(s, pfx, strlen(pfx)) == 0;
+static int starts_with(const char *s, const char *pfx) {
+  return strncmp(s, pfx, strlen(pfx)) == 0;
 }
 
 // Helper to publish JSON
-static void publish_json(const char* topic, const char* json) {
+static void publish_json(const char *topic, const char *json) {
 
-    if (!s_client || !ul_core_is_connected()) return;
-    esp_mqtt_client_publish(s_client, topic, json, 0, 1, 0);
+  if (!s_client || !ul_core_is_connected())
+    return;
+  esp_mqtt_client_publish(s_client, topic, json, 0, 1, 0);
 }
-
 
 // Build and publish status JSON snapshot
 static void publish_status_snapshot(void) {
-    char topic[128];
-    snprintf(topic, sizeof(topic), "ul/%s/evt/status", ul_core_get_node_id());
-    cJSON* root = cJSON_CreateObject();
-    cJSON_AddStringToObject(root, "node", ul_core_get_node_id());
+  char topic[128];
+  snprintf(topic, sizeof(topic), "ul/%s/evt/status", ul_core_get_node_id());
+  cJSON *root = cJSON_CreateObject();
+  cJSON_AddStringToObject(root, "node", ul_core_get_node_id());
 
-    // uptime
-    cJSON_AddNumberToObject(root, "uptime_s", esp_timer_get_time()/1000000);
+  // uptime
+  cJSON_AddNumberToObject(root, "uptime_s", esp_timer_get_time() / 1000000);
 
-    // WS strips
-    cJSON* jws = cJSON_CreateArray();
-    for (int i=0;i<2;i++) {
-        ul_ws_strip_status_t st;
-        if (ul_ws_get_status(i, &st)) {
-            cJSON* o = cJSON_CreateObject();
-            cJSON_AddNumberToObject(o, "strip", i);
-            cJSON_AddBoolToObject(o, "enabled", st.enabled);
-            cJSON_AddBoolToObject(o, "power", st.power);
-            cJSON_AddStringToObject(o, "effect", st.effect);
-            cJSON_AddNumberToObject(o, "brightness", st.brightness);
-            cJSON_AddNumberToObject(o, "pixels", st.pixels);
-            cJSON_AddNumberToObject(o, "gpio", st.gpio);
-            cJSON_AddNumberToObject(o, "fps", st.fps);
-            cJSON* col = cJSON_CreateIntArray((int[]){st.color[0],st.color[1],st.color[2]},3);
-            cJSON_AddItemToObject(o, "color", col);
-            cJSON_AddItemToArray(jws, o);
-        }
+  // WS strips
+  cJSON *jws = cJSON_CreateArray();
+  for (int i = 0; i < 2; i++) {
+    ul_ws_strip_status_t st;
+    if (ul_ws_get_status(i, &st)) {
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddNumberToObject(o, "strip", i);
+      cJSON_AddBoolToObject(o, "enabled", st.enabled);
+      cJSON_AddBoolToObject(o, "power", st.power);
+      cJSON_AddStringToObject(o, "effect", st.effect);
+      cJSON_AddNumberToObject(o, "brightness", st.brightness);
+      cJSON_AddNumberToObject(o, "pixels", st.pixels);
+      cJSON_AddNumberToObject(o, "gpio", st.gpio);
+      cJSON_AddNumberToObject(o, "fps", st.fps);
+      cJSON *col = cJSON_CreateIntArray(
+          (int[]){st.color[0], st.color[1], st.color[2]}, 3);
+      cJSON_AddItemToObject(o, "color", col);
+      cJSON_AddItemToArray(jws, o);
     }
-    cJSON_AddItemToObject(root, "ws", jws);
+  }
+  cJSON_AddItemToObject(root, "ws", jws);
 
-    // White channels
-    cJSON* jw = cJSON_CreateArray();
-    for (int i=0;i<4;i++) {
-        ul_white_ch_status_t st;
-        if (ul_white_get_status(i, &st)) {
-            cJSON* o = cJSON_CreateObject();
-            cJSON_AddNumberToObject(o, "channel", i);
-            cJSON_AddBoolToObject(o, "enabled", st.enabled);
-            cJSON_AddStringToObject(o, "effect", st.effect);
-            cJSON_AddNumberToObject(o, "brightness", st.brightness);
-            cJSON_AddNumberToObject(o, "gpio", st.gpio);
-            cJSON_AddNumberToObject(o, "pwm_hz", st.pwm_hz);
-            cJSON_AddItemToArray(jw, o);
-        }
+  // White channels
+  cJSON *jw = cJSON_CreateArray();
+  for (int i = 0; i < 4; i++) {
+    ul_white_ch_status_t st;
+    if (ul_white_get_status(i, &st)) {
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddNumberToObject(o, "channel", i);
+      cJSON_AddBoolToObject(o, "enabled", st.enabled);
+      cJSON_AddStringToObject(o, "effect", st.effect);
+      cJSON_AddNumberToObject(o, "brightness", st.brightness);
+      cJSON_AddNumberToObject(o, "gpio", st.gpio);
+      cJSON_AddNumberToObject(o, "pwm_hz", st.pwm_hz);
+      cJSON_AddItemToArray(jw, o);
     }
-    cJSON_AddItemToObject(root, "white", jw);
+  }
+  cJSON_AddItemToObject(root, "white", jw);
 
-    // Sensors
-    ul_sensor_status_t ss; ul_sensors_get_status(&ss);
-    cJSON* jsens = cJSON_CreateObject();
-    cJSON_AddNumberToObject(jsens, "pir_motion_time_s", ss.pir_motion_time_s);
-    cJSON_AddNumberToObject(jsens, "sonic_motion_time_s", ss.sonic_motion_time_s);
-    cJSON_AddNumberToObject(jsens, "sonic_threshold_mm", ss.sonic_threshold_mm);
-    cJSON_AddNumberToObject(jsens, "motion_on_channel", ss.motion_on_channel);
-    cJSON_AddBoolToObject(jsens, "pir_enabled", ss.pir_enabled);
-    cJSON_AddBoolToObject(jsens, "ultra_enabled", ss.ultra_enabled);
-    cJSON_AddBoolToObject(jsens, "pir_active", ss.pir_active);
-    cJSON_AddBoolToObject(jsens, "ultra_active", ss.ultra_active);
-    cJSON_AddNumberToObject(jsens, "motion_state", ss.motion_state);
-    cJSON_AddItemToObject(root, "sensors", jsens);
+  // Sensors
+  ul_sensor_status_t ss;
+  ul_sensors_get_status(&ss);
+  cJSON *jsens = cJSON_CreateObject();
+  cJSON_AddNumberToObject(jsens, "pir_motion_time_s", ss.pir_motion_time_s);
+  cJSON_AddNumberToObject(jsens, "sonic_motion_time_s", ss.sonic_motion_time_s);
+  cJSON_AddNumberToObject(jsens, "sonic_threshold_mm", ss.sonic_threshold_mm);
+  cJSON_AddNumberToObject(jsens, "motion_on_channel", ss.motion_on_channel);
+  cJSON_AddBoolToObject(jsens, "pir_enabled", ss.pir_enabled);
+  cJSON_AddBoolToObject(jsens, "ultra_enabled", ss.ultra_enabled);
+  cJSON_AddBoolToObject(jsens, "pir_active", ss.pir_active);
+  cJSON_AddBoolToObject(jsens, "ultra_active", ss.ultra_active);
+  cJSON_AddNumberToObject(jsens, "motion_state", ss.motion_state);
+  cJSON_AddItemToObject(root, "sensors", jsens);
 
-    // OTA (static fields from Kconfig)
-    cJSON* jota = cJSON_CreateObject();
-    cJSON_AddStringToObject(jota, "manifest_url", CONFIG_UL_OTA_MANIFEST_URL);
-    cJSON_AddItemToObject(root, "ota", jota);
+  // OTA (static fields from Kconfig)
+  cJSON *jota = cJSON_CreateObject();
+  cJSON_AddStringToObject(jota, "manifest_url", CONFIG_UL_OTA_MANIFEST_URL);
+  cJSON_AddItemToObject(root, "ota", jota);
 
-    char* json = cJSON_PrintUnformatted(root);
-    publish_json(topic, json);
-    cJSON_free(json);
-    cJSON_Delete(root);
+  char *json = cJSON_PrintUnformatted(root);
+  publish_json(topic, json);
+  cJSON_free(json);
+  cJSON_Delete(root);
 }
 
-void ul_mqtt_publish_status(void)
-{
-    char topic[128];
-    snprintf(topic, sizeof(topic), "ul/%s/evt/status", ul_core_get_node_id());
-    publish_json(topic, "{\"status\":\"ok\"}");
+void ul_mqtt_publish_status(void) {
+  char topic[128];
+  snprintf(topic, sizeof(topic), "ul/%s/evt/status", ul_core_get_node_id());
+  publish_json(topic, "{\"status\":\"ok\"}");
 }
 
 // Publish confirmation for ws/set including echo of effect parameters
-static void publish_ws_ack(int strip, const char* effect, cJSON* params, bool ok) {
-    char topic[128];
-    snprintf(topic, sizeof(topic), "ul/%s/evt/status", ul_core_get_node_id());
-    cJSON* root = cJSON_CreateObject();
-    if (ok) {
-        cJSON_AddStringToObject(root, "status", "ok");
-        cJSON_AddNumberToObject(root, "strip", strip);
-        if (effect) cJSON_AddStringToObject(root, "effect", effect);
-        if (params && cJSON_IsArray(params)) {
-            cJSON_AddItemToObject(root, "params", cJSON_Duplicate(params, true));
-        } else {
-            cJSON_AddItemToObject(root, "params", cJSON_CreateArray());
-        }
+static void publish_ws_ack(int strip, const char *effect, cJSON *params,
+                           bool ok) {
+  char topic[128];
+  snprintf(topic, sizeof(topic), "ul/%s/evt/status", ul_core_get_node_id());
+  cJSON *root = cJSON_CreateObject();
+  if (ok) {
+    cJSON_AddStringToObject(root, "status", "ok");
+    cJSON_AddNumberToObject(root, "strip", strip);
+    if (effect)
+      cJSON_AddStringToObject(root, "effect", effect);
+    if (params && cJSON_IsArray(params)) {
+      cJSON_AddItemToObject(root, "params", cJSON_Duplicate(params, true));
     } else {
-        cJSON_AddStringToObject(root, "status", "error");
-        cJSON_AddStringToObject(root, "error", "invalid effect");
+      cJSON_AddItemToObject(root, "params", cJSON_CreateArray());
     }
-    char* json = cJSON_PrintUnformatted(root);
-    publish_json(topic, json);
-    cJSON_free(json);
-    cJSON_Delete(root);
+  } else {
+    cJSON_AddStringToObject(root, "status", "error");
+    cJSON_AddStringToObject(root, "error", "invalid effect");
+  }
+  char *json = cJSON_PrintUnformatted(root);
+  publish_json(topic, json);
+  cJSON_free(json);
+  cJSON_Delete(root);
 }
 
-void ul_mqtt_publish_motion(const char* sid, const char* state)
-{
-    char topic[128];
-    char payload[160];
-    snprintf(topic, sizeof(topic), "ul/%s/evt/sensor/motion", ul_core_get_node_id());
-    snprintf(payload, sizeof(payload), "{\"sid\":\"%s\",\"state\":\"%s\"}", sid, state);
-    publish_json(topic, payload);
+void ul_mqtt_publish_motion(const char *sid, const char *state) {
+  char topic[128];
+  char payload[160];
+  snprintf(topic, sizeof(topic), "ul/%s/evt/sensor/motion",
+           ul_core_get_node_id());
+  snprintf(payload, sizeof(payload), "{\"sid\":\"%s\",\"state\":\"%s\"}", sid,
+           state);
+  publish_json(topic, payload);
 }
 
-static void handle_cmd_ws_set(cJSON* root) {
-    int strip = 0;
-    cJSON* jstrip = cJSON_GetObjectItem(root, "strip");
-    if (jstrip && cJSON_IsNumber(jstrip)) strip = jstrip->valueint;
+static void handle_cmd_ws_set(cJSON *root) {
+  int strip = 0;
+  cJSON *jstrip = cJSON_GetObjectItem(root, "strip");
+  if (jstrip && cJSON_IsNumber(jstrip))
+    strip = jstrip->valueint;
 
-    const char* effect = NULL;
-    cJSON* jeffect = cJSON_GetObjectItem(root, "effect");
-    if (jeffect && cJSON_IsString(jeffect)) effect = jeffect->valuestring;
+  const char *effect = NULL;
+  cJSON *jeffect = cJSON_GetObjectItem(root, "effect");
+  if (jeffect && cJSON_IsString(jeffect))
+    effect = jeffect->valuestring;
 
-    cJSON* params = cJSON_GetObjectItem(root, "params");
+  cJSON *params = cJSON_GetObjectItem(root, "params");
 
-    ul_ws_apply_json(root);
+  ul_ws_apply_json(root);
 
-    bool ok = false;
-    if (effect) {
-        ul_ws_strip_status_t st;
-        if (ul_ws_get_status(strip, &st)) {
-            ok = strcmp(st.effect, effect) == 0;
-        }
+  bool ok = false;
+  if (effect) {
+    ul_ws_strip_status_t st;
+    if (ul_ws_get_status(strip, &st)) {
+      ok = strcmp(st.effect, effect) == 0;
     }
+  }
 
-    publish_ws_ack(strip, effect, params, ok);
+  publish_ws_ack(strip, effect, params, ok);
 }
 
-static void handle_cmd_ws_power(cJSON* root) {
-    int strip = cJSON_GetObjectItem(root, "strip") ? cJSON_GetObjectItem(root, "strip")->valueint : 0;
-    cJSON* jon = cJSON_GetObjectItem(root, "on");
-    bool on = (jon && cJSON_IsBool(jon)) ? cJSON_IsTrue(jon) : true;
-    ul_ws_power(strip, on);
-    ul_mqtt_publish_status();
+static void handle_cmd_ws_power(cJSON *root) {
+  int strip = cJSON_GetObjectItem(root, "strip")
+                  ? cJSON_GetObjectItem(root, "strip")->valueint
+                  : 0;
+  cJSON *jon = cJSON_GetObjectItem(root, "on");
+  bool on = (jon && cJSON_IsBool(jon)) ? cJSON_IsTrue(jon) : true;
+  ul_ws_power(strip, on);
+  ul_mqtt_publish_status();
 }
-
 
 // ---- Minimal JSON schema helpers ----
-static bool j_is_int_in(cJSON* obj, const char* key, int minv, int maxv, int* out) {
-    cJSON* j = cJSON_GetObjectItem(obj, key);
-    if (!j || !cJSON_IsNumber(j)) return false;
-    int v = j->valueint;
-    if (v < minv || v > maxv) return false;
-    if (out) *out = v;
-    return true;
+static bool j_is_int_in(cJSON *obj, const char *key, int minv, int maxv,
+                        int *out) {
+  cJSON *j = cJSON_GetObjectItem(obj, key);
+  if (!j || !cJSON_IsNumber(j))
+    return false;
+  int v = j->valueint;
+  if (v < minv || v > maxv)
+    return false;
+  if (out)
+    *out = v;
+  return true;
 }
-static void handle_cmd_sensor_cooldown(cJSON* root) {
+static void handle_cmd_sensor_cooldown(cJSON *root) {
 
-    cJSON* js = cJSON_GetObjectItem(root, "seconds");
-    int s; if (j_is_int_in(root, "seconds", 10, 3600, &s)) { ul_sensors_set_cooldown(s);
-        ul_mqtt_publish_status();
-    } else { ESP_LOGW(TAG,"invalid seconds"); }
-}
-
-static void handle_cmd_sensor_motion(cJSON* root) {
-    int v;
-    if (j_is_int_in(root, "pir_motion_time", 1, 3600, &v)) {
-        ul_sensors_set_pir_motion_time(v);
-    }
-    if (j_is_int_in(root, "sonic_motion_time", 1, 3600, &v)) {
-        ul_sensors_set_sonic_motion_time(v);
-    }
-    if (j_is_int_in(root, "sonic_threshold_distance", 50, 4000, &v)) {
-        ul_sensors_set_sonic_threshold_mm(v);
-    }
-    if (j_is_int_in(root, "motion_on_channel", -1, 3, &v)) {
-        ul_sensors_set_motion_on_channel(v);
-    }
-    for (int i = 0; i < 3; ++i) {
-        char key[8];
-        snprintf(key, sizeof(key), "state%d", i);
-        cJSON* st = cJSON_GetObjectItem(root, key);
-        if (st && cJSON_IsObject(st)) {
-            char* ws = NULL; char* white = NULL;
-            cJSON* jws = cJSON_GetObjectItem(st, "ws");
-            if (jws) ws = cJSON_PrintUnformatted(jws);
-            cJSON* jw = cJSON_GetObjectItem(st, "white");
-            if (jw) white = cJSON_PrintUnformatted(jw);
-            ul_sensors_set_motion_command((ul_motion_state_t)i, ws, white);
-            if (ws) cJSON_free(ws);
-            if (white) cJSON_free(white);
-        }
-    }
+  cJSON *js = cJSON_GetObjectItem(root, "seconds");
+  int s;
+  if (j_is_int_in(root, "seconds", 10, 3600, &s)) {
+    ul_sensors_set_cooldown(s);
     ul_mqtt_publish_status();
+  } else {
+    ESP_LOGW(TAG, "invalid seconds");
+  }
 }
 
-
-static void handle_cmd_white_set(cJSON* root) {
-    ul_white_apply_json(root);
-}
-static void on_message(esp_mqtt_event_handle_t event)
-{
-    // topic expected: ul/<node>/cmd/...
-    char node[64] = {0};
-    const char* topic = event->topic;
-    int tlen = event->topic_len;
-    if (!topic || tlen <= 0) return;
-
-    // Extract node id segment
-    // pattern: "ul/xxxx/cmd/..."
-    const char* p = memchr(topic, '/', tlen);
-    if (!p) return;
-    p++; // after "ul/"
-    const char* slash2 = memchr(p, '/', (topic+tlen) - p);
-    if (!slash2) return;
-    int node_len = (int)(slash2 - p);
-    if (node_len <= 0 || node_len >= (int)sizeof(node)) return;
-    memcpy(node, p, node_len); node[node_len] = 0;
-
-    if (strcmp(node, ul_core_get_node_id()) != 0 && strcmp(node, "+") != 0) {
-        // not for us
-        return;
+static void handle_cmd_sensor_motion(cJSON *root) {
+  int v;
+  if (j_is_int_in(root, "pir_motion_time", 1, 3600, &v)) {
+    ul_sensors_set_pir_motion_time(v);
+  }
+  if (j_is_int_in(root, "sonic_motion_time", 1, 3600, &v)) {
+    ul_sensors_set_sonic_motion_time(v);
+  }
+  if (j_is_int_in(root, "sonic_threshold_distance", 50, 4000, &v)) {
+    ul_sensors_set_sonic_threshold_mm(v);
+  }
+  if (j_is_int_in(root, "motion_on_channel", -1, 3, &v)) {
+    ul_sensors_set_motion_on_channel(v);
+  }
+  for (int i = 0; i < 3; ++i) {
+    char key[8];
+    snprintf(key, sizeof(key), "state%d", i);
+    cJSON *st = cJSON_GetObjectItem(root, key);
+    if (st && cJSON_IsObject(st)) {
+      char *ws = NULL;
+      char *white = NULL;
+      cJSON *jws = cJSON_GetObjectItem(st, "ws");
+      if (jws)
+        ws = cJSON_PrintUnformatted(jws);
+      cJSON *jw = cJSON_GetObjectItem(st, "white");
+      if (jw)
+        white = cJSON_PrintUnformatted(jw);
+      ul_sensors_set_motion_command((ul_motion_state_t)i, ws, white);
+      if (ws)
+        cJSON_free(ws);
+      if (white)
+        cJSON_free(white);
     }
-
-    // Grab command path after "ul/<node>/"
-    const char* cmdroot = slash2 + 1;
-    int cmdlen = (topic + tlen) - cmdroot;
-
-    // Parse JSON
-    cJSON* root = cJSON_ParseWithLength(event->data, event->data_len);
-    if (!root) {
-        ESP_LOGW(TAG, "Invalid JSON payload");
-        return;
-    }
-
-    if (cmdlen >= 3 && strncmp(cmdroot, "cmd", 3)==0) {
-        const char* sub = cmdroot + 4; // skip "cmd/"
-        if (starts_with(sub, "ws/set")) {
-            handle_cmd_ws_set(root);
-        } else if (starts_with(sub, "ws/power")) {
-            handle_cmd_ws_power(root);
-        } else if (starts_with(sub, "sensor/cooldown")) {
-            handle_cmd_sensor_cooldown(root);
-        } else if (starts_with(sub, "sensor/motion")) {
-            handle_cmd_sensor_motion(root);
-        } else if (starts_with(sub, "ota/check")) { ul_mqtt_publish_status();
-            ul_ota_check_now(true); publish_status_snapshot();
-        } else if (starts_with(sub, "white/set")) { handle_cmd_white_set(root); ul_mqtt_publish_status(); } else if (starts_with(sub, "status")) { ul_mqtt_publish_status_now(); } else {
-            ESP_LOGW(TAG, "Unknown cmd path: %.*s", cmdlen, cmdroot);
-        }
-    }
-    cJSON_Delete(root);
+  }
+  ul_mqtt_publish_status();
 }
 
-static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data)
-{
-    esp_mqtt_event_handle_t event = event_data;
-    switch (event->event_id) {
-        case MQTT_EVENT_CONNECTED: {
-            ESP_LOGI(TAG, "MQTT connected");
-            s_ready = true;
-            if (ul_core_is_connected()) {
-                char topic[128];
-                snprintf(topic, sizeof(topic), "ul/%s/cmd/#", ul_core_get_node_id());
-                esp_mqtt_client_subscribe(s_client, topic, 1);
-                // Also allow broadcast to any node if you publish to ul/+/cmd/#
-                esp_mqtt_client_subscribe(s_client, "ul/+/cmd/#", 0);
-            }
-            break;
-        }
-        case MQTT_EVENT_DISCONNECTED:
-            ESP_LOGW(TAG, "MQTT disconnected");
-            s_ready = false;
-            break;
-        case MQTT_EVENT_DATA:
-            on_message(event);
-            break;
-        default:
-            break;
+static void handle_cmd_white_set(cJSON *root) { ul_white_apply_json(root); }
+static void on_message(esp_mqtt_event_handle_t event) {
+  // topic expected: ul/<node>/cmd/...
+  char node[64] = {0};
+  const char *topic = event->topic;
+  int tlen = event->topic_len;
+  if (!topic || tlen <= 0)
+    return;
+
+  // Extract node id segment
+  // pattern: "ul/xxxx/cmd/..."
+  const char *p = memchr(topic, '/', tlen);
+  if (!p)
+    return;
+  p++; // after "ul/"
+  const char *slash2 = memchr(p, '/', (topic + tlen) - p);
+  if (!slash2)
+    return;
+  int node_len = (int)(slash2 - p);
+  if (node_len <= 0 || node_len >= (int)sizeof(node))
+    return;
+  memcpy(node, p, node_len);
+  node[node_len] = 0;
+
+  if (strcmp(node, ul_core_get_node_id()) != 0 && strcmp(node, "+") != 0) {
+    // not for us
+    return;
+  }
+
+  // Grab command path after "ul/<node>/"
+  const char *cmdroot = slash2 + 1;
+  int cmdlen = (topic + tlen) - cmdroot;
+
+  // Parse JSON
+  cJSON *root = cJSON_ParseWithLength(event->data, event->data_len);
+  if (!root) {
+    ESP_LOGW(TAG, "Invalid JSON payload");
+    return;
+  }
+
+  if (cmdlen >= 3 && strncmp(cmdroot, "cmd", 3) == 0) {
+    const char *sub = cmdroot + 4; // skip "cmd/"
+    if (starts_with(sub, "ws/set")) {
+      handle_cmd_ws_set(root);
+    } else if (starts_with(sub, "ws/power")) {
+      handle_cmd_ws_power(root);
+    } else if (starts_with(sub, "sensor/cooldown")) {
+      handle_cmd_sensor_cooldown(root);
+    } else if (starts_with(sub, "sensor/motion")) {
+      handle_cmd_sensor_motion(root);
+    } else if (starts_with(sub, "ota/check")) {
+      ul_mqtt_publish_status();
+      ul_ota_check_now(true);
+      publish_status_snapshot();
+    } else if (starts_with(sub, "white/set")) {
+      handle_cmd_white_set(root);
+      ul_mqtt_publish_status();
+    } else if (starts_with(sub, "status")) {
+      ul_mqtt_publish_status_now();
+    } else {
+      ESP_LOGW(TAG, "Unknown cmd path: %.*s", cmdlen, cmdroot);
     }
+  }
+  cJSON_Delete(root);
 }
 
-void ul_mqtt_start(void)
-{
-    if (!ul_core_is_connected()) {
-        ESP_LOGW(TAG, "Network not connected; MQTT not started");
-        return;
+static void mqtt_event_handler(void *handler_args, esp_event_base_t base,
+                               int32_t event_id, void *event_data) {
+  esp_mqtt_event_handle_t event = event_data;
+  switch (event->event_id) {
+  case MQTT_EVENT_CONNECTED: {
+    ESP_LOGI(TAG, "MQTT connected");
+    s_ready = true;
+    if (ul_core_is_connected()) {
+      char topic[128];
+      snprintf(topic, sizeof(topic), "ul/%s/cmd/#", ul_core_get_node_id());
+      esp_mqtt_client_subscribe(s_client, topic, 1);
+      // Also allow broadcast to any node if you publish to ul/+/cmd/#
+      esp_mqtt_client_subscribe(s_client, "ul/+/cmd/#", 0);
     }
-    // MQTT runs at modest priority. On the ESP32-C3 all tasks share the
-    // single core, so no explicit core assignment is needed.
-    esp_mqtt_client_config_t cfg = {
-        .broker.address.uri = CONFIG_UL_MQTT_URI,
-        .credentials.username = CONFIG_UL_MQTT_USER,
-        .credentials.authentication.password = CONFIG_UL_MQTT_PASS,
-        .task.priority = 5,
-        .task.stack_size = 6144,
-    };
-    s_client = esp_mqtt_client_init(&cfg);
-    esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, mqtt_event_handler, NULL);
-    esp_mqtt_client_start(s_client);
+    break;
+  }
+  case MQTT_EVENT_DISCONNECTED:
+    ESP_LOGW(TAG, "MQTT disconnected");
+    s_ready = false;
+    break;
+  case MQTT_EVENT_DATA:
+    on_message(event);
+    break;
+  default:
+    break;
+  }
+}
+
+void ul_mqtt_start(void) {
+  if (!ul_core_is_connected()) {
+    ESP_LOGW(TAG, "Network not connected; MQTT not started");
+    return;
+  }
+  // MQTT runs at modest priority. On the ESP32-C3 all tasks share the
+  // single core, so no explicit core assignment is needed.
+  esp_mqtt_client_config_t cfg = {
+      .broker.address.uri = CONFIG_UL_MQTT_URI,
+      .credentials.username = CONFIG_UL_MQTT_USER,
+      .credentials.authentication.password = CONFIG_UL_MQTT_PASS,
+      .task.priority = 5,
+      .task.stack_size = 6144,
+  };
+  s_client = esp_mqtt_client_init(&cfg);
+  esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, mqtt_event_handler,
+                                 NULL);
+  esp_mqtt_client_start(s_client);
+}
+
+void ul_mqtt_stop(void) {
+  if (!s_client)
+    return;
+  esp_mqtt_client_stop(s_client);
+  esp_mqtt_client_destroy(s_client);
+  s_client = NULL;
+  s_ready = false;
 }
 
 bool ul_mqtt_is_ready(void) { return s_ready; }
 
-void ul_mqtt_publish_status_now(void){ publish_status_snapshot(); }
+void ul_mqtt_publish_status_now(void) { publish_status_snapshot(); }
 
-void ul_mqtt_run_local(const char* path, const char* json) {
-    if (!path || !json) return;
-    cJSON* root = cJSON_Parse(json);
-    if (!root) return;
-    if (starts_with(path, "ws/set")) {
-        handle_cmd_ws_set(root);
-    } else if (starts_with(path, "ws/power")) {
-        handle_cmd_ws_power(root);
-    } else if (starts_with(path, "white/set")) {
-        handle_cmd_white_set(root);
-    } else if (starts_with(path, "sensor/motion")) {
-        handle_cmd_sensor_motion(root);
-    } else if (starts_with(path, "sensor/cooldown")) {
-        handle_cmd_sensor_cooldown(root);
-    }
-    cJSON_Delete(root);
+void ul_mqtt_run_local(const char *path, const char *json) {
+  if (!path || !json)
+    return;
+  cJSON *root = cJSON_Parse(json);
+  if (!root)
+    return;
+  if (starts_with(path, "ws/set")) {
+    handle_cmd_ws_set(root);
+  } else if (starts_with(path, "ws/power")) {
+    handle_cmd_ws_power(root);
+  } else if (starts_with(path, "white/set")) {
+    handle_cmd_white_set(root);
+  } else if (starts_with(path, "sensor/motion")) {
+    handle_cmd_sensor_motion(root);
+  } else if (starts_with(path, "sensor/cooldown")) {
+    handle_cmd_sensor_cooldown(root);
+  }
+  cJSON_Delete(root);
 }

--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -1,44 +1,62 @@
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "esp_log.h"
-#include "nvs_flash.h"
 #include "esp_event.h"
+#include "esp_log.h"
 #include "esp_netif.h"
 #include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "nvs_flash.h"
+#include <stdbool.h>
 
 #include "ul_core.h"
 #include "ul_mqtt.h"
 #include "ul_ota.h"
 #include "ul_sensors.h"
-#include "ul_ws_engine.h"
 #include "ul_white_engine.h"
+#include "ul_ws_engine.h"
 
 static const char *TAG = "app";
 
-void app_main(void)
-{
-    ESP_LOGI(TAG, "UltraLights boot");
+static bool s_services_running = false;
 
-    ESP_ERROR_CHECK(nvs_flash_init());
-    ESP_ERROR_CHECK(esp_netif_init());
-    ESP_ERROR_CHECK(esp_event_loop_create_default());
-
-    ul_core_wifi_start();
-    ul_core_wait_for_ip(pdMS_TO_TICKS(10000));
-    ul_core_sntp_start();
-
-    ul_mqtt_start();
-
-    ul_ws_engine_start();    // 60 FPS LED engine
-    ul_white_engine_start(); // 200 Hz smoothing
-
-    ul_sensors_start();
-
-    ul_ota_start(); // periodic + MQTT trigger
-
-    // Status heartbeat via MQTT
-    while (true) {
-        ul_mqtt_publish_status();
-        vTaskDelay(pdMS_TO_TICKS(30 * 1000));
+static void connectivity_cb(bool connected, void *ctx) {
+  int strips = ul_ws_get_strip_count();
+  for (int i = 0; i < strips; ++i) {
+    ul_ws_power(i, connected);
+  }
+  if (connected) {
+    if (!s_services_running) {
+      ul_mqtt_start();
+      ul_ws_engine_start();    // 60 FPS LED engine
+      ul_white_engine_start(); // 200 Hz smoothing
+      ul_sensors_start();
+      ul_ota_start(); // periodic + MQTT trigger
+      s_services_running = true;
     }
+  } else {
+    if (s_services_running) {
+      ul_mqtt_stop();
+      s_services_running = false;
+    }
+    ESP_LOGW(TAG, "Network disconnected");
+  }
+}
+
+void app_main(void) {
+  ESP_LOGI(TAG, "UltraLights boot");
+
+  ESP_ERROR_CHECK(nvs_flash_init());
+  ESP_ERROR_CHECK(esp_netif_init());
+  ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+  ul_core_wifi_start();
+  ul_core_register_connectivity_cb(connectivity_cb, NULL);
+  bool connected = ul_core_wait_for_ip(portMAX_DELAY);
+  connectivity_cb(connected, NULL);
+  ul_core_sntp_start();
+
+  // Status heartbeat via MQTT
+  while (true) {
+    ul_mqtt_publish_status();
+    vTaskDelay(pdMS_TO_TICKS(30 * 1000));
+  }
 }


### PR DESCRIPTION
## Summary
- add ul_core connectivity callback API
- start/stop MQTT and LEDs based on network state
- wait indefinitely for IP before launching services

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fe0bd2ac8326a9fc22e33fa438f3