### PR TITLE
Check connectivity before heartbeat publish

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/include/ul_mqtt.h
+++ b/UltraNodeV5/components/ul_mqtt/include/ul_mqtt.h
@@ -13,6 +13,7 @@ void ul_mqtt_publish_status(void);
 void ul_mqtt_publish_status_now(void);
 void ul_mqtt_publish_motion(const char *sid, const char *state);
 bool ul_mqtt_is_ready(void);
+bool ul_mqtt_is_connected(void);
 
 // Execute a command locally without publishing over MQTT. The path should match
 // the suffix of a normal command topic (e.g. "ws/set").

--- a/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
+++ b/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
@@ -371,6 +371,8 @@ void ul_mqtt_stop(void) {
   s_ready = false;
 }
 
+bool ul_mqtt_is_connected(void) { return s_ready; }
+
 bool ul_mqtt_is_ready(void) { return s_ready; }
 
 void ul_mqtt_publish_status_now(void) { publish_status_snapshot(); }

--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -56,7 +56,11 @@ void app_main(void) {
 
   // Status heartbeat via MQTT
   while (true) {
-    ul_mqtt_publish_status();
+    if (ul_core_is_connected() && ul_mqtt_is_connected()) {
+      ul_mqtt_publish_status();
+    } else {
+      ESP_LOGW(TAG, "Skipping status publish (disconnected)");
+    }
     vTaskDelay(pdMS_TO_TICKS(30 * 1000));
   }
 }


### PR DESCRIPTION
## Summary
- Avoid sending status updates when either core or MQTT is disconnected
- Provide `ul_mqtt_is_connected` helper to report MQTT connection state

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68c304ef7d6883269e3cdb27f6eaabf8