### PR TITLE
Reset Wi-Fi backoff after IP connect

### DIFF
--- a/UltraNodeV5/components/ul_core/ul_core.c
+++ b/UltraNodeV5/components/ul_core/ul_core.c
@@ -62,6 +62,7 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
     ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
     ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
     s_retry_num = 0;
+    s_backoff_ms = 1000;
     xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
     if (s_conn_cb)
       s_conn_cb(true, s_conn_ctx);


### PR DESCRIPTION
## Summary
- ensure reconnect backoff resets to 1000ms after obtaining an IP

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c310a205c8832683db56266bfb8c3b