### PR TITLE
Add Wi-Fi shutdown helper

### DIFF
--- a/UltraNodeV5/components/ul_core/include/ul_core.h
+++ b/UltraNodeV5/components/ul_core/include/ul_core.h
@@ -10,6 +10,7 @@ extern "C" {
 void ul_core_wifi_start(void);
 bool ul_core_wait_for_ip(TickType_t timeout);
 bool ul_core_is_connected(void);
+void ul_core_wifi_stop(void); // Call before reinitializing or shutting down networking
 void ul_core_sntp_start(void);
 const char *ul_core_get_node_id(void);
 


### PR DESCRIPTION
## Summary
- add ul_core_wifi_stop to shut down Wi-Fi and release resources
- expose stop helper in ul_core API

## Testing
- `idf.py --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c310b5b018832696d866ba858a3012