### PR TITLE
Add configurable timezone

### DIFF
--- a/UltraNodeV5/components/ul_core/ul_core.c
+++ b/UltraNodeV5/components/ul_core/ul_core.c
@@ -130,7 +130,11 @@ static void sntp_sync_task(void *arg) {
 }
 
 void ul_core_sntp_start(void) {
-  setenv("TZ", "PST8PDT,M3.2.0/2,M11.1.0/2", 1); // America/Los_Angeles
+  const char *tz = CONFIG_UL_TIMEZONE;
+  if (tz[0] == '\0') {
+    tz = "UTC";
+  }
+  setenv("TZ", tz, 1);
   tzset();
 
   esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -23,6 +23,11 @@ menu "Node / Network"
         int "SNTP sync interval (seconds)"
         range 60 86400
         default 21600
+    config UL_TIMEZONE
+        string "Time zone (TZ string)"
+        default ""
+        help
+            POSIX TZ string (e.g., "PST8PDT,M3.2.0/2,M11.1.0/2"). If left empty, UTC is used.
 endmenu
 
 menu "MQTT"


### PR DESCRIPTION
## Summary
- add Kconfig option for timezone
- use CONFIG_UL_TIMEZONE to set TZ during SNTP startup with UTC fallback

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c310ba2b3c832695836faff079eba1