### PR TITLE
Handle Wi-Fi reconnect errors

### DIFF
--- a/UltraNodeV5/components/ul_core/ul_core.c
+++ b/UltraNodeV5/components/ul_core/ul_core.c
@@ -37,7 +37,11 @@ void ul_core_register_connectivity_cb(ul_core_conn_cb_t cb, void *ctx) {
 
 static void wifi_reconnect_timer_cb(void *arg) {
   xEventGroupClearBits(s_wifi_event_group, WIFI_FAIL_BIT);
-  esp_wifi_connect();
+  esp_err_t err = esp_wifi_connect();
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_wifi_connect failed: %s", esp_err_to_name(err));
+    esp_timer_start_once(s_reconnect_timer, s_backoff_ms * 1000);
+  }
   s_retry_num++;
   s_backoff_ms = s_backoff_ms * 2;
   if (s_backoff_ms > WIFI_MAX_BACKOFF_MS)


### PR DESCRIPTION
## Summary
- capture `esp_wifi_connect` return code in `wifi_reconnect_timer_cb`
- log connection failures and reschedule reconnect attempts

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c310be4aac83269abfd41386deef14