### PR TITLE
Handle connection result without manual callback

### DIFF
--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -65,7 +65,9 @@ void app_main(void) {
   ul_core_wifi_start();
   ul_core_register_connectivity_cb(connectivity_cb, NULL);
   bool connected = ul_core_wait_for_ip(portMAX_DELAY);
-  connectivity_cb(connected, NULL);
+  if (!connected) {
+    ESP_LOGE(TAG, "Failed to obtain IP address");
+  }
   ul_core_sntp_start();
 
   // Status heartbeat via MQTT


### PR DESCRIPTION
## Summary
- remove direct connectivity callback invocation after waiting for IP
- log an error if `ul_core_wait_for_ip` fails to obtain an IP address

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c31302336083268941ab07267f8f87