### PR TITLE
Stop services when disconnected

### DIFF
--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -41,6 +41,10 @@ static void service_manager_task(void *ctx) {
       } else {
         if (s_services_running) {
           ul_mqtt_stop();
+          ul_ws_engine_stop();
+          ul_white_engine_stop();
+          ul_sensors_stop();
+          ul_ota_stop();
           s_services_running = false;
         }
         ESP_LOGW(TAG, "Network disconnected");


### PR DESCRIPTION
## Summary
- Stop LED, white, sensor, and OTA services when the network disconnects
- Track service state to prevent duplicate starts

## Testing
- `idf.py build` *(command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c312fc21bc83269d3bc935e93ec357