### PR TITLE
Fix SNTP resync and declare ul_core dependency

### DIFF
--- a/UltraNodeV5/components/ul_core/ul_core.c
+++ b/UltraNodeV5/components/ul_core/ul_core.c
@@ -194,7 +194,8 @@ static void sntp_sync_task(void *arg) {
     while (!ul_core_is_connected()) {
       vTaskDelay(pdMS_TO_TICKS(1000));
     }
-    esp_err_t err = esp_netif_sntp_sync();
+    esp_netif_sntp_stop();
+    esp_err_t err = esp_netif_sntp_start();
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "SNTP resync failed: %s", esp_err_to_name(err));
     } else {
@@ -213,6 +214,7 @@ void ul_core_sntp_start(void) {
 
   esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
   esp_netif_sntp_init(&config);
+  ESP_ERROR_CHECK(esp_netif_sntp_start());
 
   // Wait until time is set (epoch > 1700000000 ~ 2023)
   time_t now = 0;

--- a/UltraNodeV5/components/ul_ws_engine/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_ws_engine/CMakeLists.txt
@@ -3,4 +3,5 @@ idf_component_register(SRCS "ul_ws_engine.c" "effects_ws/registry.c"
                             "effects_ws/twinkle.c" "effects_ws/theater_chase.c" "effects_ws/wipe.c"
                             "effects_ws/gradient_scroll.c" "effects_ws/triple_wave.c" "effects_ws/flash.c" "effects_ws/spacewaves.c"
                        INCLUDE_DIRS "include" "effects_ws"
-                       REQUIRES json led_strip driver esp_timer ul_common_effects ul_task)
+                       REQUIRES json led_strip driver esp_timer ul_common_effects ul_task
+                       PRIV_REQUIRES ul_core)


### PR DESCRIPTION
## Summary
- Restart SNTP client on each sync interval and start it after initialization
- Declare ul_core as a private dependency for ul_ws_engine component

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install --user esp-idf` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f82a59f88326bf19cf318a50e255