### PR TITLE
Fix unused symbol warnings in sensors and MQTT components

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
+++ b/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
@@ -200,8 +200,6 @@ static bool j_is_int_in(cJSON *obj, const char *key, int minv, int maxv,
   return true;
 }
 static void handle_cmd_sensor_cooldown(cJSON *root) {
-
-  cJSON *js = cJSON_GetObjectItem(root, "seconds");
   int s;
   if (j_is_int_in(root, "seconds", 10, 3600, &s)) {
     ul_sensors_set_cooldown(s);

--- a/UltraNodeV5/components/ul_sensors/ul_sensors.c
+++ b/UltraNodeV5/components/ul_sensors/ul_sensors.c
@@ -11,14 +11,16 @@
 #include "ul_white_engine.h"
 #include <string.h>
 
-static const char* TAG = "ul_sensors";
-
 static volatile int pir_motion_time_s = CONFIG_UL_SENSOR_COOLDOWN_S;
 static volatile int sonic_motion_time_s = CONFIG_UL_SENSOR_COOLDOWN_S;
 static volatile int sonic_threshold_mm = CONFIG_UL_ULTRA_DISTANCE_MM;
 static volatile int motion_on_channel = -1;
+#if CONFIG_UL_PIR_ENABLED
 static int64_t pir_until = 0;
+#endif
+#if CONFIG_UL_ULTRA_ENABLED
 static int64_t ultra_until = 0;
+#endif
 static uint8_t saved_brightness = 0;
 static bool brightness_override = false;
 static ul_motion_state_t current_state = UL_MOTION_NONE;
@@ -57,6 +59,7 @@ static void apply_motion_state(ul_motion_state_t st) {
     }
 }
 
+#if CONFIG_UL_PIR_ENABLED || CONFIG_UL_ULTRA_ENABLED
 static void set_until(volatile int64_t* until_var, int seconds) {
     *until_var = esp_timer_get_time() + (int64_t)seconds * 1000000LL;
 }
@@ -64,6 +67,7 @@ static void set_until(volatile int64_t* until_var, int seconds) {
 static bool is_active(volatile int64_t* until_var) {
     return esp_timer_get_time() < *until_var;
 }
+#endif
 
 static void sensors_task(void*)
 {


### PR DESCRIPTION
## Summary
- conditionally compile sensor cooldown helpers and timers
- drop unused debug tag and JSON variable

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install espressif` *(fails: No matching distribution found)*
- `pip install esp-idf` *(fails: No matching distribution found)*
- `pip install idf-component-manager`


------
https://chatgpt.com/codex/tasks/task_e_68c31dfd7c1483269bf68e2faa49cdd7