### PR TITLE
Ensure solid effect param defs and validate WS definitions

### DIFF
--- a/Server/app/effects.py
+++ b/Server/app/effects.py
@@ -72,3 +72,7 @@ WHITE_PARAM_DEFS = {
     ],
 }
 
+# ``solid`` is fundamental and must always exist for the web interface. Ensure
+# a default parameter definition is present even if trimmed elsewhere.
+WS_PARAM_DEFS.setdefault("solid", [{"type": "color", "label": "Color"}])
+

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -71,6 +71,12 @@ def node_page(request: Request, node_id: str):
         subtitle = f"{house.get('name', house['id'])} • {room.get('name', room['id'])}"
     else:
         subtitle = None
+
+    missing = [eff for eff in WS_EFFECTS if eff not in WS_PARAM_DEFS]
+    if missing:
+        import logging
+        logging.warning("WS_PARAM_DEFS missing entries for: %s", ", ".join(sorted(missing)))
+
     return templates.TemplateResponse(
         "node.html",
         {

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -33,11 +33,7 @@
 const WS_PARAM_DEFS={{ ws_param_defs|tojson }};
 
 function getParamDefs(eff){
-  let defs=WS_PARAM_DEFS[eff]||[];
-  if(eff==='solid'&&defs.length===0){
-    defs=[{type:'color',label:'Color'}];
-  }
-  return defs;
+  return WS_PARAM_DEFS[eff]||[];
 }
 function hexToRgb(hex){hex=hex.replace('#','');if(hex.length===3)hex=hex.split('').map(x=>x+x).join('');const num=parseInt(hex,16);return[(num>>16)&255,(num>>8)&255,num&255];}
 function spawnColorPicker(parent,value,onChange){


### PR DESCRIPTION
## Summary
- Drop client-side fallback for `solid` effect; rely on server-provided definitions.
- Guarantee server always provides `solid` effect parameters.
- Warn when any WS effect lacks parameter definitions.

## Testing
- `python -m py_compile Server/app/effects.py Server/app/routes_pages.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3daa8adc88326b3c4afb6b49d5b1c