### PR TITLE
feat: share parameter form utilities

### DIFF
--- a/Server/app/effects.py
+++ b/Server/app/effects.py
@@ -27,6 +27,7 @@ WHITE_EFFECTS = set(_load_effects("UltraNodeV5/components/ul_white_engine/effect
 #              integer value.
 # ``number`` – render an ``<input type="number">`` for floating‑point or
 #              free‑form numeric input.
+# ``toggle`` – render a checkbox and append 1 if checked, otherwise 0.
 
 WS_PARAM_DEFS = {
     # Solid color – single RGB value

--- a/Server/app/static/params.js
+++ b/Server/app/static/params.js
@@ -1,0 +1,79 @@
+export function spawnColorPicker(parent, key, value, onChange) {
+  const pickerDiv = document.createElement('div');
+  pickerDiv.className = 'w-32 h-32';
+  parent.appendChild(pickerDiv);
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.dataset.paramKey = key;
+  parent.appendChild(input);
+  const picker = new iro.ColorPicker(pickerDiv, { color: value || '#ffffff', width: 128 });
+  const update = () => {
+    const { r, g, b } = picker.color.rgb;
+    input.value = JSON.stringify([r, g, b]);
+    if (onChange) onChange();
+  };
+  picker.on('color:change', update);
+  update();
+  return input;
+}
+
+export function renderParams(defs, container, onChange) {
+  container.innerHTML = '';
+  defs.forEach((d, idx) => {
+    const key = d.name || idx;
+    const wrap = document.createElement('div');
+    if (d.label) {
+      const lab = document.createElement('label');
+      lab.className = 'text-xs opacity-70';
+      lab.textContent = d.label;
+      wrap.appendChild(lab);
+    }
+    let input;
+    if (d.type === 'color') {
+      input = spawnColorPicker(wrap, key, d.value, onChange);
+    } else {
+      input = document.createElement('input');
+      if (d.type === 'slider') {
+        input.type = 'range';
+        input.min = d.min;
+        input.max = d.max;
+        input.value = d.value;
+        input.addEventListener('input', onChange);
+      } else if (d.type === 'toggle') {
+        input.type = 'checkbox';
+        input.checked = !!d.value;
+        input.addEventListener('change', onChange);
+      } else {
+        input.type = 'number';
+        if (d.min !== undefined) input.min = d.min;
+        if (d.max !== undefined) input.max = d.max;
+        if (d.step !== undefined) input.step = d.step;
+        input.value = d.value !== undefined ? d.value : '';
+        input.addEventListener('input', onChange);
+      }
+      input.dataset.paramKey = key;
+      wrap.appendChild(input);
+    }
+    container.appendChild(wrap);
+  });
+}
+
+export function collectParams(defs, container) {
+  const out = [];
+  defs.forEach((d, idx) => {
+    const key = d.name || idx;
+    const input = container.querySelector(`[data-param-key="${key}"]`);
+    if (!input) return;
+    if (d.type === 'color') {
+      const rgb = JSON.parse(input.value);
+      out.push(...rgb);
+    } else if (d.type === 'slider') {
+      out.push(parseInt(input.value, 10));
+    } else if (d.type === 'toggle') {
+      out.push(input.checked ? 1 : 0);
+    } else {
+      out.push(parseFloat(input.value));
+    }
+  });
+  return out;
+}

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -24,7 +24,8 @@
     <button id="wSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
   </div>
 </section>
-<script>
+<script type="module">
+import {renderParams,collectParams} from '/static/params.js';
 const WHITE_PARAM_DEFS={{ white_param_defs|tojson }};
 async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
 const chEl=document.getElementById('wChannel');
@@ -46,60 +47,13 @@ function scheduleWhite(){
     wPendingSend=setTimeout(()=>{wLastSend=Date.now();sendWhite();},delay);
   }
 }
-
-function renderParams(){
-  wParamsEl.innerHTML='';
+function updateParams(){
   const defs=WHITE_PARAM_DEFS[effEl.value]||[];
-  defs.forEach((d,idx)=>{
-    const wrap=document.createElement('div');
-    if(d.label){
-      const lab=document.createElement('label');
-      lab.className='text-xs opacity-70';
-      lab.textContent=d.label;
-      wrap.appendChild(lab);
-    }
-    let input=document.createElement('input');
-    if(d.type==='slider'){
-      input.type='range';
-      input.min=d.min;input.max=d.max;input.value=d.value;
-      input.addEventListener('input',scheduleWhite);
-    }else if(d.type==='toggle'){
-      input.type='checkbox';
-      input.checked=!!d.value;
-      input.addEventListener('change',scheduleWhite);
-    }else{
-      input.type='number';
-      if(d.min!==undefined)input.min=d.min;
-      if(d.max!==undefined)input.max=d.max;
-      if(d.step!==undefined)input.step=d.step;
-      input.value=d.value!==undefined?d.value:'';
-      input.addEventListener('input',scheduleWhite);
-    }
-    input.dataset.index=idx;
-    wrap.appendChild(input);
-    wParamsEl.appendChild(wrap);
-  });
+  renderParams(defs,wParamsEl,scheduleWhite);
 }
-effEl.onchange=()=>{renderParams();scheduleWhite();};
+effEl.onchange=()=>{updateParams();scheduleWhite();};
 chEl.onchange=scheduleWhite;
 wBriEl.addEventListener('input',scheduleWhite);
-
-function collectParams(){
-  const defs=WHITE_PARAM_DEFS[effEl.value]||[];
-  const out=[];
-  defs.forEach((d,idx)=>{
-    const input=wParamsEl.querySelector(`[data-index="${idx}"]`);
-    if(!input)return;
-    if(d.type==='slider'){
-      out.push(parseInt(input.value,10));
-    }else if(d.type==='toggle'){
-      out.push(input.checked?1:0);
-    }else{
-      out.push(parseFloat(input.value));
-    }
-  });
-  return out;
-}
 
 function sendWhite(){
   const channel=parseInt(chEl.value,10);
@@ -108,7 +62,7 @@ function sendWhite(){
   if(!effect)return;
   const brightness=parseInt(wBriEl.value,10);
   if(Number.isNaN(brightness))return;
-  const params=collectParams();
+  const params=collectParams(WHITE_PARAM_DEFS[effEl.value]||[],wParamsEl);
   const msg={channel,effect,brightness};
   if(params.length)msg.params=params;
   post(`/api/node/{{ node.id }}/white/set`,msg);

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -29,7 +29,8 @@
   </div>
 </section>
 <script src="https://cdn.jsdelivr.net/npm/@jaames/iro@5"></script>
-<script>
+<script type="module">
+import {renderParams,collectParams} from '/static/params.js';
 const WS_PARAM_DEFS={{ ws_param_defs|tojson }};
 
 function getParamDefs(eff){
@@ -38,19 +39,6 @@ function getParamDefs(eff){
     defs=[{type:'color',label:'Color'}];
   }
   return defs;
-}
-function hexToRgb(hex){hex=hex.replace('#','');if(hex.length===3)hex=hex.split('').map(x=>x+x).join('');const num=parseInt(hex,16);return[(num>>16)&255,(num>>8)&255,num&255];}
-function spawnColorPicker(parent,value,onChange){
-  const pickerDiv=document.createElement('div');
-  pickerDiv.className='w-32 h-32';
-  parent.appendChild(pickerDiv);
-  const input=document.createElement('input');
-  input.type='hidden';
-  input.value=value||'#ffffff';
-  parent.appendChild(input);
-  const picker=new iro.ColorPicker(pickerDiv,{color:input.value,width:128});
-  picker.on('color:change',c=>{input.value=c.hexString;if(onChange)onChange();});
-  return input;
 }
 async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
 const stripEl=document.getElementById('wsStrip');
@@ -74,63 +62,16 @@ function scheduleSend(){
   }
 }
 
-function renderParams(){
-  paramsEl.innerHTML='';
+function updateParams(){
   const eff=effectEl.value.trim();
   const defs=getParamDefs(eff);
-  defs.forEach((d,idx)=>{
-    const wrap=document.createElement('div');
-    if(d.label){
-      const lab=document.createElement('label');
-      lab.className='text-xs opacity-70';
-      lab.textContent=d.label;
-      wrap.appendChild(lab);
-    }
-    let input;
-    if(d.type==='color'){
-      input=spawnColorPicker(wrap,d.value,scheduleSend);
-    }else{
-      input=document.createElement('input');
-      if(d.type==='slider'){
-        input.type='range';
-        input.min=d.min;input.max=d.max;input.value=d.value;
-      }else{
-        input.type='number';
-        if(d.min!==undefined)input.min=d.min;
-        if(d.max!==undefined)input.max=d.max;
-        if(d.step!==undefined)input.step=d.step;
-        input.value=d.value!==undefined?d.value:'';
-      }
-      input.addEventListener('input',scheduleSend);
-      wrap.appendChild(input);
-    }
-    paramsEl.appendChild(wrap);
-  });
+  renderParams(defs,paramsEl,scheduleSend);
 }
-effectEl.onchange=()=>{renderParams();scheduleSend();};
+effectEl.onchange=()=>{updateParams();scheduleSend();};
 stripEl.onchange=scheduleSend;
 briEl.addEventListener('input',scheduleSend);
 speedEl.addEventListener('input',scheduleSend);
-if(effectEl.value)renderParams();
-
-function collectParams(){
-  const defs=getParamDefs(effectEl.value.trim());
-  const inputs=paramsEl.querySelectorAll('input');
-  const out=[];
-  defs.forEach((d,idx)=>{
-    const input=inputs[idx];
-    if(!input)return;
-      if(d.type==='color'){
-        const rgb=hexToRgb(input.value);
-        out.push(...rgb);
-      }else if(d.type==='slider'){
-        out.push(parseInt(input.value,10));
-      }else{
-        out.push(parseFloat(input.value));
-      }
-  });
-  return out;
-}
+if(effectEl.value)updateParams();
 
 function sendCmd(){
   const strip=parseInt(stripEl.value,10);
@@ -140,7 +81,7 @@ function sendCmd(){
   const bri=parseInt(briEl.value,10);
   if(Number.isNaN(bri))return;
   const speed=parseInt(speedEl.value,10)/100;
-  const params=collectParams();
+  const params=collectParams(getParamDefs(eff),paramsEl);
   const msg={strip,effect:eff,brightness:bri,speed,params};
   post(`/api/node/{{ node.id }}/ws/set`,msg);
 }

--- a/Server/docs/effects.md
+++ b/Server/docs/effects.md
@@ -1,0 +1,53 @@
+# Effect Parameters and Utilities
+
+This server exposes lighting effects for addressable LED strips and white channels. To avoid duplicating UI logic, the parameter form code is shared across modules.
+
+## Parameter utilities
+
+`Server/app/static/params.js` exports helpers used by the templates:
+
+- `spawnColorPicker(parent, key, value, onChange)` – insert an [`iro.js`](https://iro.js.org) colour picker bound to a `data-param-key` and keep the selected RGB triplet (as JSON) in a hidden `<input>`.
+- `renderParams(defs, container, onChange)` – create form controls from an array of effect descriptors. Each descriptor specifies the `type`, optional `label`, and settings such as `min`, `max`, or `value`. Inputs are tagged with a `data-param-key` derived from the descriptor name or index and wired to the `onChange` callback so callers can throttle MQTT messages.
+- `collectParams(defs, container)` – look up elements by `data-param-key`, reading numbers directly or expanding stored RGB arrays into the positional parameter list expected by the firmware.
+
+`ws.html` and `white.html` import these utilities with
+
+```html
+<script type="module">
+import { renderParams, collectParams } from '/static/params.js';
+```
+
+This removes duplicate input handling code.
+
+Templates that expose colour parameters (such as `ws.html`) must include the `iro.js` script before importing `params.js`. Modules that only use numeric inputs, like `white.html`, can omit the extra script:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@jaames/iro@5"></script>
+<script type="module" src="/static/params.js"></script>
+```
+
+### Descriptor types
+
+Effect descriptors support these `type` values:
+
+- `color` – choose an RGB colour using `iro.js`; the triplet is flattened into the `params` array.
+- `slider` – range input producing an integer value.
+- `number` – numeric input for floats or free‑form numbers.
+- `toggle` – checkbox that appends `1` when checked or `0` when cleared.
+
+## Adding a new effect
+
+1. **Implement the effect in firmware** and register it in the appropriate `registry.c` so that `effects.py` detects its name.
+2. **Describe its parameters** in `Server/app/effects.py` by adding an entry to `WS_PARAM_DEFS` or `WHITE_PARAM_DEFS`. Each descriptor corresponds to one positional argument sent over MQTT.
+3. The web UI will automatically list the new effect and render the controls using `renderParams`. Use `collectParams` when constructing the message body to obtain the values.
+
+Example descriptor:
+
+```python
+WS_PARAM_DEFS["sparkle"] = [
+    {"type": "color", "label": "Sparkle Color"},
+    {"type": "slider", "label": "Density", "min": 1, "max": 100, "value": 10},
+]
+```
+
+After reloading the page, the "sparkle" effect appears with a colour picker and slider. No additional template changes are required.


### PR DESCRIPTION
## Summary
- add shared params.js module for rendering and collecting effect parameters
- refactor ws.html and white.html to import shared utilities and remove duplicates
- document parameter utilities and steps for adding new effects
- key inputs with `data-param-key` and store colour selections as RGB arrays
- load iro.js in colour-capable modules and document supported descriptor types
- drop colour picker from white channel since it only handles numeric inputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3daa959c08326b52a63755f8edd2b