### PR TITLE
Add room preset infrastructure and swell effect

### DIFF
--- a/Server/app/effects.py
+++ b/Server/app/effects.py
@@ -71,6 +71,11 @@ WHITE_PARAM_DEFS = {
     "breathe": [
         {"type": "slider", "label": "Period (ms)", "min": 100, "max": 5000, "value": 1000},
     ],
+    "swell": [
+        {"type": "slider", "label": "Start Brightness", "min": 0, "max": 255, "value": 0},
+        {"type": "slider", "label": "End Brightness", "min": 0, "max": 255, "value": 255},
+        {"type": "slider", "label": "Time (ms)", "min": 0, "max": 5000, "value": 1000},
+    ],
 }
 
 # ``solid`` is fundamental and must always exist for the web interface. Ensure

--- a/Server/app/presets.py
+++ b/Server/app/presets.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .mqtt_bus import MqttBus
+
+# Presets are organized by house and room. Each preset contains a list of
+# actions to perform when the preset is applied. Actions target a node and one
+# of its modules (ws, white, etc.). This structure intentionally mirrors the
+# existing command APIs so that presets can be expanded incrementally.
+ROOM_PRESETS: Dict[str, Dict[str, List[Dict[str, Any]]]] = {
+    # "example-house": {
+    #     "living-room": [
+    #         {
+    #             "id": "all-off",
+    #             "name": "All Off",
+    #             "actions": [
+    #                 {
+    #                     "node": "example-node",
+    #                     "module": "ws_power",
+    #                     "strip": 0,
+    #                     "on": False,
+    #                 }
+    #             ],
+    #         }
+    #     ]
+    # }
+}
+
+
+def get_room_presets(house_id: str, room_id: str) -> List[Dict[str, Any]]:
+    """Return presets defined for ``house_id``/``room_id``."""
+    return ROOM_PRESETS.get(house_id, {}).get(room_id, [])
+
+
+def get_preset(house_id: str, room_id: str, preset_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a specific preset from ``house_id``/``room_id``."""
+    for preset in get_room_presets(house_id, room_id):
+        if preset.get("id") == preset_id:
+            return preset
+    return None
+
+
+def apply_preset(bus: MqttBus, preset: Dict[str, Any]) -> None:
+    """Apply ``preset`` by sending commands through ``bus``."""
+    for action in preset.get("actions", []):
+        node = action.get("node")
+        module = action.get("module")
+        if module == "ws":
+            bus.ws_set(
+                node,
+                int(action.get("strip", 0)),
+                action.get("effect", ""),
+                int(action.get("brightness", 0)),
+                float(action.get("speed", 1.0)),
+                action.get("params"),
+            )
+        elif module == "white":
+            bus.white_set(
+                node,
+                int(action.get("channel", 0)),
+                action.get("effect", ""),
+                int(action.get("brightness", 0)),
+                action.get("params"),
+            )
+        elif module == "ws_power":
+            bus.ws_power(node, int(action.get("strip", 0)), bool(action.get("on", False)))
+        elif module == "sensor_cooldown":
+            bus.sensor_cooldown(node, int(action.get("seconds", 30)))
+        else:
+            # Unknown action type; ignore for now.
+            continue

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException
 from .mqtt_bus import MqttBus
 from . import registry
 from .effects import WS_EFFECTS, WHITE_EFFECTS
+from .presets import get_preset, apply_preset
 
 router = APIRouter()
 BUS: Optional[MqttBus] = None
@@ -47,6 +48,15 @@ def api_add_node(house_id: str, room_id: str, payload: Dict[str, Any]):
     except KeyError:
         raise HTTPException(404, "Unknown room")
     return {"ok": True, "node": node}
+
+
+@router.post("/api/house/{house_id}/room/{room_id}/preset/{preset_id}")
+def api_apply_preset(house_id: str, room_id: str, preset_id: str):
+    preset = get_preset(house_id, room_id, preset_id)
+    if not preset:
+        raise HTTPException(404, "Unknown preset")
+    apply_preset(get_bus(), preset)
+    return {"ok": True}
 
 # ---- Node command APIs -------------------------------------------------
 

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -4,6 +4,7 @@ from fastapi.templating import Jinja2Templates
 from .config import settings
 from . import registry
 from .effects import WS_EFFECTS, WHITE_EFFECTS, WS_PARAM_DEFS, WHITE_PARAM_DEFS
+from .presets import get_room_presets
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
@@ -48,6 +49,7 @@ def room_page(request: Request, house_id: str, room_id: str):
             status_code=404,
         )
     title = f"{house.get('name', house_id)} - {room.get('name', room_id)}"
+    presets = get_room_presets(house_id, room_id)
     return templates.TemplateResponse(
         "room.html",
         {
@@ -56,6 +58,7 @@ def room_page(request: Request, house_id: str, room_id: str):
             "room": room,
             "title": title,
             "subtitle": title,
+            "presets": presets,
         },
     )
 

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -13,6 +13,16 @@
   </a>
   {% endfor %}
 </div>
+<div class="mt-8">
+  <h2 class="text-2xl font-semibold mb-4">Presets</h2>
+  <div class="flex flex-wrap gap-2">
+    {% for p in presets %}
+    <button class="preset glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400" data-id="{{ p.id }}">{{ p.name }}</button>
+    {% else %}
+    <div class="opacity-60">No presets configured.</div>
+    {% endfor %}
+  </div>
+</div>
 <script>
 document.getElementById('addNode').onclick = async () => {
   const name = prompt('New node name');
@@ -22,5 +32,14 @@ document.getElementById('addNode').onclick = async () => {
   });
   if(res.ok) location.reload(); else alert('Failed to add node');
 };
+document.querySelectorAll('.preset').forEach(btn => {
+  btn.onclick = async () => {
+    const id = btn.dataset.id;
+    const res = await fetch(`/api/house/{{ house.id }}/room/{{ room.id }}/preset/${id}`, {
+      method:'POST'
+    });
+    if(!res.ok) alert('Failed to apply preset');
+  };
+});
 </script>
 {% endblock %}

--- a/UltraNodeV5/components/ul_white_engine/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_white_engine/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "ul_white_engine.c" "effects_white/registry.c" "effects_white/solid.c" "effects_white/breathe.c"
+idf_component_register(SRCS "ul_white_engine.c" "effects_white/registry.c" "effects_white/solid.c" "effects_white/breathe.c" "effects_white/swell.c"
                        INCLUDE_DIRS "include" "effects_white"
                        REQUIRES json driver esp_timer ul_common_effects ul_task)

--- a/UltraNodeV5/components/ul_white_engine/effects_white/effect.h
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/effect.h
@@ -12,3 +12,4 @@ typedef struct {
 } white_effect_t;
 
 const white_effect_t* ul_white_get_effects(int* count);
+int ul_white_effect_current_channel(void);

--- a/UltraNodeV5/components/ul_white_engine/effects_white/registry.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/registry.c
@@ -8,9 +8,14 @@ void white_breathe_apply_params(int ch, const cJSON* params);
 void white_solid_init(void);
 uint8_t white_solid_render(int frame_idx);
 
+void white_swell_init(void);
+uint8_t white_swell_render(int frame_idx);
+void white_swell_apply_params(int ch, const cJSON* params);
+
 static const white_effect_t effects[] = {
     {"solid", white_solid_init, white_solid_render, NULL},
     {"breathe", white_breathe_init, white_breathe_render, white_breathe_apply_params},
+    {"swell", white_swell_init, white_swell_render, white_swell_apply_params},
 };
 
 const white_effect_t* ul_white_get_effects(int* count) {

--- a/UltraNodeV5/components/ul_white_engine/effects_white/swell.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/swell.c
@@ -1,0 +1,61 @@
+#include "effect.h"
+#include "sdkconfig.h"
+#include "cJSON.h"
+
+static uint8_t s_start[4];
+static uint8_t s_end[4];
+static int s_frames[4];
+static int s_progress[4];
+
+void white_swell_init(void) {
+    for (int i = 0; i < 4; ++i) {
+        s_start[i] = 0;
+        s_end[i] = 255;
+        s_frames[i] = 1;
+        s_progress[i] = 0;
+    }
+}
+
+uint8_t white_swell_render(int frame_idx) {
+    (void)frame_idx;
+    int ch = ul_white_effect_current_channel();
+    if (ch < 0 || ch > 3) return 0;
+    if (s_progress[ch] < s_frames[ch]) {
+        float t = s_frames[ch] ? (float)s_progress[ch] / (float)s_frames[ch] : 1.0f;
+        int v = (int)(s_start[ch] + (s_end[ch] - s_start[ch]) * t + 0.5f);
+        s_progress[ch]++;
+        if (v < 0) v = 0;
+        if (v > 255) v = 255;
+        return (uint8_t)v;
+    }
+    return s_end[ch];
+}
+
+void white_swell_apply_params(int ch, const cJSON* params) {
+    if (ch < 0 || ch > 3) return;
+    if (!params || !cJSON_IsArray(params)) return;
+    const cJSON* p0 = cJSON_GetArrayItem(params, 0);
+    const cJSON* p1 = cJSON_GetArrayItem(params, 1);
+    const cJSON* p2 = cJSON_GetArrayItem(params, 2);
+    if (p0 && cJSON_IsNumber(p0)) {
+        int x = p0->valueint;
+        if (x < 0) x = 0;
+        if (x > 255) x = 255;
+        s_start[ch] = (uint8_t)x;
+    }
+    if (p1 && cJSON_IsNumber(p1)) {
+        int y = p1->valueint;
+        if (y < 0) y = 0;
+        if (y > 255) y = 255;
+        s_end[ch] = (uint8_t)y;
+    }
+    if (p2 && cJSON_IsNumber(p2)) {
+        int ms = p2->valueint;
+        if (ms < 0) ms = 0;
+        int f = (ms * CONFIG_UL_WHITE_SMOOTH_HZ) / 1000;
+        if (f < 1) f = 1;
+        s_frames[ch] = f;
+    }
+    s_progress[ch] = 0;
+}
+

--- a/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
+++ b/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
@@ -31,6 +31,7 @@ typedef struct {
 static white_ch_t s_ch[4];
 static int s_count = 0;
 static TaskHandle_t s_white_task = NULL;
+static int s_current_ch_idx = 0;
 
 static const white_effect_t* find_eff(const char* name) {
     int n=0; const white_effect_t* t = ul_white_get_effects(&n);
@@ -59,6 +60,8 @@ static void setup_ledc_channel(int ch, int gpio, int freq_hz)
     };
     ledc_channel_config(&ccfg);
 }
+
+int ul_white_effect_current_channel(void) { return s_current_ch_idx; }
 
 static void ch_init(int idx, bool enabled, int gpio, int ledc_ch, int pwm_hz) {
     s_ch[idx].enabled = enabled;
@@ -89,6 +92,7 @@ static void white_task(void*)
         for (int i=0;i<4;i++) {
             if (!s_ch[i].enabled) continue;
             uint8_t v = 0;
+            s_current_ch_idx = i;
             if (s_ch[i].eff && s_ch[i].eff->render) {
                 v = s_ch[i].eff->render(s_ch[i].frame_idx++);
             }

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -120,9 +120,10 @@ Example – flash between red and blue:
 }
 ```
 
-Registered effects: `solid` and `breathe`.
+Registered effects: `solid`, `breathe`, and `swell`.
 * `solid` – static output with no parameters.
 * `breathe` – optional params: `[period_ms]` to control the breath cycle length.
+* `swell` – params `[x, y, t_ms]` fade from brightness `x` to `y` over `t_ms` milliseconds then hold at `y`.
 
 ### Sensor and OTA commands
 


### PR DESCRIPTION
## Summary
- add presets module defining per-room preset structure and apply helper
- expose presets in room page template and FastAPI routes
- allow rooms to trigger presets via new API and UI buttons
- implement white "swell" effect with start/end brightness and duration
- document and expose params for the swell effect in server UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4e96df5b8832684d3e5224e384fc2