### PR TITLE
Add room preset infrastructure and swell effect

### DIFF
--- a/Server/app/effects.py
+++ b/Server/app/effects.py
@@ -71,6 +71,11 @@ WHITE_PARAM_DEFS = {
     "breathe": [
         {"type": "slider", "label": "Period (ms)", "min": 100, "max": 5000, "value": 1000},
     ],
+    "swell": [
+        {"type": "slider", "label": "Start Brightness", "min": 0, "max": 255, "value": 0},
+        {"type": "slider", "label": "End Brightness", "min": 0, "max": 255, "value": 255},
+        {"type": "slider", "label": "Time (ms)", "min": 0, "max": 5000, "value": 1000},
+    ],
 }
 
 # ``solid`` is fundamental and must always exist for the web interface. Ensure

--- a/Server/app/presets.py
+++ b/Server/app/presets.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .mqtt_bus import MqttBus
+
+
+def _white_swell_action(node: str, ch: int, start: int, end: int, ms: int) -> Dict[str, Any]:
+    """Return a single white-channel swell action."""
+
+    return {
+        "node": node,
+        "module": "white",
+        "channel": ch,
+        "effect": "swell",
+        "brightness": start,
+        "params": [start, end, ms],
+    }
+
+
+def _white_swell_actions(nodes: List[str], start: int, end: int, ms: int,
+                         channels: Optional[List[int]] = None) -> List[Dict[str, Any]]:
+    """Generate white-channel swell actions for ``nodes``.
+
+    Each node receives one action per requested channel that starts at
+    ``start`` brightness and swells to ``end`` over ``ms`` milliseconds.  If
+    ``channels`` is ``None`` all four channels are targeted.
+    """
+
+    actions: List[Dict[str, Any]] = []
+    if channels is None:
+        channels = list(range(4))
+    for node in nodes:
+        for ch in channels:
+            actions.append(_white_swell_action(node, ch, start, end, ms))
+    return actions
+
+# Presets are organized by house and room. Each preset contains a list of
+# actions to perform when the preset is applied. Actions target a node and one
+# of its modules (ws, white, etc.). This structure intentionally mirrors the
+# existing command APIs so that presets can be expanded incrementally.
+ROOM_PRESETS: Dict[str, Dict[str, List[Dict[str, Any]]]] = {
+    # Example preset: all white channels swell from 0 → 100 over 5s
+    "del-sur": {
+        "room-1": [
+            {
+                "id": "white-swell-100",
+                "name": "White Swell 0→100",
+                "actions": _white_swell_actions(
+                    ["del-sur-room-1-node1", "node"], start=0, end=100, ms=5000
+                ),
+            }
+        ],
+        "kitchen": [],
+    },
+    "sdsu": {"kitchen": []},
+}
+
+# Kitchen presets for each house
+for house_id, node_id in (
+    ("del-sur", "del-sur-kitchen-node1"),
+    ("sdsu", "sdsu-kitchen-node1"),
+):
+    ROOM_PRESETS[house_id]["kitchen"] = [
+        {
+            "id": "swell-on",
+            "name": "Swell On",
+            "actions": _white_swell_actions([node_id], 0, 100, 5000, channels=[0, 1, 2]),
+        },
+        {
+            "id": "midnight-snack",
+            "name": "Midnight Snack",
+            "actions": [
+                _white_swell_action(node_id, 0, 0, 10, 5000),
+                _white_swell_action(node_id, 1, 0, 50, 5000),
+            ],
+        },
+        {
+            "id": "kitchens-closed",
+            "name": "Kitchen's Closed",
+            "actions": [
+                _white_swell_action(node_id, 2, 100, 255, 5000),
+                _white_swell_action(node_id, 1, 100, 0, 5000),
+                _white_swell_action(node_id, 0, 100, 0, 5000),
+            ],
+        },
+        {
+            "id": "normal",
+            "name": "Normal",
+            "actions": _white_swell_actions([node_id], 0, 150, 5000, channels=[0, 1, 2]),
+        },
+    ]
+
+
+def get_room_presets(house_id: str, room_id: str) -> List[Dict[str, Any]]:
+    """Return presets defined for ``house_id``/``room_id``."""
+    return ROOM_PRESETS.get(house_id, {}).get(room_id, [])
+
+
+def get_preset(house_id: str, room_id: str, preset_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a specific preset from ``house_id``/``room_id``."""
+    for preset in get_room_presets(house_id, room_id):
+        if preset.get("id") == preset_id:
+            return preset
+    return None
+
+
+def apply_preset(bus: MqttBus, preset: Dict[str, Any]) -> None:
+    """Apply ``preset`` by sending commands through ``bus``."""
+    for action in preset.get("actions", []):
+        node = action.get("node")
+        module = action.get("module")
+        if module == "ws":
+            bus.ws_set(
+                node,
+                int(action.get("strip", 0)),
+                action.get("effect", ""),
+                int(action.get("brightness", 0)),
+                float(action.get("speed", 1.0)),
+                action.get("params"),
+            )
+        elif module == "white":
+            bus.white_set(
+                node,
+                int(action.get("channel", 0)),
+                action.get("effect", ""),
+                int(action.get("brightness", 0)),
+                action.get("params"),
+            )
+        elif module == "ws_power":
+            bus.ws_power(node, int(action.get("strip", 0)), bool(action.get("on", False)))
+        elif module == "sensor_cooldown":
+            bus.sensor_cooldown(node, int(action.get("seconds", 30)))
+        else:
+            # Unknown action type; ignore for now.
+            continue

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException
 from .mqtt_bus import MqttBus
 from . import registry
 from .effects import WS_EFFECTS, WHITE_EFFECTS
+from .presets import get_preset, apply_preset
 
 router = APIRouter()
 BUS: Optional[MqttBus] = None
@@ -47,6 +48,15 @@ def api_add_node(house_id: str, room_id: str, payload: Dict[str, Any]):
     except KeyError:
         raise HTTPException(404, "Unknown room")
     return {"ok": True, "node": node}
+
+
+@router.post("/api/house/{house_id}/room/{room_id}/preset/{preset_id}")
+def api_apply_preset(house_id: str, room_id: str, preset_id: str):
+    preset = get_preset(house_id, room_id, preset_id)
+    if not preset:
+        raise HTTPException(404, "Unknown preset")
+    apply_preset(get_bus(), preset)
+    return {"ok": True}
 
 # ---- Node command APIs -------------------------------------------------
 

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -4,6 +4,7 @@ from fastapi.templating import Jinja2Templates
 from .config import settings
 from . import registry
 from .effects import WS_EFFECTS, WHITE_EFFECTS, WS_PARAM_DEFS, WHITE_PARAM_DEFS
+from .presets import get_room_presets
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
@@ -48,6 +49,7 @@ def room_page(request: Request, house_id: str, room_id: str):
             status_code=404,
         )
     title = f"{house.get('name', house_id)} - {room.get('name', room_id)}"
+    presets = get_room_presets(house_id, room_id)
     return templates.TemplateResponse(
         "room.html",
         {
@@ -56,6 +58,7 @@ def room_page(request: Request, house_id: str, room_id: str):
             "room": room,
             "title": title,
             "subtitle": title,
+            "presets": presets,
         },
     )
 

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -13,6 +13,16 @@
   </a>
   {% endfor %}
 </div>
+<div class="mt-8">
+  <h2 class="text-2xl font-semibold mb-4">Presets</h2>
+  <div class="flex flex-wrap gap-2">
+    {% for p in presets %}
+    <button class="preset glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400" data-id="{{ p.id }}">{{ p.name }}</button>
+    {% else %}
+    <div class="opacity-60">No presets configured.</div>
+    {% endfor %}
+  </div>
+</div>
 <script>
 document.getElementById('addNode').onclick = async () => {
   const name = prompt('New node name');
@@ -22,5 +32,14 @@ document.getElementById('addNode').onclick = async () => {
   });
   if(res.ok) location.reload(); else alert('Failed to add node');
 };
+document.querySelectorAll('.preset').forEach(btn => {
+  btn.onclick = async () => {
+    const id = btn.dataset.id;
+    const res = await fetch(`/api/house/{{ house.id }}/room/{{ room.id }}/preset/${id}`, {
+      method:'POST'
+    });
+    if(!res.ok) alert('Failed to apply preset');
+  };
+});
 </script>
 {% endblock %}

--- a/Server/docs/presets.md
+++ b/Server/docs/presets.md
@@ -1,0 +1,48 @@
+# Room Presets
+
+The server can expose room-level "presets"—named groups of actions that
+apply to every node in a room.  Presets are defined in
+`Server/app/presets.py` and are surfaced on each room page and through the
+API.
+
+## Example: swell all white channels
+
+`presets.py` includes helpers, `_white_swell_action` and
+`_white_swell_actions`, that generate the necessary MQTT commands to run the
+`swell` effect on specific white channels for a list of nodes.  Channels may be
+faded either up or down by choosing appropriate start and end brightness values.
+The example below fades all white channels from off to a brightness of 100 over
+five seconds for both nodes in `del-sur`'s `room-1`:
+
+```python
+ROOM_PRESETS = {
+    "del-sur": {
+        "room-1": [
+            {
+                "id": "white-swell-100",
+                "name": "White Swell 0→100",
+                "actions": _white_swell_actions(
+                    ["del-sur-room-1-node1", "node"], start=0, end=100, ms=5000
+                ),
+            }
+        ]
+    }
+}
+```
+
+Triggering this preset causes each node's white channels (0–3) to fade from
+brightness 0 to 100 in five seconds and hold that final level.
+
+## Kitchen presets
+
+Both houses include a `kitchen` room with several predefined presets showcasing
+more targeted swells:
+
+* **Swell On** – channels 0‑2 swell from 0 to 100 over five seconds.
+* **Midnight Snack** – channel 0 swells 0→10 and channel 1 swells 0→50.
+* **Kitchen's Closed** – channel 2 swells 100→255 while channels 0 and 1 dim
+  from 100 to 0.
+* **Normal** – channels 0‑2 swell from 0 to 150 over five seconds.
+
+Each preset is defined with `_white_swell_action` calls specifying the node,
+channel, start brightness, end brightness and duration in milliseconds.

--- a/UltraNodeV5/components/ul_white_engine/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_white_engine/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "ul_white_engine.c" "effects_white/registry.c" "effects_white/solid.c" "effects_white/breathe.c"
+idf_component_register(SRCS "ul_white_engine.c" "effects_white/registry.c" "effects_white/solid.c" "effects_white/breathe.c" "effects_white/swell.c"
                        INCLUDE_DIRS "include" "effects_white"
                        REQUIRES json driver esp_timer ul_common_effects ul_task)

--- a/UltraNodeV5/components/ul_white_engine/effects_white/effect.h
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/effect.h
@@ -12,3 +12,4 @@ typedef struct {
 } white_effect_t;
 
 const white_effect_t* ul_white_get_effects(int* count);
+int ul_white_effect_current_channel(void);

--- a/UltraNodeV5/components/ul_white_engine/effects_white/registry.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/registry.c
@@ -8,9 +8,14 @@ void white_breathe_apply_params(int ch, const cJSON* params);
 void white_solid_init(void);
 uint8_t white_solid_render(int frame_idx);
 
+void white_swell_init(void);
+uint8_t white_swell_render(int frame_idx);
+void white_swell_apply_params(int ch, const cJSON* params);
+
 static const white_effect_t effects[] = {
     {"solid", white_solid_init, white_solid_render, NULL},
     {"breathe", white_breathe_init, white_breathe_render, white_breathe_apply_params},
+    {"swell", white_swell_init, white_swell_render, white_swell_apply_params},
 };
 
 const white_effect_t* ul_white_get_effects(int* count) {

--- a/UltraNodeV5/components/ul_white_engine/effects_white/swell.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/swell.c
@@ -1,0 +1,61 @@
+#include "effect.h"
+#include "sdkconfig.h"
+#include "cJSON.h"
+
+static uint8_t s_start[4];
+static uint8_t s_end[4];
+static int s_frames[4];
+static int s_progress[4];
+
+void white_swell_init(void) {
+    for (int i = 0; i < 4; ++i) {
+        s_start[i] = 0;
+        s_end[i] = 255;
+        s_frames[i] = 1;
+        s_progress[i] = 0;
+    }
+}
+
+uint8_t white_swell_render(int frame_idx) {
+    (void)frame_idx;
+    int ch = ul_white_effect_current_channel();
+    if (ch < 0 || ch > 3) return 0;
+    if (s_progress[ch] < s_frames[ch]) {
+        float t = s_frames[ch] ? (float)s_progress[ch] / (float)s_frames[ch] : 1.0f;
+        int v = (int)(s_start[ch] + (s_end[ch] - s_start[ch]) * t + 0.5f);
+        s_progress[ch]++;
+        if (v < 0) v = 0;
+        if (v > 255) v = 255;
+        return (uint8_t)v;
+    }
+    return s_end[ch];
+}
+
+void white_swell_apply_params(int ch, const cJSON* params) {
+    if (ch < 0 || ch > 3) return;
+    if (!params || !cJSON_IsArray(params)) return;
+    const cJSON* p0 = cJSON_GetArrayItem(params, 0);
+    const cJSON* p1 = cJSON_GetArrayItem(params, 1);
+    const cJSON* p2 = cJSON_GetArrayItem(params, 2);
+    if (p0 && cJSON_IsNumber(p0)) {
+        int x = p0->valueint;
+        if (x < 0) x = 0;
+        if (x > 255) x = 255;
+        s_start[ch] = (uint8_t)x;
+    }
+    if (p1 && cJSON_IsNumber(p1)) {
+        int y = p1->valueint;
+        if (y < 0) y = 0;
+        if (y > 255) y = 255;
+        s_end[ch] = (uint8_t)y;
+    }
+    if (p2 && cJSON_IsNumber(p2)) {
+        int ms = p2->valueint;
+        if (ms < 0) ms = 0;
+        int f = (ms * CONFIG_UL_WHITE_SMOOTH_HZ) / 1000;
+        if (f < 1) f = 1;
+        s_frames[ch] = f;
+    }
+    s_progress[ch] = 0;
+}
+

--- a/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
+++ b/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
@@ -31,6 +31,7 @@ typedef struct {
 static white_ch_t s_ch[4];
 static int s_count = 0;
 static TaskHandle_t s_white_task = NULL;
+static int s_current_ch_idx = 0;
 
 static const white_effect_t* find_eff(const char* name) {
     int n=0; const white_effect_t* t = ul_white_get_effects(&n);
@@ -59,6 +60,8 @@ static void setup_ledc_channel(int ch, int gpio, int freq_hz)
     };
     ledc_channel_config(&ccfg);
 }
+
+int ul_white_effect_current_channel(void) { return s_current_ch_idx; }
 
 static void ch_init(int idx, bool enabled, int gpio, int ledc_ch, int pwm_hz) {
     s_ch[idx].enabled = enabled;
@@ -89,6 +92,7 @@ static void white_task(void*)
         for (int i=0;i<4;i++) {
             if (!s_ch[i].enabled) continue;
             uint8_t v = 0;
+            s_current_ch_idx = i;
             if (s_ch[i].eff && s_ch[i].eff->render) {
                 v = s_ch[i].eff->render(s_ch[i].frame_idx++);
             }

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -120,9 +120,10 @@ Example – flash between red and blue:
 }
 ```
 
-Registered effects: `solid` and `breathe`.
+Registered effects: `solid`, `breathe`, and `swell`.
 * `solid` – static output with no parameters.
 * `breathe` – optional params: `[period_ms]` to control the breath cycle length.
+* `swell` – params `[x, y, t_ms]` fade from brightness `x` to `y` over `t_ms` milliseconds then hold at `y`.
 
 ### Sensor and OTA commands
 


### PR DESCRIPTION
## Summary
- add presets module defining per-room preset structure and apply helper
- expose presets in room page template and FastAPI routes
- allow rooms to trigger presets via new API and UI buttons
- implement white "swell" effect with start/end brightness and duration
- document and expose params for the swell effect in server UI
- add sample preset that swells all room white channels from 0→100 over 5s
- support channel-specific swell actions and add kitchen presets (Swell On, Midnight Snack, Kitchen's Closed, Normal)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4e96df5b8832684d3e5224e384fc2