### PR TITLE
Add OTA toggle and update default firmware URL

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
+++ b/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
@@ -118,10 +118,12 @@ static void publish_status_snapshot(void) {
   cJSON_AddNumberToObject(jsens, "motion_state", ss.motion_state);
   cJSON_AddItemToObject(root, "sensors", jsens);
 
+#if CONFIG_UL_OTA_ENABLED
   // OTA (static fields from Kconfig)
   cJSON *jota = cJSON_CreateObject();
   cJSON_AddStringToObject(jota, "manifest_url", CONFIG_UL_OTA_MANIFEST_URL);
   cJSON_AddItemToObject(root, "ota", jota);
+#endif
 
   char *json = cJSON_PrintUnformatted(root);
   publish_json(topic, json);
@@ -331,11 +333,15 @@ static void on_message(esp_mqtt_event_handle_t event) {
       handle_cmd_sensor_cooldown(root);
     } else if (starts_with(sub, "sensor/motion")) {
       handle_cmd_sensor_motion(root);
-    } else if (starts_with(sub, "ota/check")) {
+    }
+#if CONFIG_UL_OTA_ENABLED
+    else if (starts_with(sub, "ota/check")) {
       ul_mqtt_publish_status();
       ul_ota_check_now(true);
       publish_status_snapshot();
-    } else if (starts_with(sub, "white/set")) {
+    }
+#endif
+    else if (starts_with(sub, "white/set")) {
       override_index_from_path(root, sub, "white/set", "channel");
       handle_cmd_white_set(root);
       ul_mqtt_publish_status();

--- a/UltraNodeV5/components/ul_ota/include/ul_ota.h
+++ b/UltraNodeV5/components/ul_ota/include/ul_ota.h
@@ -1,13 +1,21 @@
 #pragma once
+#include "sdkconfig.h"
 #include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#if CONFIG_UL_OTA_ENABLED
 void ul_ota_start(void);
 void ul_ota_stop(void);
 // Triggered via MQTT: ul/<node_id>/cmd/ota/check
 void ul_ota_check_now(bool force);
+#else
+static inline void ul_ota_start(void) {}
+static inline void ul_ota_stop(void) {}
+static inline void ul_ota_check_now(bool force) {}
+#endif
 
 #ifdef __cplusplus
 }

--- a/UltraNodeV5/components/ul_ota/ul_ota.c
+++ b/UltraNodeV5/components/ul_ota/ul_ota.c
@@ -1,4 +1,6 @@
 #include "ul_ota.h"
+
+#if CONFIG_UL_OTA_ENABLED
 #include "sdkconfig.h"
 #include "esp_https_ota.h"
 #include "esp_http_client.h"
@@ -177,3 +179,5 @@ void ul_ota_check_now(bool force)
         log_ota_error_hint(err, handle);
     }
 }
+
+#endif // CONFIG_UL_OTA_ENABLED

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -41,8 +41,12 @@ menu "MQTT"
 endmenu
 
 menu "OTA"
+    config UL_OTA_ENABLED
+        bool "Enable OTA updates"
+        default n
     config UL_OTA_MANIFEST_URL
         string "Manifest URL"
+        default "https://lights.evm100.org/firmware/UltraLights/<node-id>/latest.bin"
     config UL_OTA_BEARER_TOKEN
         string "Bearer token"
     config UL_OTA_HMAC_SECRET

--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -35,7 +35,9 @@ static void service_manager_task(void *ctx) {
           ul_ws_engine_start();    // 60 FPS LED engine
           ul_white_engine_start(); // 200 Hz smoothing
           ul_sensors_start();
+#if CONFIG_UL_OTA_ENABLED
           ul_ota_start(); // periodic + MQTT trigger
+#endif
           s_services_running = true;
         }
       } else {
@@ -44,7 +46,9 @@ static void service_manager_task(void *ctx) {
           ul_ws_engine_stop();
           ul_white_engine_stop();
           ul_sensors_stop();
+#if CONFIG_UL_OTA_ENABLED
           ul_ota_stop();
+#endif
           s_services_running = false;
         }
         ESP_LOGW(TAG, "Network disconnected");

--- a/UltraNodeV5/sdkconfig
+++ b/UltraNodeV5/sdkconfig
@@ -526,7 +526,8 @@ CONFIG_UL_MQTT_PASS="ulpwd"
 #
 # OTA
 #
-CONFIG_UL_OTA_MANIFEST_URL="https://lights.evm100.org/firmware/UltraLights/living-room-1/latest.bin"
+CONFIG_UL_OTA_ENABLED=n
+CONFIG_UL_OTA_MANIFEST_URL="https://lights.evm100.org/firmware/UltraLights/<node-id>/latest.bin"
 CONFIG_UL_OTA_BEARER_TOKEN=""
 CONFIG_UL_OTA_HMAC_SECRET=""
 CONFIG_UL_OTA_INTERVAL_S=3600

--- a/UltraNodeV5/sdkconfig.defaults
+++ b/UltraNodeV5/sdkconfig.defaults
@@ -14,7 +14,8 @@ CONFIG_UL_MQTT_USER="uluser"
 CONFIG_UL_MQTT_PASS="ulpwd"
 
 # ---- OTA ----
-CONFIG_UL_OTA_MANIFEST_URL="https://lights.evm100.org/manifest.json"
+CONFIG_UL_OTA_ENABLED=n
+CONFIG_UL_OTA_MANIFEST_URL="https://lights.evm100.org/firmware/UltraLights/<node-id>/latest.bin"
 CONFIG_UL_OTA_BEARER_TOKEN="changeme-token"
 CONFIG_UL_OTA_HMAC_SECRET="changeme-hmac"
 CONFIG_UL_OTA_INTERVAL_S=3600

--- a/UltraNodeV5/sdkconfig.old
+++ b/UltraNodeV5/sdkconfig.old
@@ -526,7 +526,8 @@ CONFIG_UL_MQTT_PASS="ulpwd"
 #
 # OTA
 #
-CONFIG_UL_OTA_MANIFEST_URL="https://lights.evm100.org/firmware/UltraLights/node01/latest.bin"
+CONFIG_UL_OTA_ENABLED=n
+CONFIG_UL_OTA_MANIFEST_URL="https://lights.evm100.org/firmware/UltraLights/<node-id>/latest.bin"
 CONFIG_UL_OTA_BEARER_TOKEN=""
 CONFIG_UL_OTA_HMAC_SECRET=""
 CONFIG_UL_OTA_INTERVAL_S=3600


### PR DESCRIPTION
## Summary
- add `UL_OTA_ENABLED` menuconfig option (default off) and update default OTA firmware URL
- guard OTA code paths so firmware builds when OTA is disabled

## Testing
- `idf.py --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c6a448445483269d2293c56f98ddb9