### PR TITLE
Add modern rainbow WS effect

### DIFF
--- a/Server/app/effects.py
+++ b/Server/app/effects.py
@@ -40,6 +40,9 @@ WS_PARAM_DEFS = {
         {"type": "slider", "label": "Wavelength", "min": 1, "max": 255, "value": 32},
     ],
 
+    # Modern rainbow – fixed 80 pixel cycle
+    "modern_rainbow": [],
+
     # Triple wave – three sets of color, wavelength and frequency
     "triple_wave": [
         {"type": "color", "label": "Wave 1 Color"},

--- a/Server/app/templates/modules/effect.html
+++ b/Server/app/templates/modules/effect.html
@@ -3,6 +3,7 @@
   <select id="effect" class="w-full bg-slate-900 border border-slate-700 rounded-lg p-2">
     <option value="static">Static</option>
     <option value="rainbow">Rainbow</option>
+    <option value="modern_rainbow">Modern Rainbow</option>
     <option value="theater">Theater Chase</option>
     <option value="fire">Fire</option>
     <option value="wave">Wave</option>

--- a/UltraNodeV5/components/ul_ws_engine/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_ws_engine/CMakeLists.txt
@@ -1,6 +1,7 @@
 idf_component_register(
     SRCS "ul_ws_engine.c" "effects_ws/registry.c"
          "effects_ws/solid.c" "effects_ws/breathe.c" "effects_ws/rainbow.c"
+         "effects_ws/modern_rainbow.c"
          "effects_ws/twinkle.c" "effects_ws/theater_chase.c" "effects_ws/wipe.c"
          "effects_ws/gradient_scroll.c" "effects_ws/triple_wave.c" "effects_ws/flash.c" "effects_ws/spacewaves.c"
     INCLUDE_DIRS "include" "effects_ws"

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/modern_rainbow.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/modern_rainbow.c
@@ -1,0 +1,35 @@
+#include "effect.h"
+#include "ul_ws_engine.h"
+
+static void hsv_to_rgb(uint8_t h, uint8_t *r, uint8_t *g, uint8_t *b) {
+    uint8_t region = h / 43;
+    uint8_t remainder = (h - region * 43) * 6;
+
+    uint8_t v = 255;
+    uint8_t p = 0;
+    uint8_t q = (uint8_t)(255 - ((uint16_t)remainder * 255 >> 8));
+    uint8_t t = (uint8_t)((uint16_t)remainder * 255 >> 8);
+
+    switch (region) {
+        case 0: *r = v; *g = t; *b = p; break;
+        case 1: *r = q; *g = v; *b = p; break;
+        case 2: *r = p; *g = v; *b = t; break;
+        case 3: *r = p; *g = q; *b = v; break;
+        case 4: *r = t; *g = p; *b = v; break;
+        default: *r = v; *g = p; *b = q; break;
+    }
+}
+
+void modern_rainbow_init(void) { }
+
+void modern_rainbow_render(uint8_t *frame_rgb, int pixels, int frame_idx) {
+    const int cycle = 80;
+    for (int i = 0; i < pixels; ++i) {
+        uint8_t hue = (uint8_t)((i * 256 / cycle + frame_idx) & 0xFF);
+        uint8_t r, g, b;
+        hsv_to_rgb(hue, &r, &g, &b);
+        frame_rgb[3 * i + 0] = r;
+        frame_rgb[3 * i + 1] = g;
+        frame_rgb[3 * i + 2] = b;
+    }
+}

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/registry.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/registry.c
@@ -4,6 +4,7 @@
 void solid_init(void);        void solid_render(uint8_t*,int,int);        void solid_apply_params(int,const cJSON*);
 void breathe_init(void);      void breathe_render(uint8_t*,int,int);
 void rainbow_init(void);      void rainbow_render(uint8_t*,int,int);      void rainbow_apply_params(int,const cJSON*);
+void modern_rainbow_init(void); void modern_rainbow_render(uint8_t*,int,int);
 void twinkle_init(void);      void twinkle_render(uint8_t*,int,int);
 void theater_chase_init(void);void theater_chase_render(uint8_t*,int,int);
 void wipe_init(void);         void wipe_render(uint8_t*,int,int);
@@ -17,6 +18,7 @@ static const ws_effect_t effects[] = {
     {"solid", solid_init, solid_render, solid_apply_params},
     {"breathe", breathe_init, breathe_render, NULL},
     {"rainbow", rainbow_init, rainbow_render, rainbow_apply_params},
+    {"modern_rainbow", modern_rainbow_init, modern_rainbow_render, NULL},
     {"twinkle", twinkle_init, twinkle_render, NULL},
     {"theater_chase", theater_chase_init, theater_chase_render, NULL},
     {"wipe", wipe_init, wipe_render, NULL},

--- a/webapp/templates/node.html
+++ b/webapp/templates/node.html
@@ -24,6 +24,7 @@
             <option value="solid">solid</option>
             <option value="breathe">breathe</option>
             <option value="rainbow">rainbow</option>
+            <option value="modern_rainbow">modern_rainbow</option>
             <option value="twinkle">twinkle</option>
             <option value="theater_chase">theater_chase</option>
             <option value="wipe">wipe</option>


### PR DESCRIPTION
## Summary
- add `modern_rainbow` effect with smooth 80‑pixel hue cycle
- expose effect to server and UI

## Testing
- `python -m py_compile Server/app/effects.py`
- `gcc -c UltraNodeV5/components/ul_ws_engine/effects_ws/modern_rainbow.c -I UltraNodeV5/components/ul_ws_engine/effects_ws -I UltraNodeV5/components/ul_ws_engine/include -I UltraNodeV5/components/ul_common_effects/include`


------
https://chatgpt.com/codex/tasks/task_e_68c6a49b204c8326b6f66e92a9339e00