### PR TITLE
Remove OTA enable flag and auto-check option

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
+++ b/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
@@ -118,12 +118,10 @@ static void publish_status_snapshot(void) {
   cJSON_AddNumberToObject(jsens, "motion_state", ss.motion_state);
   cJSON_AddItemToObject(root, "sensors", jsens);
 
-#if CONFIG_UL_OTA_ENABLED
   // OTA (static fields from Kconfig)
   cJSON *jota = cJSON_CreateObject();
   cJSON_AddStringToObject(jota, "manifest_url", CONFIG_UL_OTA_MANIFEST_URL);
   cJSON_AddItemToObject(root, "ota", jota);
-#endif
 
   char *json = cJSON_PrintUnformatted(root);
   publish_json(topic, json);

--- a/UltraNodeV5/components/ul_ota/include/ul_ota.h
+++ b/UltraNodeV5/components/ul_ota/include/ul_ota.h
@@ -8,12 +8,8 @@ extern "C" {
 
 // Triggered via MQTT: ul/<node_id>/cmd/ota/check
 void ul_ota_check_now(bool force);
-#else
-static inline void ul_ota_start(void) {}
-static inline void ul_ota_stop(void) {}
-static inline void ul_ota_check_now(bool force) {}
-#endif
 
 #ifdef __cplusplus
 }
 #endif
+

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -41,9 +41,6 @@ menu "MQTT"
 endmenu
 
 menu "OTA"
-    config UL_OTA_AUTO_CHECK
-        bool "Enable periodic auto-check"
-        default n
     config UL_OTA_MANIFEST_URL
         string "Manifest URL"
         default "https://lights.evm100.org/firmware/UltraLights/<node-id>/latest.bin"


### PR DESCRIPTION
## Summary
- Simplify OTA header by removing unused enable stubs
- Always include OTA manifest details in MQTT status
- Drop periodic OTA auto-check config from Kconfig

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72d0748f48326a7b7d40dc75c63cb