### PR TITLE
Pin service manager task to networking core

### DIFF
--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -10,6 +10,7 @@
 
 #include "ul_core.h"
 #include "ul_mqtt.h"
+#include "ul_task.h"
 #include "ul_white_engine.h"
 #include "ul_ws_engine.h"
 #if CONFIG_UL_PIR_ENABLED
@@ -76,8 +77,8 @@ void app_main(void) {
   ESP_ERROR_CHECK(esp_netif_init());
   ESP_ERROR_CHECK(esp_event_loop_create_default());
 
-  xTaskCreate(service_manager_task, "svc_mgr", 4096, NULL, 5,
-              &s_service_task);
+  ul_task_create(service_manager_task, "svc_mgr", 4096, NULL, 5,
+                 &s_service_task, 0);
   ul_core_wifi_start();
   ul_core_register_connectivity_cb(connectivity_cb, NULL);
   bool connected = ul_core_wait_for_ip(portMAX_DELAY);


### PR DESCRIPTION
## Summary
- ensure service manager task runs on the networking core by using `ul_task_create` pinned to core 0
- include `ul_task.h` for new task creation helper

## Testing
- `cd UltraNodeV5 && idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c790445a3483269a4a443bba15b108