### PR TITLE
Pin SNTP sync task to core 0

### DIFF
--- a/UltraNodeV5/components/ul_core/ul_core.c
+++ b/UltraNodeV5/components/ul_core/ul_core.c
@@ -10,6 +10,7 @@
 #include "esp_system.h"
 #include "freertos/event_groups.h"
 #include "freertos/task.h"
+#include "ul_task.h"
 #include <string.h>
 #include <time.h>
 
@@ -229,5 +230,6 @@ void ul_core_sntp_start(void) {
     vTaskDelay(pdMS_TO_TICKS(1000));
   }
   ESP_LOGI(TAG, "Time sync: %ld", now);
-  xTaskCreate(sntp_sync_task, "sntp_sync", 2048, NULL, tskIDLE_PRIORITY, NULL);
+  ul_task_create(sntp_sync_task, "sntp_sync", 2048, NULL, tskIDLE_PRIORITY,
+                 NULL, 0);
 }


### PR DESCRIPTION
## Summary
- include ul_task.h in ul_core to use task abstraction
- create sntp_sync_task with ul_task_create to pin it to core 0

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c79044e4ec8326ac481e8140369677