### PR TITLE
fix: include chip info header and add ul_task dependency

### DIFF
--- a/UltraNodeV5/components/ul_core/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_core/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(SRCS "ul_core.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES nvs_flash esp_wifi esp_event esp_netif esp_timer lwip)
+                       REQUIRES nvs_flash esp_wifi esp_event esp_netif esp_timer lwip
+                       PRIV_REQUIRES ul_task)

--- a/UltraNodeV5/components/ul_task/ul_task.c
+++ b/UltraNodeV5/components/ul_task/ul_task.c
@@ -1,4 +1,5 @@
 #include "esp_system.h"
+#include "esp_chip_info.h"
 #include "ul_task.h"
 
 uint8_t ul_core_count;


### PR DESCRIPTION
## Summary
- include esp_chip_info.h in ul_task
- add ul_task to ul_core's private dependencies

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c792584c9483268a9729d5e8173b37