### PR TITLE
Handle LEDC speed mode absence on newer targets

### DIFF
--- a/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
+++ b/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
@@ -12,8 +12,10 @@
 
 #if CONFIG_UL_IS_ESP32C3
 #define UL_LEDC_SPEED_MODE LEDC_LOW_SPEED_MODE
-#else
+#elif defined(LEDC_HIGH_SPEED_MODE)
 #define UL_LEDC_SPEED_MODE LEDC_HIGH_SPEED_MODE
+#else
+#define UL_LEDC_SPEED_MODE LEDC_LOW_SPEED_MODE
 #endif
 
 static const char* TAG = "ul_white";


### PR DESCRIPTION
## Summary
- fall back to the LEDC low speed mode when the high speed mode enum is unavailable
- retain the ESP32-C3 specific handling while supporting newer targets like the ESP32-S3

## Testing
- idf.py build (fails: command not found in container)


------
https://chatgpt.com/codex/tasks/task_e_68c89020a6988326ab39d25fa20eafee