### PR TITLE
Remove unused common effects helpers

### DIFF
--- a/UltraNodeV5/components/ul_common_effects/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_common_effects/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "easing.c" "gamma.c" "transitions.c"
+idf_component_register(SRCS "gamma.c"
                        INCLUDE_DIRS "include")

--- a/UltraNodeV5/components/ul_common_effects/easing.c
+++ b/UltraNodeV5/components/ul_common_effects/easing.c
@@ -1,3 +1,0 @@
-#include "ul_common_effects.h"
-#include <math.h>
-float ul_ease_in_out(float t) { return 0.5f*(1.0f - cosf((float)M_PI*t)); }

--- a/UltraNodeV5/components/ul_common_effects/include/ul_common_effects.h
+++ b/UltraNodeV5/components/ul_common_effects/include/ul_common_effects.h
@@ -1,6 +1,4 @@
 #pragma once
 #include <stdint.h>
 
-float ul_ease_in_out(float t);
 uint8_t ul_gamma8(uint8_t x);
-void ul_apply_transition(uint8_t* dst, const uint8_t* src_from, const uint8_t* src_to, int count, float alpha);

--- a/UltraNodeV5/components/ul_common_effects/transitions.c
+++ b/UltraNodeV5/components/ul_common_effects/transitions.c
@@ -1,9 +1,0 @@
-#include "ul_common_effects.h"
-void ul_apply_transition(uint8_t* dst, const uint8_t* a, const uint8_t* b, int count, float alpha) {
-    for (int i=0;i<count;i++) {
-        int v = (int)(a[i]*(1.0f-alpha) + b[i]*alpha + 0.5f);
-        if (v<0) v=0;
-	if (v>255) v=255;
-        dst[i]=(uint8_t)v;
-    }
-}


### PR DESCRIPTION
## Summary
- remove unused easing and transition helper sources from ul_common_effects
- drop the obsolete prototypes from the public header
- update the component registration to build only the active gamma module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c922fec32c83268852a9d509a3265b