### PR TITLE
Add configurable WS2812 backend for ESP32-C3 support

### DIFF
--- a/UltraNodeV5/components/ul_ws_engine/ul_ws_engine.c
+++ b/UltraNodeV5/components/ul_ws_engine/ul_ws_engine.c
@@ -6,10 +6,12 @@
 #include "ul_task.h"
 #include "ul_core.h"
 #include "esp_log.h"
+#include "esp_heap_caps.h"
 #include "led_strip.h"
-#include "led_strip_spi.h"
 #include "led_strip_types.h"
+#if CONFIG_UL_WS_BACKEND_SPI
 #include "driver/spi_master.h"
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -93,30 +95,61 @@ static const ws_effect_t* find_effect_by_name(const char* name) {
 }
 
 static void init_strip(int idx, int gpio, int pixels, bool enabled) {
-    if (!enabled) { s_strips[idx].pixels = 0; return; }
+    if (!enabled) {
+        s_strips[idx].pixels = 0;
+        s_strips[idx].handle = NULL;
+        s_strips[idx].frame = NULL;
+        return;
+    }
+
     led_strip_config_t strip_config = {
         .strip_gpio_num = gpio,
         .max_leds = pixels,
         .led_model = LED_MODEL_WS2812,
-        .flags.invert_out = false
+        .flags.invert_out = false,
     };
-    led_strip_spi_config_t spi_config = {
+
+#if CONFIG_UL_WS_BACKEND_SPI
+    led_strip_spi_config_t backend_config = {
         .clk_src = SPI_CLK_SRC_DEFAULT,
-        .spi_bus = 
+        .spi_bus =
 #if CONFIG_UL_IS_ESP32C3
             SPI2_HOST,
 #else
             (idx == 0 ? SPI2_HOST : SPI3_HOST),
 #endif
         .flags = {
-            .with_dma = true,
+            .with_dma = CONFIG_UL_WS_SPI_USE_DMA,
         },
     };
-    ESP_ERROR_CHECK(led_strip_new_spi_device(&strip_config, &spi_config, &s_strips[idx].handle));
+    ESP_ERROR_CHECK(led_strip_new_spi_device(&strip_config, &backend_config,
+                                             &s_strips[idx].handle));
+#elif CONFIG_UL_WS_BACKEND_RMT
+    led_strip_rmt_config_t backend_config = {
+        .clk_src = RMT_CLK_SRC_DEFAULT,
+        .resolution_hz = 10 * 1000 * 1000,
+        .mem_block_symbols = 0,
+        .flags = {
+            .with_dma = 0,
+        },
+    };
+    ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &backend_config,
+                                             &s_strips[idx].handle));
+#else
+#error "Unsupported WS backend configuration"
+#endif
+
     led_strip_clear(s_strips[idx].handle);
     s_strips[idx].pixels = pixels;
-    s_strips[idx].frame = (uint8_t*)heap_caps_malloc(pixels*3, MALLOC_CAP_8BIT);
-    memset(s_strips[idx].frame, 0, pixels*3);
+    s_strips[idx].frame = (uint8_t *)heap_caps_calloc(pixels * 3, sizeof(uint8_t),
+                                                      MALLOC_CAP_8BIT);
+    if (!s_strips[idx].frame) {
+        ESP_LOGE(TAG, "Failed to allocate frame buffer for strip %d", idx);
+        led_strip_del(s_strips[idx].handle);
+        s_strips[idx].handle = NULL;
+        s_strips[idx].pixels = 0;
+        return;
+    }
     // defaults
     int n=0; const ws_effect_t* tbl = ul_ws_get_effects(&n);
     s_strips[idx].eff = &tbl[0]; // solid
@@ -203,12 +236,8 @@ void ul_ws_engine_start(void)
 #else
     init_strip(0, 0, 0, false);
 #endif
-#if !CONFIG_UL_IS_ESP32C3
 #if CONFIG_UL_WS1_ENABLED
     init_strip(1, CONFIG_UL_WS1_GPIO, CONFIG_UL_WS1_PIXELS, true);
-#else
-    init_strip(1, 0, 0, false);
-#endif
 #else
     init_strip(1, 0, 0, false);
 #endif

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -3,7 +3,12 @@ menu "UltraLights Configuration"
 menu "System"
     config UL_IS_ESP32C3
         bool "Target is ESP32-C3"
+        default y if IDF_TARGET_ESP32C3
         default n
+        help
+            Enable this option when building the firmware for ESP32-C3 based
+            hardware. It is automatically selected when the ESP-IDF target is
+            set to esp32c3 via `idf.py set-target esp32c3`.
 endmenu
 
 menu "Node / Network"
@@ -100,6 +105,33 @@ menu "Sensors"
 endmenu
 
 menu "WS2812 Strips"
+    choice UL_WS_BACKEND
+        prompt "WS2812 driver backend"
+        default UL_WS_BACKEND_SPI if !UL_IS_ESP32C3
+        default UL_WS_BACKEND_RMT
+        help
+            Select the peripheral used to refresh WS2812 LED strips. The SPI
+            backend provides the highest throughput on multi-bus targets such
+            as ESP32-S3. The RMT backend is broadly compatible, including with
+            ESP32-C3, and should be selected if the target lacks a spare SPI
+            host.
+        config UL_WS_BACKEND_SPI
+            bool "SPI"
+        config UL_WS_BACKEND_RMT
+            bool "RMT"
+    endchoice
+
+    config UL_WS_SPI_USE_DMA
+        bool "Use SPI DMA for WS2812 refresh"
+        depends on UL_WS_BACKEND_SPI
+        default y if !UL_IS_ESP32C3
+        default n
+        help
+            Enable DMA when driving WS2812 strips via the SPI backend. This
+            improves refresh throughput on targets that offer dedicated DMA
+            channels (e.g. ESP32-S3). Disable on targets where SPI DMA is not
+            available.
+
     menu "Strip 0"
         config UL_WS0_ENABLED
             bool "Enabled"
@@ -114,6 +146,7 @@ menu "WS2812 Strips"
     menu "Strip 1"
         config UL_WS1_ENABLED
             bool "Enabled"
+            depends on !(UL_IS_ESP32C3 && UL_WS_BACKEND_SPI)
             default n
         config UL_WS1_GPIO
             int "GPIO"


### PR DESCRIPTION
## Summary
- automatically enable the ESP32-C3 Kconfig flag when the IDF target is esp32c3 and add menu options to select the WS2812 backend and SPI DMA usage
- update the WS2812 engine to instantiate either the SPI or RMT driver based on the new Kconfig choice, with safer frame allocation and relaxed second-strip gating

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9229d3f4883268f85854cd3fa6e15