### PR TITLE
Remove MQTT strip power command

### DIFF
--- a/Server/app/mqtt_bus.py
+++ b/Server/app/mqtt_bus.py
@@ -48,10 +48,6 @@ class MqttBus:
         # firmware that still expects it.
         self.pub(topic_cmd(node_id, f"ws/set/{strip}"), msg, retain=True)
 
-    def ws_power(self, node_id: str, strip: int, on: bool):
-        msg = {"strip": int(strip), "on": bool(on)}
-        self.pub(topic_cmd(node_id, "ws/power"), msg)
-
     # ---- White channel commands ----
     def white_set(
         self,
@@ -90,6 +86,6 @@ class MqttBus:
         for _, _, n in registry.iter_nodes():
             nid = n["id"]
             for i in range(4):
-                self.ws_power(nid, i, False)
+                self.ws_set(nid, i, "solid", 255, 1.0, [0, 0, 0])
                 self.white_set(nid, i, "solid", 0)
 

--- a/Server/app/presets.py
+++ b/Server/app/presets.py
@@ -212,8 +212,6 @@ def apply_preset(bus: MqttBus, preset: Dict[str, Any]) -> None:
                 int(action.get("brightness", 0)),
                 action.get("params"),
             )
-        elif module == "ws_power":
-            bus.ws_power(node, int(action.get("strip", 0)), bool(action.get("on", False)))
         elif module == "sensor_cooldown":
             bus.sensor_cooldown(node, int(action.get("seconds", 30)))
         else:

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -127,19 +127,6 @@ def api_ws_set(node_id: str, payload: Dict[str, Any]):
     get_bus().ws_set(node_id, strip, effect, brightness, speed, params)
     return {"ok": True}
 
-@router.post("/api/node/{node_id}/ws/power")
-def api_ws_power(node_id: str, payload: Dict[str, Any]):
-    _valid_node(node_id)
-    try:
-        strip = int(payload.get("strip"))
-    except Exception:
-        raise HTTPException(400, "invalid strip")
-    if not 0 <= strip < 4:
-        raise HTTPException(400, "invalid strip")
-    on = bool(payload.get("on", True))
-    get_bus().ws_power(node_id, strip, on)
-    return {"ok": True}
-
 @router.post("/api/node/{node_id}/white/set")
 def api_white_set(node_id: str, payload: Dict[str, Any]):
     _valid_node(node_id)

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -84,11 +84,11 @@ function sendCmd(){
 
 document.getElementById('wsSet').onclick=sendCmd;
 
-document.getElementById('wsOn').onclick=async()=>{
-  const s=parseInt(stripEl.value,10);if(Number.isNaN(s)){alert('Invalid strip');return;}await post(`/api/node/{{ node.id }}/ws/power`,{strip:s,on:true});
-};
+document.getElementById('wsOn').onclick=sendCmd;
 document.getElementById('wsOff').onclick=async()=>{
-  const s=parseInt(stripEl.value,10);if(Number.isNaN(s)){alert('Invalid strip');return;}await post(`/api/node/{{ node.id }}/ws/power`,{strip:s,on:false});
+  const s=parseInt(stripEl.value,10);
+  if(Number.isNaN(s)){alert('Invalid strip');return;}
+  await post(`/api/node/{{ node.id }}/ws/set`,{strip:s,effect:'solid',brightness:255,speed:1.0,params:[0,0,0]});
 };
 </script>
 

--- a/UltraNodeV5/components/ul_ws_engine/include/ul_ws_engine.h
+++ b/UltraNodeV5/components/ul_ws_engine/include/ul_ws_engine.h
@@ -15,7 +15,6 @@ bool ul_ws_set_effect(int strip, const char* name);     // returns true if found
 void ul_ws_set_solid_rgb(int strip, uint8_t r, uint8_t g, uint8_t b);
 void ul_ws_get_solid_rgb(int strip, uint8_t* r, uint8_t* g, uint8_t* b);
 void ul_ws_set_brightness(int strip, uint8_t bri);      // 0..255
-void ul_ws_power(int strip, bool on);
 
 // Utility: convert "#RRGGBB" string to RGB components
 bool ul_ws_hex_to_rgb(const char* hex, uint8_t* r, uint8_t* g, uint8_t* b);
@@ -23,7 +22,6 @@ bool ul_ws_hex_to_rgb(const char* hex, uint8_t* r, uint8_t* g, uint8_t* b);
 // Status API
 typedef struct {
     bool enabled;
-    bool power;
     char effect[24];
     uint8_t brightness;
     int pixels;

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -106,11 +106,8 @@ Example – flash between red and blue:
 }
 ```
 
-`ul/<node-id>/cmd/ws/power`
-
-```json
-{ "strip": <int>, "on": <bool> }
-```
+To turn a strip off, publish a `ws/set` command with the `solid` effect and
+RGB parameters `[0, 0, 0]`.
 
 ### White PWM channels (`white`)
 

--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -28,10 +28,6 @@ static void service_manager_task(void *ctx) {
   while (true) {
     if (xTaskNotifyWait(0, 0, &value, portMAX_DELAY) == pdTRUE) {
       bool connected = value;
-      int strips = ul_ws_get_strip_count();
-      for (int i = 0; i < strips; ++i) {
-        ul_ws_power(i, connected);
-      }
       if (connected) {
         if (!s_services_running) {
           ul_mqtt_start();


### PR DESCRIPTION
## Summary
- drop the ws strip power flag from the firmware and always render frames, defaulting to a solid black color when unconfigured
- remove the cmd/ws/power MQTT handler and update the server API, presets, and UI to use ws/set with a solid black payload when turning strips off
- document the new approach in the MQTT guide and keep status snapshots free of the legacy power field

## Testing
- python -m compileall Server

------
https://chatgpt.com/codex/tasks/task_e_68c92bbd6d4c8326b23cddfe3e69a189