### PR TITLE
Guard RGB engine when strips are disabled

### DIFF
--- a/UltraNodeV5/components/ul_rgb_engine/effects_rgb/color_swell.c
+++ b/UltraNodeV5/components/ul_rgb_engine/effects_rgb/color_swell.c
@@ -1,5 +1,8 @@
-#include "effect.h"
 #include "sdkconfig.h"
+
+#if CONFIG_UL_RGB0_ENABLED || CONFIG_UL_RGB1_ENABLED || CONFIG_UL_RGB2_ENABLED || CONFIG_UL_RGB3_ENABLED
+
+#include "effect.h"
 #include "cJSON.h"
 #include <stdbool.h>
 
@@ -99,3 +102,5 @@ void rgb_color_swell_render(int strip, uint8_t out_rgb[3], int frame_idx) {
     out_rgb[1] = (uint8_t)((s_color[strip][1] * value) / 255);
     out_rgb[2] = (uint8_t)((s_color[strip][2] * value) / 255);
 }
+
+#endif

--- a/UltraNodeV5/components/ul_rgb_engine/effects_rgb/registry.c
+++ b/UltraNodeV5/components/ul_rgb_engine/effects_rgb/registry.c
@@ -1,5 +1,8 @@
+#include "sdkconfig.h"
 #include "effect.h"
 #include <stddef.h>
+
+#if CONFIG_UL_RGB0_ENABLED || CONFIG_UL_RGB1_ENABLED || CONFIG_UL_RGB2_ENABLED || CONFIG_UL_RGB3_ENABLED
 
 void rgb_solid_init(void);
 void rgb_solid_render(int strip, uint8_t out_rgb[3], int frame_idx);
@@ -17,3 +20,12 @@ const rgb_effect_t* ul_rgb_get_effects(int* count) {
     if (count) *count = sizeof(effects) / sizeof(effects[0]);
     return effects;
 }
+
+#else
+
+const rgb_effect_t* ul_rgb_get_effects(int* count) {
+    if (count) *count = 0;
+    return NULL;
+}
+
+#endif

--- a/UltraNodeV5/components/ul_rgb_engine/effects_rgb/solid.c
+++ b/UltraNodeV5/components/ul_rgb_engine/effects_rgb/solid.c
@@ -1,3 +1,7 @@
+#include "sdkconfig.h"
+
+#if CONFIG_UL_RGB0_ENABLED || CONFIG_UL_RGB1_ENABLED || CONFIG_UL_RGB2_ENABLED || CONFIG_UL_RGB3_ENABLED
+
 #include "effect.h"
 #include "ul_rgb_engine.h"
 #include "cJSON.h"
@@ -28,3 +32,5 @@ void rgb_solid_render(int strip, uint8_t out_rgb[3], int frame_idx) {
     out_rgb[1] = g;
     out_rgb[2] = b;
 }
+
+#endif

--- a/UltraNodeV5/components/ul_rgb_engine/ul_rgb_engine.c
+++ b/UltraNodeV5/components/ul_rgb_engine/ul_rgb_engine.c
@@ -1,5 +1,54 @@
 #include "ul_rgb_engine.h"
 #include "sdkconfig.h"
+
+#if !(CONFIG_UL_RGB0_ENABLED || CONFIG_UL_RGB1_ENABLED || CONFIG_UL_RGB2_ENABLED || CONFIG_UL_RGB3_ENABLED)
+
+#include <string.h>
+
+int ul_rgb_effect_current_strip(void) { return -1; }
+
+void ul_rgb_engine_start(void) {}
+
+void ul_rgb_engine_stop(void) {}
+
+void ul_rgb_apply_json(cJSON* root) { (void)root; }
+
+bool ul_rgb_set_effect(int strip, const char* name) {
+    (void)strip;
+    (void)name;
+    return false;
+}
+
+bool ul_rgb_set_brightness(int strip, uint8_t bri) {
+    (void)strip;
+    (void)bri;
+    return false;
+}
+
+void ul_rgb_set_solid_rgb(int strip, uint8_t r, uint8_t g, uint8_t b) {
+    (void)strip;
+    (void)r;
+    (void)g;
+    (void)b;
+}
+
+void ul_rgb_get_solid_rgb(int strip, uint8_t* r, uint8_t* g, uint8_t* b) {
+    (void)strip;
+    if (r) *r = 0;
+    if (g) *g = 0;
+    if (b) *b = 0;
+}
+
+int ul_rgb_get_strip_count(void) { return 0; }
+
+bool ul_rgb_get_status(int strip, ul_rgb_strip_status_t* out) {
+    (void)strip;
+    if (out) memset(out, 0, sizeof(*out));
+    return false;
+}
+
+#else
+
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/ledc.h"
@@ -317,3 +366,5 @@ bool ul_rgb_get_status(int strip, ul_rgb_strip_status_t* out) {
     }
     return true;
 }
+
+#endif  // any RGB strips enabled


### PR DESCRIPTION
## Summary
- provide stub implementations for the RGB engine when all menuconfig RGB strips are disabled so nothing is built for them
- guard the RGB effect sources so they are only compiled when at least one strip is enabled

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9dc3de3808326818d5c9c55d7b724