### PR TITLE
Add per-channel brightness locks for node modules

### DIFF
--- a/Server/app/brightness_limits.py
+++ b/Server/app/brightness_limits.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Dict, Optional
+
+from .config import settings
+
+
+class BrightnessLimitsStore:
+    """Persistence helper for per-channel brightness limits."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._lock = threading.RLock()
+        self._data = self._load()
+
+    def _load(self) -> Dict[str, Dict[str, Dict[str, int]]]:
+        if not self.path.exists():
+            return {}
+        try:
+            payload = json.loads(self.path.read_text())
+        except Exception:
+            return {}
+
+        data: Dict[str, Dict[str, Dict[str, int]]] = {}
+        if not isinstance(payload, dict):
+            return data
+
+        for node_id, modules in payload.items():
+            if not isinstance(modules, dict):
+                continue
+            node_key = str(node_id)
+            node_limits: Dict[str, Dict[str, int]] = {}
+            for module, channels in modules.items():
+                if not isinstance(channels, dict):
+                    continue
+                module_limits: Dict[str, int] = {}
+                for channel, value in channels.items():
+                    if not isinstance(value, (int, float)):
+                        continue
+                    limit = int(value)
+                    if 0 <= limit <= 255:
+                        module_limits[str(channel)] = limit
+                if module_limits:
+                    node_limits[str(module)] = module_limits
+            if node_limits:
+                data[node_key] = node_limits
+        return data
+
+    def _save_locked(self) -> None:
+        serialized = json.dumps(self._data, indent=2)
+        tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path.write_text(serialized)
+        tmp_path.replace(self.path)
+
+    def save(self) -> None:
+        with self._lock:
+            self._save_locked()
+
+    def get_limit(self, node_id: str, module: str, channel: int) -> Optional[int]:
+        channel_key = str(channel)
+        with self._lock:
+            module_limits = (
+                self._data.get(str(node_id), {}).get(str(module), {})
+            )
+            value = module_limits.get(channel_key)
+            if value is None:
+                return None
+            return int(value)
+
+    def set_limit(
+        self, node_id: str, module: str, channel: int, limit: Optional[int]
+    ) -> Optional[int]:
+        node_key = str(node_id)
+        module_key = str(module)
+        channel_key = str(channel)
+        with self._lock:
+            if limit is None:
+                node_limits = self._data.get(node_key)
+                if not node_limits:
+                    return None
+                module_limits = node_limits.get(module_key)
+                if not module_limits or channel_key not in module_limits:
+                    return None
+                module_limits.pop(channel_key, None)
+                if not module_limits:
+                    node_limits.pop(module_key, None)
+                if not node_limits:
+                    self._data.pop(node_key, None)
+                self._save_locked()
+                return None
+
+            limit = max(0, min(255, int(limit)))
+            node_limits = self._data.setdefault(node_key, {})
+            module_limits = node_limits.setdefault(module_key, {})
+            module_limits[channel_key] = limit
+            self._save_locked()
+            return limit
+
+    def get_limits_for_node(self, node_id: str) -> Dict[str, Dict[str, int]]:
+        with self._lock:
+            modules = self._data.get(str(node_id))
+            if not modules:
+                return {}
+            return {
+                module: dict(channels)
+                for module, channels in modules.items()
+            }
+
+
+brightness_limits = BrightnessLimitsStore(settings.BRIGHTNESS_LIMITS_FILE)
+

--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -66,6 +66,12 @@ class Settings:
             str(Path(__file__).with_name("motion_schedule.json")),
         )
     )
+    BRIGHTNESS_LIMITS_FILE = Path(
+        os.getenv(
+            "BRIGHTNESS_LIMITS_FILE",
+            str(Path(__file__).with_name("brightness_limits.json")),
+        )
+    )
     if REGISTRY_FILE.exists():
         DEVICE_REGISTRY = json.loads(REGISTRY_FILE.read_text())
     else:

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -6,6 +6,7 @@ from .effects import WS_EFFECTS, WHITE_EFFECTS, RGB_EFFECTS
 from .presets import get_preset, apply_preset, get_room_presets
 from .motion import motion_manager, SPECIAL_ROOM_PRESETS
 from .motion_schedule import motion_schedule
+from .brightness_limits import brightness_limits
 
 router = APIRouter()
 BUS: Optional[MqttBus] = None
@@ -188,6 +189,34 @@ def api_rgb_set(node_id: str, payload: Dict[str, Any]):
         params = clean
     get_bus().rgb_set(node_id, strip, effect, brightness, params)
     return {"ok": True}
+
+
+@router.post("/api/node/{node_id}/{module}/brightness-limit")
+def api_set_brightness_limit(node_id: str, module: str, payload: Dict[str, Any]):
+    node = _valid_node(node_id)
+    module_key = str(module).lower()
+    if module_key not in {"ws", "white", "rgb"}:
+        raise HTTPException(404, "unsupported module")
+    if module_key not in node.get("modules", []):
+        raise HTTPException(404, "module not available")
+    try:
+        channel = int(payload.get("channel"))
+    except Exception:
+        raise HTTPException(400, "invalid channel")
+    if not 0 <= channel < 4:
+        raise HTTPException(400, "invalid channel")
+    limit = payload.get("limit")
+    if limit is None:
+        brightness_limits.set_limit(node_id, module_key, channel, None)
+        return {"ok": True, "limit": None}
+    try:
+        value = int(limit)
+    except Exception:
+        raise HTTPException(400, "invalid limit")
+    if not 0 <= value <= 255:
+        raise HTTPException(400, "invalid limit")
+    stored = brightness_limits.set_limit(node_id, module_key, channel, value)
+    return {"ok": True, "limit": stored}
 
 @router.post("/api/node/{node_id}/sensor/cooldown")
 def api_sensor_cooldown(node_id: str, payload: Dict[str, Any]):

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -19,6 +19,7 @@ from .effects import (
 from .presets import get_room_presets
 from .motion import motion_manager, SPECIAL_ROOM_PRESETS
 from .motion_schedule import motion_schedule
+from .brightness_limits import brightness_limits
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
@@ -179,5 +180,6 @@ def node_page(request: Request, node_id: str):
             "ws_param_defs": WS_PARAM_DEFS,
             "white_param_defs": WHITE_PARAM_DEFS,
             "rgb_param_defs": RGB_PARAM_DEFS,
+            "brightness_limits": brightness_limits.get_limits_for_node(node["id"]),
         },
     )

--- a/Server/app/templates/modules/rgb.html
+++ b/Server/app/templates/modules/rgb.html
@@ -11,7 +11,10 @@
   <div class="mb-3">
     <label class="text-xs opacity-70">Color</label>
     <div id="rgbParams" class="mt-2 space-y-2"></div>
-    <label class="text-xs opacity-70 block mt-2">Brightness</label>
+    <div class="flex items-center justify-between mt-2">
+      <label for="rgbBri" class="text-xs opacity-70">Brightness</label>
+      <button id="rgbBriLock" type="button" class="text-xl leading-none" title="Lock brightness" aria-pressed="false">🔓</button>
+    </div>
     <input id="rgbBri" type="range" min="0" max="255" value="255" class="w-full">
   </div>
   <div class="flex gap-2">
@@ -24,12 +27,89 @@
 <script type="module">
 import {renderParams,collectParams} from '/static/params.js';
 const RGB_PARAM_DEFS={{ rgb_param_defs|tojson }};
+const MODULE_KEY='rgb';
 const stripEl=document.getElementById('rgbStrip');
 const briEl=document.getElementById('rgbBri');
+const lockBtn=document.getElementById('rgbBriLock');
 const paramsEl=document.getElementById('rgbParams');
 const solidParams=RGB_PARAM_DEFS['solid']||[{"type":"color","label":"Color"}];
 
-async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+async function post(path,body){
+  const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+  if(!res.ok){throw new Error('Request failed');}
+  return res;
+}
+
+function activeStrip(){
+  const value=parseInt(stripEl.value,10);
+  return Number.isNaN(value)?null:value;
+}
+
+function getLimit(channel){
+  const data=window.nodeBrightnessLimits;
+  if(!data)return null;
+  const moduleData=data[MODULE_KEY];
+  if(!moduleData)return null;
+  const value=moduleData[String(channel)];
+  return typeof value==='number'?value:null;
+}
+
+function cacheLimit(channel,limit){
+  const data=window.nodeBrightnessLimits||(window.nodeBrightnessLimits={});
+  const key=String(channel);
+  if(limit===null||limit===undefined){
+    const moduleData=data[MODULE_KEY];
+    if(moduleData){
+      delete moduleData[key];
+      if(Object.keys(moduleData).length===0){
+        delete data[MODULE_KEY];
+      }
+    }
+    return;
+  }
+  const moduleData=data[MODULE_KEY]||(data[MODULE_KEY]={});
+  moduleData[key]=limit;
+}
+
+function clampBrightness(value){
+  if(typeof value!=='number'){
+    value=parseInt(value,10);
+  }
+  if(Number.isNaN(value))return null;
+  const strip=activeStrip();
+  if(strip!==null){
+    const limit=getLimit(strip);
+    if(limit!==null){
+      value=Math.min(value,limit);
+    }
+  }
+  if(value<0)value=0;
+  if(value>255)value=255;
+  return value;
+}
+
+function applyBrightnessLimit(){
+  const strip=activeStrip();
+  const limit=strip===null?null:getLimit(strip);
+  const maxValue=limit!==null?limit:255;
+  briEl.max=maxValue;
+  const current=parseInt(briEl.value,10);
+  let adjusted=current;
+  if(Number.isNaN(adjusted)){
+    adjusted=maxValue;
+  }
+  adjusted=Math.max(0,Math.min(adjusted,maxValue));
+  const changed=Number.isNaN(current)||adjusted!==current;
+  if(changed){
+    briEl.value=String(adjusted);
+  }
+  lockBtn.textContent=limit!==null?'🔒':'🔓';
+  lockBtn.setAttribute('aria-pressed',limit!==null?'true':'false');
+  lockBtn.title=limit!==null?`Unlock brightness limit (${maxValue})`:'Lock brightness to current value';
+  if(changed){
+    scheduleSend();
+  }
+}
 
 let lastSend=0;
 let pending=null;
@@ -56,21 +136,84 @@ function collectColorParams(){
 }
 
 function sendCmd(brightOverride){
-  const strip=parseInt(stripEl.value,10);
-  if(Number.isNaN(strip))return;
-  const brightness=brightOverride!==undefined?brightOverride:parseInt(briEl.value,10);
+  const strip=activeStrip();
+  if(strip===null)return;
+  let brightness=brightOverride!==undefined?brightOverride:parseInt(briEl.value,10);
   if(Number.isNaN(brightness))return;
+  const clamped=clampBrightness(brightness);
+  if(clamped===null)return;
+  brightness=clamped;
+  briEl.value=String(brightness);
   const params=collectColorParams();
   const msg={strip,effect:'solid',brightness,params};
-  post(`/api/node/{{ node.id }}/rgb/set`,msg);
+  post(`/api/node/{{ node.id }}/rgb/set`,msg).catch(()=>{alert('Request failed');});
 }
 
-stripEl.onchange=scheduleSend;
-briEl.addEventListener('input',scheduleSend);
+async function persistLimit(channel,limit){
+  try{
+    const res=await post(`/api/node/{{ node.id }}/rgb/brightness-limit`,{channel,limit});
+    let payload=null;
+    try{
+      payload=await res.json();
+    }catch(err){payload=null;}
+    if(payload&&payload.limit!==undefined){
+      const value=payload.limit;
+      if(typeof value==='number'){
+        cacheLimit(channel,Math.max(0,Math.min(255,value)));
+      }else{
+        cacheLimit(channel,null);
+      }
+    }else{
+      if(typeof limit==='number'){
+        cacheLimit(channel,limit);
+      }else{
+        cacheLimit(channel,null);
+      }
+    }
+    applyBrightnessLimit();
+  }catch(err){
+    console.error(err);
+    alert('Request failed');
+    applyBrightnessLimit();
+  }
+}
+
+stripEl.onchange=()=>{applyBrightnessLimit();scheduleSend();};
+briEl.addEventListener('input',()=>{
+  const clamped=clampBrightness(briEl.value);
+  if(clamped===null)return;
+  if(clamped!==parseInt(briEl.value,10)){
+    briEl.value=String(clamped);
+  }
+  scheduleSend();
+});
 updateParams();
+applyBrightnessLimit();
 
 const setBtn=document.getElementById('rgbSet');
 setBtn.onclick=()=>sendCmd();
-document.getElementById('rgbOn').onclick=()=>{briEl.value=255;sendCmd(255);};
-document.getElementById('rgbOff').onclick=()=>{briEl.value=0;sendCmd(0);};
+document.getElementById('rgbOn').onclick=()=>{
+  const strip=activeStrip();
+  const limit=strip===null?null:getLimit(strip);
+  const target=limit!==null?limit:255;
+  briEl.value=String(target);
+  sendCmd(target);
+};
+document.getElementById('rgbOff').onclick=()=>{
+  briEl.value='0';
+  sendCmd(0);
+};
+
+lockBtn.addEventListener('click',()=>{
+  const strip=activeStrip();
+  if(strip===null){alert('Invalid strip');return;}
+  const currentLimit=getLimit(strip);
+  if(currentLimit!==null){
+    persistLimit(strip,null);
+    return;
+  }
+  const brightness=clampBrightness(briEl.value);
+  if(brightness===null){alert('Invalid brightness');return;}
+  persistLimit(strip,brightness);
+});
 </script>

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -17,7 +17,10 @@
       {% endfor %}
     </select>
     <div id="wParams" class="mt-2 space-y-2"></div>
-    <label class="text-xs opacity-70 block mt-2">Brightness</label>
+    <div class="flex items-center justify-between mt-2">
+      <label for="wBri" class="text-xs opacity-70">Brightness</label>
+      <button id="wBriLock" type="button" class="text-xl leading-none" title="Lock brightness" aria-pressed="false">🔓</button>
+    </div>
     <input id="wBri" type="range" min="0" max="255" value="255" class="w-full">
   </div>
   <div class="flex gap-2">
@@ -27,11 +30,90 @@
 <script type="module">
 import {renderParams,collectParams} from '/static/params.js';
 const WHITE_PARAM_DEFS={{ white_param_defs|tojson }};
-async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+const MODULE_KEY='white';
+
+async function post(path,body){
+  const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+  if(!res.ok){throw new Error('Request failed');}
+  return res;
+}
+
 const chEl=document.getElementById('wChannel');
 const effEl=document.getElementById('wEffect');
 const wBriEl=document.getElementById('wBri');
+const lockBtn=document.getElementById('wBriLock');
 const wParamsEl=document.getElementById('wParams');
+
+function activeChannel(){
+  const value=parseInt(chEl.value,10);
+  return Number.isNaN(value)?null:value;
+}
+
+function getLimit(channel){
+  const data=window.nodeBrightnessLimits;
+  if(!data)return null;
+  const moduleData=data[MODULE_KEY];
+  if(!moduleData)return null;
+  const value=moduleData[String(channel)];
+  return typeof value==='number'?value:null;
+}
+
+function cacheLimit(channel,limit){
+  const data=window.nodeBrightnessLimits||(window.nodeBrightnessLimits={});
+  const key=String(channel);
+  if(limit===null||limit===undefined){
+    const moduleData=data[MODULE_KEY];
+    if(moduleData){
+      delete moduleData[key];
+      if(Object.keys(moduleData).length===0){
+        delete data[MODULE_KEY];
+      }
+    }
+    return;
+  }
+  const moduleData=data[MODULE_KEY]||(data[MODULE_KEY]={});
+  moduleData[key]=limit;
+}
+
+function clampBrightness(value){
+  if(typeof value!=='number'){
+    value=parseInt(value,10);
+  }
+  if(Number.isNaN(value))return null;
+  const channel=activeChannel();
+  if(channel!==null){
+    const limit=getLimit(channel);
+    if(limit!==null){
+      value=Math.min(value,limit);
+    }
+  }
+  if(value<0)value=0;
+  if(value>255)value=255;
+  return value;
+}
+
+function applyBrightnessLimit(){
+  const channel=activeChannel();
+  const limit=channel===null?null:getLimit(channel);
+  const maxValue=limit!==null?limit:255;
+  wBriEl.max=maxValue;
+  const current=parseInt(wBriEl.value,10);
+  let adjusted=current;
+  if(Number.isNaN(adjusted)){
+    adjusted=maxValue;
+  }
+  adjusted=Math.max(0,Math.min(adjusted,maxValue));
+  const changed=Number.isNaN(current)||adjusted!==current;
+  if(changed){
+    wBriEl.value=String(adjusted);
+  }
+  lockBtn.textContent=limit!==null?'🔒':'🔓';
+  lockBtn.setAttribute('aria-pressed',limit!==null?'true':'false');
+  lockBtn.title=limit!==null?`Unlock brightness limit (${maxValue})`:'Lock brightness to current value';
+  if(changed){
+    scheduleWhite();
+  }
+}
 
 // Throttled sender for real-time updates (max ~10 Hz)
 let wLastSend=0;
@@ -47,26 +129,83 @@ function scheduleWhite(){
     wPendingSend=setTimeout(()=>{wLastSend=Date.now();sendWhite();},delay);
   }
 }
+
 function updateParams(){
   const defs=WHITE_PARAM_DEFS[effEl.value]||[];
   renderParams(defs,wParamsEl,scheduleWhite);
 }
+
 effEl.onchange=()=>{updateParams();scheduleWhite();};
-chEl.onchange=scheduleWhite;
-wBriEl.addEventListener('input',scheduleWhite);
+chEl.onchange=()=>{applyBrightnessLimit();scheduleWhite();};
+wBriEl.addEventListener('input',()=>{
+  const clamped=clampBrightness(wBriEl.value);
+  if(clamped===null)return;
+  if(clamped!==parseInt(wBriEl.value,10)){
+    wBriEl.value=String(clamped);
+  }
+  scheduleWhite();
+});
+if(effEl.value)updateParams();
+applyBrightnessLimit();
 
 function sendWhite(){
-  const channel=parseInt(chEl.value,10);
-  if(Number.isNaN(channel))return;
+  const channel=activeChannel();
+  if(channel===null)return;
   const effect=effEl.value.trim();
   if(!effect)return;
-  const brightness=parseInt(wBriEl.value,10);
+  let brightness=parseInt(wBriEl.value,10);
   if(Number.isNaN(brightness))return;
+  const clamped=clampBrightness(brightness);
+  if(clamped===null)return;
+  brightness=clamped;
+  wBriEl.value=String(brightness);
   const params=collectParams(WHITE_PARAM_DEFS[effEl.value]||[],wParamsEl);
   const msg={channel,effect,brightness};
   if(params.length)msg.params=params;
-  post(`/api/node/{{ node.id }}/white/set`,msg);
+  post(`/api/node/{{ node.id }}/white/set`,msg).catch(()=>{alert('Request failed');});
 }
 
-document.getElementById('wSet').onclick=sendWhite;
+async function persistLimit(channel,limit){
+  try{
+    const res=await post(`/api/node/{{ node.id }}/white/brightness-limit`,{channel,limit});
+    let payload=null;
+    try{
+      payload=await res.json();
+    }catch(err){payload=null;}
+    if(payload&&payload.limit!==undefined){
+      const value=payload.limit;
+      if(typeof value==='number'){
+        cacheLimit(channel,Math.max(0,Math.min(255,value)));
+      }else{
+        cacheLimit(channel,null);
+      }
+    }else{
+      if(typeof limit==='number'){
+        cacheLimit(channel,limit);
+      }else{
+        cacheLimit(channel,null);
+      }
+    }
+    applyBrightnessLimit();
+  }catch(err){
+    console.error(err);
+    alert('Request failed');
+    applyBrightnessLimit();
+  }
+}
+
+lockBtn.addEventListener('click',()=>{
+  const channel=activeChannel();
+  if(channel===null){alert('Invalid channel');return;}
+  const currentLimit=getLimit(channel);
+  if(currentLimit!==null){
+    persistLimit(channel,null);
+    return;
+  }
+  const brightness=clampBrightness(wBriEl.value);
+  if(brightness===null){alert('Invalid brightness');return;}
+  persistLimit(channel,brightness);
+});
+
+document.getElementById('wSet').onclick=()=>sendWhite();
 </script>

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -21,7 +21,10 @@
       {% endfor %}
     </select>
     <div id="wsParams" class="mt-2 space-y-2"></div>
-    <label class="text-xs opacity-70 block mt-2">Brightness</label>
+    <div class="flex items-center justify-between mt-2">
+      <label for="wsBri" class="text-xs opacity-70">Brightness</label>
+      <button id="wsBriLock" type="button" class="text-xl leading-none" title="Lock brightness" aria-pressed="false">🔓</button>
+    </div>
     <input id="wsBri" type="range" min="0" max="255" value="255" class="w-full">
   </div>
   <div class="flex gap-2">
@@ -34,15 +37,94 @@
 <script type="module">
 import {renderParams,collectParams} from '/static/params.js';
 const WS_PARAM_DEFS={{ ws_param_defs|tojson }};
+const MODULE_KEY='ws';
 
 function getParamDefs(eff){
   return WS_PARAM_DEFS[eff]||[];
 }
-async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+
+async function post(path,body){
+  const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+  if(!res.ok){throw new Error('Request failed');}
+  return res;
+}
+
 const stripEl=document.getElementById('wsStrip');
 const effectEl=document.getElementById('wsEffect');
 const briEl=document.getElementById('wsBri');
+const lockBtn=document.getElementById('wsBriLock');
 const paramsEl=document.getElementById('wsParams');
+
+function activeStrip(){
+  const value=parseInt(stripEl.value,10);
+  return Number.isNaN(value)?null:value;
+}
+
+function getLimit(channel){
+  const data=window.nodeBrightnessLimits;
+  if(!data)return null;
+  const moduleData=data[MODULE_KEY];
+  if(!moduleData)return null;
+  const value=moduleData[String(channel)];
+  return typeof value==='number'?value:null;
+}
+
+function cacheLimit(channel,limit){
+  const data=window.nodeBrightnessLimits||(window.nodeBrightnessLimits={});
+  const key=String(channel);
+  if(limit===null||limit===undefined){
+    const moduleData=data[MODULE_KEY];
+    if(moduleData){
+      delete moduleData[key];
+      if(Object.keys(moduleData).length===0){
+        delete data[MODULE_KEY];
+      }
+    }
+    return;
+  }
+  const moduleData=data[MODULE_KEY]||(data[MODULE_KEY]={});
+  moduleData[key]=limit;
+}
+
+function clampBrightness(value){
+  if(typeof value!=='number'){
+    value=parseInt(value,10);
+  }
+  if(Number.isNaN(value))return null;
+  const strip=activeStrip();
+  if(strip!==null){
+    const limit=getLimit(strip);
+    if(limit!==null){
+      value=Math.min(value,limit);
+    }
+  }
+  if(value<0)value=0;
+  if(value>255)value=255;
+  return value;
+}
+
+function applyBrightnessLimit(){
+  const strip=activeStrip();
+  const limit=strip===null?null:getLimit(strip);
+  const maxValue=limit!==null?limit:255;
+  briEl.max=maxValue;
+  const current=parseInt(briEl.value,10);
+  let adjusted=current;
+  if(Number.isNaN(adjusted)){
+    adjusted=maxValue;
+  }
+  adjusted=Math.max(0,Math.min(adjusted,maxValue));
+  const changed=Number.isNaN(current)||adjusted!==current;
+  if(changed){
+    briEl.value=String(adjusted);
+  }
+  lockBtn.textContent=limit!==null?'🔒':'🔓';
+  lockBtn.setAttribute('aria-pressed',limit!==null?'true':'false');
+  lockBtn.title=limit!==null?`Unlock brightness limit (${maxValue})`:'Lock brightness to current value';
+  if(changed){
+    scheduleSend();
+  }
+}
 
 // Throttled sender for real-time updates (max ~10 Hz)
 let lastSend=0;
@@ -64,30 +146,95 @@ function updateParams(){
   const defs=getParamDefs(eff);
   renderParams(defs,paramsEl,scheduleSend);
 }
-effectEl.onchange=()=>{updateParams();scheduleSend();};
-stripEl.onchange=scheduleSend;
-briEl.addEventListener('input',scheduleSend);
-if(effectEl.value)updateParams();
 
-function sendCmd(){
-  const strip=parseInt(stripEl.value,10);
-  if(Number.isNaN(strip))return;
+effectEl.onchange=()=>{updateParams();scheduleSend();};
+stripEl.onchange=()=>{applyBrightnessLimit();scheduleSend();};
+briEl.addEventListener('input',()=>{
+  const clamped=clampBrightness(briEl.value);
+  if(clamped===null)return;
+  if(clamped!==parseInt(briEl.value,10)){
+    briEl.value=String(clamped);
+  }
+  scheduleSend();
+});
+if(effectEl.value)updateParams();
+applyBrightnessLimit();
+
+function sendCmd(brightOverride){
+  const strip=activeStrip();
+  if(strip===null)return;
   const eff=effectEl.value.trim();
   if(!eff)return;
-  const bri=parseInt(briEl.value,10);
+  let bri=brightOverride!==undefined?brightOverride:parseInt(briEl.value,10);
   if(Number.isNaN(bri))return;
+  const clamped=clampBrightness(bri);
+  if(clamped===null)return;
+  bri=clamped;
+  briEl.value=String(bri);
   const params=collectParams(getParamDefs(eff),paramsEl);
   const msg={strip,effect:eff,brightness:bri,params};
-  post(`/api/node/{{ node.id }}/ws/set`,msg);
+  post(`/api/node/{{ node.id }}/ws/set`,msg).catch(()=>{alert('Request failed');});
 }
 
-document.getElementById('wsSet').onclick=sendCmd;
+async function persistLimit(channel,limit){
+  try{
+    const res=await post(`/api/node/{{ node.id }}/ws/brightness-limit`,{channel,limit});
+    let payload=null;
+    try{
+      payload=await res.json();
+    }catch(err){payload=null;}
+    if(payload&&payload.limit!==undefined){
+      const value=payload.limit;
+      if(typeof value==='number'){
+        cacheLimit(channel,Math.max(0,Math.min(255,value)));
+      }else{
+        cacheLimit(channel,null);
+      }
+    }else{
+      if(typeof limit==='number'){
+        cacheLimit(channel,limit);
+      }else{
+        cacheLimit(channel,null);
+      }
+    }
+    applyBrightnessLimit();
+  }catch(err){
+    console.error(err);
+    alert('Request failed');
+    applyBrightnessLimit();
+  }
+}
 
-document.getElementById('wsOn').onclick=sendCmd;
+lockBtn.addEventListener('click',()=>{
+  const strip=activeStrip();
+  if(strip===null){alert('Invalid strip');return;}
+  const currentLimit=getLimit(strip);
+  if(currentLimit!==null){
+    persistLimit(strip,null);
+    return;
+  }
+  const brightness=clampBrightness(briEl.value);
+  if(brightness===null){alert('Invalid brightness');return;}
+  persistLimit(strip,brightness);
+});
+
+document.getElementById('wsSet').onclick=()=>sendCmd();
+
+document.getElementById('wsOn').onclick=()=>{
+  const strip=activeStrip();
+  const limit=strip===null?null:getLimit(strip);
+  const target=limit!==null?limit:255;
+  briEl.value=String(target);
+  sendCmd(target);
+};
 document.getElementById('wsOff').onclick=async()=>{
-  const s=parseInt(stripEl.value,10);
-  if(Number.isNaN(s)){alert('Invalid strip');return;}
-  await post(`/api/node/{{ node.id }}/ws/set`,{strip:s,effect:'solid',brightness:255,params:[0,0,0]});
+  const s=activeStrip();
+  if(s===null){alert('Invalid strip');return;}
+  try{
+    await post(`/api/node/{{ node.id }}/ws/set`,{strip:s,effect:'solid',brightness:255,params:[0,0,0]});
+  }catch(err){
+    alert('Request failed');
+  }
 };
 </script>
 

--- a/Server/app/templates/node.html
+++ b/Server/app/templates/node.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="text-2xl font-semibold mb-4">{{ node.name }}</h2>
+<script>
+  window.nodeBrightnessLimits = {{ brightness_limits|default({})|tojson }};
+</script>
 <div class="grid md:grid-cols-2 gap-6">
   {% for mod in node.modules %}
     {% include 'modules/' ~ mod ~ '.html' %}


### PR DESCRIPTION
## Summary
- add a persistent brightness limit store and expose it through the API
- preload node pages with stored limits and add lock controls to ws, white, and rgb modules
- clamp brightness sliders and commands based on saved limits

## Testing
- python -m compileall ..

------
https://chatgpt.com/codex/tasks/task_e_68ca8a6a180c832692f13fe6471239a4