### PR TITLE
Add on/off controls for white and rgb modules

### DIFF
--- a/Server/app/templates/modules/rgb.html
+++ b/Server/app/templates/modules/rgb.html
@@ -18,7 +18,6 @@
     <input id="rgbBri" type="range" min="0" max="255" value="255" class="w-full">
   </div>
   <div class="flex gap-2">
-    <button id="rgbSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
     <button id="rgbOn" class="px-4 py-2 pill bg-green-600 hover:bg-green-500 text-white">On</button>
     <button id="rgbOff" class="px-4 py-2 pill bg-red-600 hover:bg-red-500 text-white">Off</button>
   </div>
@@ -135,16 +134,29 @@ function collectColorParams(){
   return params;
 }
 
-function sendCmd(brightOverride){
+function sendCmd(options={}){
   const strip=activeStrip();
   if(strip===null)return;
-  let brightness=brightOverride!==undefined?brightOverride:parseInt(briEl.value,10);
+  let brightness=options.brightness!==undefined?options.brightness:parseInt(briEl.value,10);
+  if(typeof brightness!=='number'){
+    brightness=parseInt(brightness,10);
+  }
   if(Number.isNaN(brightness))return;
   const clamped=clampBrightness(brightness);
   if(clamped===null)return;
   brightness=clamped;
-  briEl.value=String(brightness);
-  const params=collectColorParams();
+  if(options.updateSlider!==false){
+    briEl.value=String(brightness);
+  }
+  let params;
+  if(options.params!==undefined){
+    params=Array.isArray(options.params)?options.params.slice():Array.from(options.params);
+  }else{
+    params=collectColorParams();
+  }
+  if(Array.isArray(params)){
+    while(params.length<3){params.push(0);}
+  }
   const msg={strip,effect:'solid',brightness,params};
   post(`/api/node/{{ node.id }}/rgb/set`,msg).catch(()=>{alert('Request failed');});
 }
@@ -190,18 +202,15 @@ briEl.addEventListener('input',()=>{
 updateParams();
 applyBrightnessLimit();
 
-const setBtn=document.getElementById('rgbSet');
-setBtn.onclick=()=>sendCmd();
 document.getElementById('rgbOn').onclick=()=>{
   const strip=activeStrip();
   const limit=strip===null?null:getLimit(strip);
   const target=limit!==null?limit:255;
   briEl.value=String(target);
-  sendCmd(target);
+  sendCmd({brightness:target});
 };
 document.getElementById('rgbOff').onclick=()=>{
-  briEl.value='0';
-  sendCmd(0);
+  sendCmd({brightness:0,params:[0,0,0]});
 };
 
 lockBtn.addEventListener('click',()=>{

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -24,7 +24,8 @@
     <input id="wBri" type="range" min="0" max="255" value="255" class="w-full">
   </div>
   <div class="flex gap-2">
-    <button id="wSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
+    <button id="wOn" class="px-4 py-2 pill bg-green-600 hover:bg-green-500 text-white">On</button>
+    <button id="wOff" class="px-4 py-2 pill bg-red-600 hover:bg-red-500 text-white">Off</button>
   </div>
 </section>
 <script type="module">
@@ -148,20 +149,37 @@ wBriEl.addEventListener('input',()=>{
 if(effEl.value)updateParams();
 applyBrightnessLimit();
 
-function sendWhite(){
+function sendWhite(options={}){
   const channel=activeChannel();
   if(channel===null)return;
-  const effect=effEl.value.trim();
+  let effect=null;
+  if(options.effect!==undefined){
+    effect=String(options.effect).trim();
+  }
+  if(!effect){
+    effect=effEl.value.trim();
+  }
   if(!effect)return;
-  let brightness=parseInt(wBriEl.value,10);
+  let brightness=options.brightness!==undefined?options.brightness:parseInt(wBriEl.value,10);
+  if(typeof brightness!=='number'){
+    brightness=parseInt(brightness,10);
+  }
   if(Number.isNaN(brightness))return;
   const clamped=clampBrightness(brightness);
   if(clamped===null)return;
   brightness=clamped;
-  wBriEl.value=String(brightness);
-  const params=collectParams(WHITE_PARAM_DEFS[effEl.value]||[],wParamsEl);
+  if(options.updateSlider!==false){
+    wBriEl.value=String(brightness);
+  }
+  let params;
+  if(options.params!==undefined){
+    params=options.params;
+  }else{
+    const defs=WHITE_PARAM_DEFS[effect]||[];
+    params=collectParams(defs,wParamsEl);
+  }
   const msg={channel,effect,brightness};
-  if(params.length)msg.params=params;
+  if(Array.isArray(params)&&params.length)msg.params=params;
   post(`/api/node/{{ node.id }}/white/set`,msg).catch(()=>{alert('Request failed');});
 }
 
@@ -206,6 +224,17 @@ lockBtn.addEventListener('click',()=>{
   if(brightness===null){alert('Invalid brightness');return;}
   persistLimit(channel,brightness);
 });
-
-document.getElementById('wSet').onclick=()=>sendWhite();
+document.getElementById('wOn').onclick=()=>{
+  const channel=activeChannel();
+  const limit=channel===null?null:getLimit(channel);
+  const target=limit!==null?limit:255;
+  wBriEl.value=String(target);
+  sendWhite({brightness:target});
+};
+document.getElementById('wOff').onclick=()=>{
+  const channel=activeChannel();
+  if(channel===null){alert('Invalid channel');return;}
+  wBriEl.value='0';
+  sendWhite({effect:'solid',brightness:0,params:[]});
+};
 </script>

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -28,7 +28,6 @@
     <input id="wsBri" type="range" min="0" max="255" value="255" class="w-full">
   </div>
   <div class="flex gap-2">
-    <button id="wsSet" class="px-4 py-2 pill bg-indigo-500 hover:bg-indigo-400 text-white">Set</button>
     <button id="wsOn" class="px-4 py-2 pill bg-green-600 hover:bg-green-500 text-white">On</button>
     <button id="wsOff" class="px-4 py-2 pill bg-red-600 hover:bg-red-500 text-white">Off</button>
   </div>
@@ -217,8 +216,6 @@ lockBtn.addEventListener('click',()=>{
   if(brightness===null){alert('Invalid brightness');return;}
   persistLimit(strip,brightness);
 });
-
-document.getElementById('wsSet').onclick=()=>sendCmd();
 
 document.getElementById('wsOn').onclick=()=>{
   const strip=activeStrip();


### PR DESCRIPTION
## Summary
- add on/off controls to the white channel module and reuse the throttled sender for live updates
- align the rgb module with the ws behavior by removing the redundant set button and extending the on/off handlers
- drop the ws "Set" button since changes are already sent live

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca8f7ba0248326abef13bd015efe66