### PR TITLE
Set default effects for lighting modules

### DIFF
--- a/Server/app/templates/modules/w.html
+++ b/Server/app/templates/modules/w.html
@@ -11,9 +11,9 @@
   <div class="mb-3">
     <label class="text-xs opacity-70">Effect</label>
     <select id="wEffect" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
-      <option value="" selected disabled>Select effect</option>
+      <option value="" disabled>Select effect</option>
       {% for eff in w_effects %}
-      <option value="{{ eff }}">{{ eff }}</option>
+      <option value="{{ eff }}"{% if eff == 'solid' %} selected{% endif %}>{{ eff }}</option>
       {% endfor %}
     </select>
     <div id="wParams" class="mt-2 space-y-2"></div>

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -11,9 +11,9 @@
   <div class="mb-3">
     <label class="text-xs opacity-70">Effect</label>
     <select id="wEffect" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
-      <option value="" selected disabled>Select effect</option>
+      <option value="" disabled>Select effect</option>
       {% for eff in white_effects %}
-      <option value="{{ eff }}">{{ eff }}</option>
+      <option value="{{ eff }}"{% if eff == 'solid' %} selected{% endif %}>{{ eff }}</option>
       {% endfor %}
     </select>
     <div id="wParams" class="mt-2 space-y-2"></div>

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -11,11 +11,11 @@
   <div class="mb-3">
     <label class="text-xs opacity-70">Effect</label>
     <select id="wsEffect" class="w-full p-1 bg-slate-900 rounded border border-slate-700">
-      <option value="" selected disabled>Select effect</option>
+      <option value="" disabled>Select effect</option>
       {% for group in ws_effect_groups %}
       <optgroup label="{{ group.label }}">
         {% for eff in group.effects %}
-        <option value="{{ eff }}" data-tier="{{ group.key }}">{{ eff }}</option>
+        <option value="{{ eff }}" data-tier="{{ group.key }}"{% if eff == 'color_swell' %} selected{% endif %}>{{ eff }}</option>
         {% endfor %}
       </optgroup>
       {% endfor %}


### PR DESCRIPTION
## Summary
- default the WS module effect dropdown to color_swell when the node page loads
- default both white module dropdowns to the solid effect so a valid option is preselected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb8bc5c8208326b3f6b54450589eec