### PR TITLE
Add house-specific admin dashboards

### DIFF
--- a/Server/app/main.py
+++ b/Server/app/main.py
@@ -6,6 +6,7 @@ from .routes_api import router as api_router
 from .routes_pages import router as pages_router
 from .ota import router as ota_router
 from .motion import motion_manager
+from .status_monitor import status_monitor
 from fastapi.responses import FileResponse, Response
 from pathlib import Path
 
@@ -41,12 +42,14 @@ async def on_start():
         asyncio.create_task(BROKER.start())
         await asyncio.sleep(0.6)
     motion_manager.start()
+    status_monitor.start()
 
 @app.on_event("shutdown")
 async def on_stop():
     if BROKER:
         await BROKER.shutdown()
     motion_manager.stop()
+    status_monitor.stop()
 
 
 @app.get("/favicon.ico", include_in_schema=False)

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -1,8 +1,11 @@
 from collections import defaultdict
 
+from typing import Any, Dict, List, Optional
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+
 from .config import settings
 from . import registry
 from .effects import (
@@ -19,6 +22,7 @@ from .effects import (
 from .presets import get_room_presets
 from .motion import motion_manager, SPECIAL_ROOM_PRESETS
 from .motion_schedule import motion_schedule
+from .status_monitor import status_monitor
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
@@ -30,6 +34,96 @@ def home(request: Request):
     return templates.TemplateResponse(
         "index.html",
         {"request": request, "houses": houses, "title": "UltraLights"},
+    )
+
+
+def _collect_admin_nodes(house_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    nodes: List[Dict[str, Any]] = []
+    for house, room, node in registry.iter_nodes():
+        if house_id and house and house.get("id") != house_id:
+            continue
+        house_name = ""
+        room_name = ""
+        node_name = ""
+        if house:
+            house_name = (house.get("name") or house.get("id") or "")
+        if room:
+            room_name = (room.get("name") or room.get("id") or "")
+        node_name = node.get("name") or node.get("id") or ""
+        node_id = node.get("id") or node_name
+        nodes.append(
+            {
+                "id": node_id,
+                "name": node_name,
+                "house": house_name,
+                "room": room_name,
+                "has_ota": "ota" in (node.get("modules") or []),
+            }
+        )
+    nodes.sort(key=lambda item: (item["house"].lower(), item["room"].lower(), item["name"].lower()))
+    return nodes
+
+
+def _admin_template_context(
+    request: Request,
+    *,
+    nodes: List[Dict[str, Any]],
+    title: str,
+    subtitle: str,
+    heading: Optional[str] = None,
+    description: Optional[str] = None,
+    status_house_id: Optional[str] = None,
+):
+    return {
+        "request": request,
+        "nodes": nodes,
+        "title": title,
+        "subtitle": subtitle,
+        "heading": heading or title,
+        "description": description
+        or "Monitor node heartbeats and trigger OTA checks.",
+        "status_timeout": status_monitor.timeout,
+        "status_house_id": status_house_id,
+    }
+
+
+@router.get("/admin", response_class=HTMLResponse)
+def admin_panel(request: Request):
+    nodes = _collect_admin_nodes()
+    return templates.TemplateResponse(
+        "admin.html",
+        _admin_template_context(
+            request,
+            nodes=nodes,
+            title="Admin Panel",
+            subtitle="System status",
+            heading="Admin Panel",
+        ),
+    )
+
+
+@router.get("/admin/house/{house_id}", response_class=HTMLResponse)
+def admin_house_panel(request: Request, house_id: str):
+    house = registry.find_house(house_id)
+    if not house:
+        return templates.TemplateResponse(
+            "base.html",
+            {"request": request, "content": "Unknown house"},
+            status_code=404,
+        )
+    house_name = house.get("name") or house.get("id") or house_id
+    nodes = _collect_admin_nodes(house_id)
+    return templates.TemplateResponse(
+        "admin.html",
+        _admin_template_context(
+            request,
+            nodes=nodes,
+            title=f"{house_name} Admin",
+            subtitle=f"{house_name} status",
+            heading=f"{house_name} Admin",
+            description=f"Monitor node heartbeats for {house_name}.",
+            status_house_id=house_id,
+        ),
     )
 
 
@@ -164,6 +258,9 @@ def node_page(request: Request, node_id: str):
         )
     ]
 
+    status_info = status_monitor.status_for(node["id"])
+    status_initial_online = bool(status_info.get("online"))
+
     return templates.TemplateResponse(
         "node.html",
         {
@@ -179,5 +276,7 @@ def node_page(request: Request, node_id: str):
             "ws_param_defs": WS_PARAM_DEFS,
             "white_param_defs": WHITE_PARAM_DEFS,
             "rgb_param_defs": RGB_PARAM_DEFS,
+            "status_timeout": status_monitor.timeout,
+            "status_initial_online": status_initial_online,
         },
     )

--- a/Server/app/status_monitor.py
+++ b/Server/app/status_monitor.py
@@ -1,0 +1,103 @@
+"""Track node heartbeat/status messages from MQTT."""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any, Dict
+
+import paho.mqtt.client as mqtt
+
+from .config import settings
+
+
+class StatusMonitor:
+    """Subscribe to node status topics and track their last "ok" heartbeat."""
+
+    def __init__(self, timeout: int = 30) -> None:
+        self.timeout = timeout
+        self.client = mqtt.Client()
+        self.client.on_connect = self._on_connect
+        self.client.on_message = self._on_message
+        self._lock = threading.Lock()
+        self._last_seen: Dict[str, float] = {}
+        self._last_ok: Dict[str, float] = {}
+        self._last_payload: Dict[str, Any] = {}
+        self._running = False
+
+    # ------------------------------------------------------------------
+    # MQTT lifecycle
+    def start(self) -> None:
+        if self._running:
+            return
+        self.client.connect(settings.BROKER_HOST, settings.BROKER_PORT, keepalive=30)
+        self.client.loop_start()
+        self._running = True
+
+    def stop(self) -> None:
+        if not self._running:
+            return
+        self.client.loop_stop()
+        self.client.disconnect()
+        self._running = False
+
+    # ------------------------------------------------------------------
+    # MQTT callbacks
+    def _on_connect(self, client: mqtt.Client, userdata, flags, rc) -> None:  # type: ignore[override]
+        client.subscribe("ul/+/evt/status")
+
+    def _on_message(self, client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:  # type: ignore[override]
+        topic = msg.topic or ""
+        parts = topic.split("/")
+        if len(parts) < 4 or parts[0] != "ul" or parts[2] != "evt":
+            return
+        node_id = parts[1]
+        now = time.time()
+        payload: Any = None
+        try:
+            payload = json.loads(msg.payload.decode("utf-8"))
+        except Exception:
+            payload = None
+        status_value: Any = None
+        if isinstance(payload, dict):
+            status_value = payload.get("status")
+        with self._lock:
+            self._last_seen[node_id] = now
+            self._last_payload[node_id] = payload
+            if status_value == "ok":
+                self._last_ok[node_id] = now
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    def snapshot(self) -> Dict[str, Dict[str, Any]]:
+        """Return a shallow copy of the current status information."""
+        now = time.time()
+        with self._lock:
+            keys = set(self._last_seen) | set(self._last_ok)
+            data: Dict[str, Dict[str, Any]] = {}
+            for node_id in keys:
+                last_seen = self._last_seen.get(node_id)
+                last_ok = self._last_ok.get(node_id)
+                payload = self._last_payload.get(node_id)
+                status_value = None
+                if isinstance(payload, dict):
+                    status_value = payload.get("status")
+                data[node_id] = {
+                    "online": bool(last_ok and now - last_ok <= self.timeout),
+                    "last_seen": last_seen,
+                    "last_ok": last_ok,
+                    "status": status_value,
+                    "payload": payload,
+                }
+        return data
+
+    def status_for(self, node_id: str) -> Dict[str, Any]:
+        """Return status information for ``node_id``."""
+        snapshot = self.snapshot()
+        return snapshot.get(
+            node_id,
+            {"online": False, "last_seen": None, "last_ok": None, "status": None, "payload": None},
+        )
+
+
+status_monitor = StatusMonitor()

--- a/Server/app/templates/admin.html
+++ b/Server/app/templates/admin.html
@@ -1,0 +1,149 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="mb-6 flex flex-col md:flex-row md:items-end md:justify-between gap-2">
+  <div>
+    <h2 class="text-3xl font-semibold">{{ heading }}</h2>
+    <p class="text-sm opacity-70">{{ description }}</p>
+  </div>
+  <div class="text-xs opacity-70">
+    <div>Healthy if last <code>{"status": "ok"}</code> within {{ status_timeout }}s.</div>
+    <div id="statusRefresh" class="mt-1">Waiting for update…</div>
+  </div>
+</div>
+
+{% if not nodes %}
+<div class="glass rounded-xl p-6 text-center text-sm opacity-70">No nodes registered.</div>
+{% else %}
+<div class="grid gap-4">
+  {% for node in nodes %}
+  <div class="glass rounded-xl p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+    <div>
+      <div class="text-lg font-semibold">{{ node.name }}</div>
+      <div class="text-sm opacity-70">{{ node.house }}{% if node.room %} • {{ node.room }}{% endif %}</div>
+      <div class="text-xs opacity-50 mt-1">ID: {{ node.id }}</div>
+    </div>
+    <div class="flex items-center gap-4">
+      <div class="flex items-center gap-2">
+        <span class="inline-block w-3 h-3 rounded-full" data-node-status="{{ node.id }}"></span>
+        <div class="text-xs leading-tight">
+          <div data-node-status-text="{{ node.id }}" class="font-semibold opacity-80">No data</div>
+          <div data-node-last="{{ node.id }}" class="opacity-60">Never seen</div>
+        </div>
+      </div>
+      <button
+        class="px-3 py-1.5 pill text-sm font-semibold bg-indigo-600 hover:bg-indigo-500 transition disabled:opacity-40 disabled:cursor-not-allowed"
+        data-node-ota="{{ node.id }}"
+        data-has-ota="{{ 'true' if node.has_ota else 'false' }}"
+        {% if not node.has_ota %}disabled{% endif %}>
+        OTA Check
+      </button>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+<div id="statusError" class="mt-4 text-sm text-rose-400 hidden"></div>
+
+<script>
+const STATUS_TIMEOUT = {{ status_timeout }};
+const STATUS_HOUSE_ID = {{ status_house_id|tojson }};
+const STATUS_URL = STATUS_HOUSE_ID ? `/api/admin/status?house_id=${encodeURIComponent(STATUS_HOUSE_ID)}` : '/api/admin/status';
+const refreshLabel = document.getElementById('statusRefresh');
+const errorEl = document.getElementById('statusError');
+const dots = Array.from(document.querySelectorAll('[data-node-status]'));
+
+function formatDelta(seconds) {
+  if (!isFinite(seconds) || seconds < 0) return 'just now';
+  if (seconds < 1) return 'just now';
+  if (seconds < 60) return `${Math.round(seconds)}s ago`;
+  if (seconds < 3600) {
+    const mins = Math.round(seconds / 60);
+    return `${mins}m ago`;
+  }
+  const hours = Math.round(seconds / 3600);
+  return `${hours}h ago`;
+}
+
+function setDot(dot, online) {
+  if (!dot) return;
+  if (online) {
+    dot.style.backgroundColor = '#22c55e';
+    dot.style.boxShadow = '0 0 12px rgba(34,197,94,0.7)';
+  } else {
+    dot.style.backgroundColor = '#ef4444';
+    dot.style.boxShadow = '0 0 12px rgba(239,68,68,0.6)';
+  }
+}
+
+dots.forEach((dot) => setDot(dot, false));
+
+async function refreshStatuses() {
+  try {
+    const res = await fetch(STATUS_URL);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    errorEl.classList.add('hidden');
+    const nowTs = Date.parse(data.now);
+    refreshLabel.textContent = `Updated ${new Date(data.now).toLocaleTimeString()}`;
+    Object.entries(data.nodes || {}).forEach(([nodeId, info]) => {
+      const dot = document.querySelector(`[data-node-status="${nodeId}"]`);
+      if (!dot) return;
+      const online = Boolean(info.online);
+      setDot(dot, online);
+      const statusEl = document.querySelector(`[data-node-status-text="${nodeId}"]`);
+      const lastEl = document.querySelector(`[data-node-last="${nodeId}"]`);
+      if (statusEl) {
+        statusEl.textContent = info.status || (online ? 'OK' : 'No data');
+      }
+      if (lastEl) {
+        const lastOk = info.last_ok ? Date.parse(info.last_ok) : null;
+        const lastSeen = info.last_seen ? Date.parse(info.last_seen) : null;
+        if (lastOk) {
+          const seconds = (nowTs - lastOk) / 1000;
+          lastEl.textContent = `OK ${formatDelta(seconds)}`;
+        } else if (lastSeen) {
+          const seconds = (nowTs - lastSeen) / 1000;
+          lastEl.textContent = `Seen ${formatDelta(seconds)}`;
+        } else {
+          lastEl.textContent = 'No status yet';
+        }
+      }
+    });
+  } catch (err) {
+    console.error('Failed to load admin status', err);
+    if (refreshLabel) refreshLabel.textContent = 'Update failed';
+    if (errorEl) {
+      errorEl.textContent = 'Unable to load node status. Retrying…';
+      errorEl.classList.remove('hidden');
+    }
+  }
+}
+
+refreshStatuses();
+setInterval(refreshStatuses, 5000);
+
+document.querySelectorAll('[data-node-ota]').forEach((btn) => {
+  const hasOta = btn.dataset.hasOta === 'true';
+  if (!hasOta) return;
+  btn.addEventListener('click', async () => {
+    if (btn.disabled) return;
+    const nodeId = btn.dataset.nodeOta;
+    const original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Checking…';
+    try {
+      const res = await fetch(`/api/node/${encodeURIComponent(nodeId)}/ota/check`, { method: 'POST' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      btn.textContent = 'Queued!';
+      setTimeout(() => { btn.textContent = original; btn.disabled = false; }, 1500);
+    } catch (err) {
+      console.error('OTA check failed', err);
+      btn.textContent = 'Failed';
+      setTimeout(() => { btn.textContent = original; btn.disabled = false; }, 2000);
+      alert(`OTA check failed for ${nodeId}`);
+    }
+  });
+});
+</script>
+{% endblock %}

--- a/Server/app/templates/house.html
+++ b/Server/app/templates/house.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="mb-6 flex justify-between items-center">
+<div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
   <h2 class="text-2xl font-semibold">Rooms</h2>
-  <button id="addRoom" class="w-12 h-12 flex items-center justify-center text-2xl rounded-full bg-indigo-600 hover:bg-indigo-500">+</button>
+  <div class="flex items-center gap-2">
+    <a href="/admin/house/{{ house.id }}" class="px-4 py-2 pill bg-slate-700 hover:bg-slate-600">Admin Panel</a>
+    <button id="addRoom" class="w-12 h-12 flex items-center justify-center text-2xl rounded-full bg-indigo-600 hover:bg-indigo-500">+</button>
+  </div>
 </div>
 <div class="grid md:grid-cols-3 gap-4">
   {% for r in house.rooms %}

--- a/Server/app/templates/index.html
+++ b/Server/app/templates/index.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="mb-6 flex justify-between items-center">
+<div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
   <h2 class="text-2xl font-semibold">Locations</h2>
-  <button id="allOff" class="px-4 py-2 pill bg-rose-600 hover:bg-rose-500">All Off</button>
+  <div class="flex items-center gap-2">
+    <a href="/admin" class="px-4 py-2 pill bg-slate-700 hover:bg-slate-600">Admin Panel</a>
+    <button id="allOff" class="px-4 py-2 pill bg-rose-600 hover:bg-rose-500">All Off</button>
+  </div>
 </div>
 
 <div class="grid md:grid-cols-3 gap-4 mt-6">

--- a/Server/app/templates/node.html
+++ b/Server/app/templates/node.html
@@ -1,9 +1,59 @@
 {% extends "base.html" %}
 {% block content %}
+<div class="flex items-center gap-2 text-sm mb-2">
+  <span class="opacity-70">Connection:</span>
+  <span
+    id="nodeStatusDot"
+    class="inline-block w-3 h-3 rounded-full"
+    role="status"
+    aria-live="polite"
+    style="background-color: #ef4444; box-shadow: 0 0 12px rgba(239,68,68,0.6);"
+  ></span>
+</div>
 <h2 class="text-2xl font-semibold mb-4">{{ node.name }}</h2>
 <div class="grid md:grid-cols-2 gap-6">
   {% for mod in node.modules %}
     {% include 'modules/' ~ mod ~ '.html' %}
   {% endfor %}
 </div>
+
+<script>
+const STATUS_NODE_ID = {{ node.id|tojson }};
+const STATUS_TIMEOUT = {{ status_timeout|tojson }};
+const STATUS_URL = `/api/node/${encodeURIComponent(STATUS_NODE_ID)}/status`;
+const statusDot = document.getElementById('nodeStatusDot');
+
+function setDot(online) {
+  if (!statusDot) return;
+  if (online) {
+    statusDot.style.backgroundColor = '#22c55e';
+    statusDot.style.boxShadow = '0 0 12px rgba(34,197,94,0.7)';
+    statusDot.setAttribute('aria-label', 'Online');
+    statusDot.title = `Online (heartbeat within ${STATUS_TIMEOUT}s)`;
+  } else {
+    statusDot.style.backgroundColor = '#ef4444';
+    statusDot.style.boxShadow = '0 0 12px rgba(239,68,68,0.6)';
+    statusDot.setAttribute('aria-label', 'Offline');
+    statusDot.title = `Offline (no heartbeat in ${STATUS_TIMEOUT}s)`;
+  }
+}
+
+setDot({{ status_initial_online|tojson }});
+
+async function refreshStatus() {
+  if (!statusDot) return;
+  try {
+    const res = await fetch(STATUS_URL, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    setDot(Boolean(data.online));
+  } catch (err) {
+    console.error('Failed to refresh node status', err);
+    setDot(false);
+  }
+}
+
+refreshStatus();
+setInterval(refreshStatus, 5000);
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add utilities to share admin node gathering/context building
- expose per-house admin dashboard filtered to nodes in the selected house and link it from each house page
- allow the admin status API and frontend to filter status polling by house
- expose a per-node status API and surface the connection indicator on the node detail view

## Testing
- python -m compileall Server/app

------
https://chatgpt.com/codex/tasks/task_e_68ca8c6bb2108326a98e270288bb5382