### PR TITLE
Filter node page modules by enabled state

### DIFF
--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
@@ -24,6 +25,90 @@ from .brightness_limits import brightness_limits
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
+
+
+_FALSEY_STRINGS = {"", "0", "false", "no", "off", "disabled", "inactive"}
+
+
+def _coerce_enabled(value: Any) -> bool:
+    """Return ``True`` when ``value`` represents an enabled module."""
+
+    if isinstance(value, str):
+        return value.strip().lower() not in _FALSEY_STRINGS
+    return bool(value)
+
+
+def _module_entry_enabled(config: Any) -> bool:
+    """Determine whether a module configuration marks the module as enabled."""
+
+    if isinstance(config, dict):
+        if "enabled" in config:
+            return _coerce_enabled(config.get("enabled"))
+        return True
+    return _coerce_enabled(config)
+
+
+def _enabled_module_keys(node: dict[str, Any]) -> list[str]:
+    """Extract enabled module keys from ``node`` preserving declaration order."""
+
+    modules = node.get("modules")
+    if not modules:
+        return []
+
+    result: list[str] = []
+
+    if isinstance(modules, dict):
+        for key, cfg in modules.items():
+            key_str = str(key).strip()
+            if not key_str:
+                continue
+            if _module_entry_enabled(cfg):
+                result.append(key_str)
+        return result
+
+    if isinstance(modules, (list, tuple)):
+        for entry in modules:
+            if isinstance(entry, str):
+                key_str = entry.strip()
+                if key_str:
+                    result.append(key_str)
+                continue
+            if isinstance(entry, dict):
+                name = (
+                    entry.get("key")
+                    or entry.get("module")
+                    or entry.get("id")
+                    or entry.get("name")
+                )
+                if not name:
+                    continue
+                key_str = str(name).strip()
+                if not key_str:
+                    continue
+                if _module_entry_enabled(entry):
+                    result.append(key_str)
+                continue
+            if entry is None:
+                continue
+            key_str = str(entry).strip()
+            if key_str:
+                result.append(key_str)
+        return result
+
+    if isinstance(modules, set):
+        for entry in modules:
+            if entry is None:
+                continue
+            key_str = str(entry).strip()
+            if key_str:
+                result.append(key_str)
+        return result
+
+    if isinstance(modules, str):
+        key_str = modules.strip()
+        return [key_str] if key_str else []
+
+    return []
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -179,6 +264,8 @@ def node_page(request: Request, node_id: str):
     else:
         subtitle = None
 
+    enabled_modules = _enabled_module_keys(node)
+
     missing = [eff for eff in WS_EFFECTS if eff not in WS_PARAM_DEFS]
     if missing:
         import logging
@@ -217,5 +304,6 @@ def node_page(request: Request, node_id: str):
             "white_param_defs": WHITE_PARAM_DEFS,
             "rgb_param_defs": RGB_PARAM_DEFS,
             "brightness_limits": brightness_limits.get_limits_for_node(node["id"]),
+            "node_modules": enabled_modules,
         },
     )

--- a/Server/app/templates/node.html
+++ b/Server/app/templates/node.html
@@ -4,9 +4,15 @@
 <script>
   window.nodeBrightnessLimits = {{ brightness_limits|default({})|tojson }};
 </script>
+{% if node_modules %}
 <div class="grid md:grid-cols-2 gap-6">
-  {% for mod in node.modules %}
-    {% include 'modules/' ~ mod ~ '.html' %}
+  {% for mod in node_modules %}
+    {% include 'modules/' ~ mod ~ '.html' ignore missing %}
   {% endfor %}
 </div>
+{% else %}
+<div class="glass rounded-2xl p-6 text-sm opacity-70">
+  This node has no enabled modules configured.
+</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- derive a filtered list of enabled modules for each node from the registry data
- update the node template to iterate over the filtered modules and handle nodes without enabled modules

## Testing
- python -m compileall Server/app

------
https://chatgpt.com/codex/tasks/task_e_68ccbe80d2dc8326905b33edc293ff8f