### PR TITLE
Limit module controls to available channels

### DIFF
--- a/Server/app/templates/modules/rgb.html
+++ b/Server/app/templates/modules/rgb.html
@@ -1,9 +1,11 @@
+{% set rgb_meta = (module_metadata | default({})).get('rgb', {}) %}
+{% set rgb_indices = rgb_meta.get('indices', []) %}
 <section class="glass rounded-2xl p-6">
   <h3 class="text-lg font-semibold mb-3">RGB Strip</h3>
   <div class="mb-2">
     <label class="text-xs opacity-70">Strip</label>
     <select id="rgbStrip" class="p-1 rounded bg-slate-900 border border-slate-700">
-      {% for i in range(4) %}
+      {% for i in rgb_indices %}
       <option value="{{ i }}">{{ i }}</option>
       {% endfor %}
     </select>
@@ -27,11 +29,14 @@
 import {renderParams,collectParams} from '/static/params.js';
 const RGB_PARAM_DEFS={{ rgb_param_defs|tojson }};
 const MODULE_KEY='rgb';
+const AVAILABLE_STRIPS={{ rgb_indices|tojson }};
 const stripEl=document.getElementById('rgbStrip');
 const briEl=document.getElementById('rgbBri');
 const lockBtn=document.getElementById('rgbBriLock');
 const paramsEl=document.getElementById('rgbParams');
 const solidParams=RGB_PARAM_DEFS['solid']||[{"type":"color","label":"Color"}];
+const onBtn=document.getElementById('rgbOn');
+const offBtn=document.getElementById('rgbOff');
 
 async function post(path,body){
   const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
@@ -39,12 +44,34 @@ async function post(path,body){
   return res;
 }
 
+function isValidStrip(strip){
+  return Number.isInteger(strip)&&AVAILABLE_STRIPS.includes(strip);
+}
+
+function ensureStripSelection(){
+  const hasStrips=AVAILABLE_STRIPS.length>0;
+  stripEl.disabled=!hasStrips;
+  briEl.disabled=!hasStrips;
+  lockBtn.disabled=!hasStrips;
+  if(onBtn)onBtn.disabled=!hasStrips;
+  if(offBtn)offBtn.disabled=!hasStrips;
+  if(!hasStrips){
+    return;
+  }
+  const current=parseInt(stripEl.value,10);
+  if(Number.isNaN(current)||!AVAILABLE_STRIPS.includes(current)){
+    stripEl.value=String(AVAILABLE_STRIPS[0]);
+  }
+}
+
 function activeStrip(){
   const value=parseInt(stripEl.value,10);
-  return Number.isNaN(value)?null:value;
+  if(Number.isNaN(value))return null;
+  return isValidStrip(value)?value:null;
 }
 
 function getLimit(channel){
+  if(!isValidStrip(channel))return null;
   const data=window.nodeBrightnessLimits;
   if(!data)return null;
   const moduleData=data[MODULE_KEY];
@@ -54,6 +81,7 @@ function getLimit(channel){
 }
 
 function cacheLimit(channel,limit){
+  if(!isValidStrip(channel))return;
   const data=window.nodeBrightnessLimits||(window.nodeBrightnessLimits={});
   const key=String(channel);
   if(limit===null||limit===undefined){
@@ -136,7 +164,7 @@ function collectColorParams(){
 
 function sendCmd(options={}){
   const strip=activeStrip();
-  if(strip===null)return;
+  if(strip===null||!isValidStrip(strip))return;
   let brightness=options.brightness!==undefined?options.brightness:parseInt(briEl.value,10);
   if(typeof brightness!=='number'){
     brightness=parseInt(brightness,10);
@@ -162,6 +190,7 @@ function sendCmd(options={}){
 }
 
 async function persistLimit(channel,limit){
+  if(!isValidStrip(channel)){alert('Invalid strip');return;}
   try{
     const res=await post(`/api/node/{{ node.id }}/rgb/brightness-limit`,{channel,limit});
     let payload=null;
@@ -190,7 +219,7 @@ async function persistLimit(channel,limit){
   }
 }
 
-stripEl.onchange=()=>{applyBrightnessLimit();scheduleSend();};
+stripEl.onchange=()=>{ensureStripSelection();applyBrightnessLimit();scheduleSend();};
 briEl.addEventListener('input',()=>{
   const clamped=clampBrightness(briEl.value);
   if(clamped===null)return;
@@ -200,22 +229,30 @@ briEl.addEventListener('input',()=>{
   scheduleSend();
 });
 updateParams();
+ensureStripSelection();
 applyBrightnessLimit();
 
-document.getElementById('rgbOn').onclick=()=>{
+if(onBtn){
+onBtn.onclick=()=>{
   const strip=activeStrip();
+  if(strip===null||!isValidStrip(strip)){alert('Invalid strip');return;}
   const limit=strip===null?null:getLimit(strip);
   const target=limit!==null?limit:255;
   briEl.value=String(target);
   sendCmd({brightness:target});
 };
-document.getElementById('rgbOff').onclick=()=>{
+}
+if(offBtn){
+offBtn.onclick=()=>{
+  const strip=activeStrip();
+  if(strip===null||!isValidStrip(strip)){alert('Invalid strip');return;}
   sendCmd({brightness:0,params:[0,0,0]});
 };
+}
 
 lockBtn.addEventListener('click',()=>{
   const strip=activeStrip();
-  if(strip===null){alert('Invalid strip');return;}
+  if(strip===null||!isValidStrip(strip)){alert('Invalid strip');return;}
   const currentLimit=getLimit(strip);
   if(currentLimit!==null){
     persistLimit(strip,null);

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -1,9 +1,11 @@
+{% set white_meta = (module_metadata | default({})).get('white', {}) %}
+{% set white_indices = white_meta.get('indices', []) %}
 <section class="glass rounded-2xl p-6">
   <h3 class="text-lg font-semibold mb-3">White Channel</h3>
   <div class="mb-2">
     <label class="text-xs opacity-70">Channel</label>
     <select id="wChannel" class="p-1 rounded bg-slate-900 border border-slate-700">
-      {% for i in range(4) %}
+      {% for i in white_indices %}
       <option value="{{ i }}">{{ i }}</option>
       {% endfor %}
     </select>
@@ -32,6 +34,7 @@
 import {renderParams,collectParams} from '/static/params.js';
 const WHITE_PARAM_DEFS={{ white_param_defs|tojson }};
 const MODULE_KEY='white';
+const AVAILABLE_CHANNELS={{ white_indices|tojson }};
 
 async function post(path,body){
   const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
@@ -44,13 +47,38 @@ const effEl=document.getElementById('wEffect');
 const wBriEl=document.getElementById('wBri');
 const lockBtn=document.getElementById('wBriLock');
 const wParamsEl=document.getElementById('wParams');
+const onBtn=document.getElementById('wOn');
+const offBtn=document.getElementById('wOff');
+
+function isValidChannel(channel){
+  return Number.isInteger(channel)&&AVAILABLE_CHANNELS.includes(channel);
+}
+
+function ensureChannelSelection(){
+  const hasChannels=AVAILABLE_CHANNELS.length>0;
+  chEl.disabled=!hasChannels;
+  effEl.disabled=!hasChannels;
+  wBriEl.disabled=!hasChannels;
+  lockBtn.disabled=!hasChannels;
+  if(onBtn)onBtn.disabled=!hasChannels;
+  if(offBtn)offBtn.disabled=!hasChannels;
+  if(!hasChannels){
+    return;
+  }
+  const current=parseInt(chEl.value,10);
+  if(Number.isNaN(current)||!AVAILABLE_CHANNELS.includes(current)){
+    chEl.value=String(AVAILABLE_CHANNELS[0]);
+  }
+}
 
 function activeChannel(){
   const value=parseInt(chEl.value,10);
-  return Number.isNaN(value)?null:value;
+  if(Number.isNaN(value))return null;
+  return isValidChannel(value)?value:null;
 }
 
 function getLimit(channel){
+  if(!isValidChannel(channel))return null;
   const data=window.nodeBrightnessLimits;
   if(!data)return null;
   const moduleData=data[MODULE_KEY];
@@ -60,6 +88,7 @@ function getLimit(channel){
 }
 
 function cacheLimit(channel,limit){
+  if(!isValidChannel(channel))return;
   const data=window.nodeBrightnessLimits||(window.nodeBrightnessLimits={});
   const key=String(channel);
   if(limit===null||limit===undefined){
@@ -137,7 +166,7 @@ function updateParams(){
 }
 
 effEl.onchange=()=>{updateParams();scheduleWhite();};
-chEl.onchange=()=>{applyBrightnessLimit();scheduleWhite();};
+chEl.onchange=()=>{ensureChannelSelection();applyBrightnessLimit();scheduleWhite();};
 wBriEl.addEventListener('input',()=>{
   const clamped=clampBrightness(wBriEl.value);
   if(clamped===null)return;
@@ -147,11 +176,12 @@ wBriEl.addEventListener('input',()=>{
   scheduleWhite();
 });
 if(effEl.value)updateParams();
+ensureChannelSelection();
 applyBrightnessLimit();
 
 function sendWhite(options={}){
   const channel=activeChannel();
-  if(channel===null)return;
+  if(channel===null||!isValidChannel(channel))return;
   let effect=null;
   if(options.effect!==undefined){
     effect=String(options.effect).trim();
@@ -184,6 +214,7 @@ function sendWhite(options={}){
 }
 
 async function persistLimit(channel,limit){
+  if(!isValidChannel(channel)){alert('Invalid channel');return;}
   try{
     const res=await post(`/api/node/{{ node.id }}/white/brightness-limit`,{channel,limit});
     let payload=null;
@@ -214,7 +245,7 @@ async function persistLimit(channel,limit){
 
 lockBtn.addEventListener('click',()=>{
   const channel=activeChannel();
-  if(channel===null){alert('Invalid channel');return;}
+  if(channel===null||!isValidChannel(channel)){alert('Invalid channel');return;}
   const currentLimit=getLimit(channel);
   if(currentLimit!==null){
     persistLimit(channel,null);
@@ -224,17 +255,22 @@ lockBtn.addEventListener('click',()=>{
   if(brightness===null){alert('Invalid brightness');return;}
   persistLimit(channel,brightness);
 });
-document.getElementById('wOn').onclick=()=>{
+if(onBtn){
+onBtn.onclick=()=>{
   const channel=activeChannel();
+  if(channel===null||!isValidChannel(channel)){alert('Invalid channel');return;}
   const limit=channel===null?null:getLimit(channel);
   const target=limit!==null?limit:255;
   wBriEl.value=String(target);
   sendWhite({brightness:target});
 };
-document.getElementById('wOff').onclick=()=>{
+}
+if(offBtn){
+offBtn.onclick=()=>{
   const channel=activeChannel();
-  if(channel===null){alert('Invalid channel');return;}
+  if(channel===null||!isValidChannel(channel)){alert('Invalid channel');return;}
   wBriEl.value='0';
   sendWhite({effect:'solid',brightness:0,params:[]});
 };
+}
 </script>

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -1,9 +1,11 @@
+{% set ws_meta = (module_metadata | default({})).get('ws', {}) %}
+{% set ws_indices = ws_meta.get('indices', []) %}
 <section class="glass rounded-2xl p-6">
   <h3 class="text-lg font-semibold mb-3">Addressable Strip</h3>
   <div class="mb-2">
     <label class="text-xs opacity-70">Strip</label>
     <select id="wsStrip" class="p-1 rounded bg-slate-900 border border-slate-700">
-      {% for i in range(4) %}
+      {% for i in ws_indices %}
       <option value="{{ i }}">{{ i }}</option>
       {% endfor %}
     </select>
@@ -37,6 +39,7 @@
 import {renderParams,collectParams} from '/static/params.js';
 const WS_PARAM_DEFS={{ ws_param_defs|tojson }};
 const MODULE_KEY='ws';
+const AVAILABLE_STRIPS={{ ws_indices|tojson }};
 
 function getParamDefs(eff){
   return WS_PARAM_DEFS[eff]||[];
@@ -53,13 +56,37 @@ const effectEl=document.getElementById('wsEffect');
 const briEl=document.getElementById('wsBri');
 const lockBtn=document.getElementById('wsBriLock');
 const paramsEl=document.getElementById('wsParams');
+const onBtn=document.getElementById('wsOn');
+const offBtn=document.getElementById('wsOff');
+
+function isValidStrip(strip){
+  return Number.isInteger(strip)&&AVAILABLE_STRIPS.includes(strip);
+}
+
+function ensureStripSelection(){
+  const hasStrips=AVAILABLE_STRIPS.length>0;
+  stripEl.disabled=!hasStrips;
+  briEl.disabled=!hasStrips;
+  lockBtn.disabled=!hasStrips;
+  if(onBtn)onBtn.disabled=!hasStrips;
+  if(offBtn)offBtn.disabled=!hasStrips;
+  if(!hasStrips){
+    return;
+  }
+  const current=parseInt(stripEl.value,10);
+  if(Number.isNaN(current)||!AVAILABLE_STRIPS.includes(current)){
+    stripEl.value=String(AVAILABLE_STRIPS[0]);
+  }
+}
 
 function activeStrip(){
   const value=parseInt(stripEl.value,10);
-  return Number.isNaN(value)?null:value;
+  if(Number.isNaN(value))return null;
+  return isValidStrip(value)?value:null;
 }
 
 function getLimit(channel){
+  if(!isValidStrip(channel))return null;
   const data=window.nodeBrightnessLimits;
   if(!data)return null;
   const moduleData=data[MODULE_KEY];
@@ -69,6 +96,7 @@ function getLimit(channel){
 }
 
 function cacheLimit(channel,limit){
+  if(!isValidStrip(channel))return;
   const data=window.nodeBrightnessLimits||(window.nodeBrightnessLimits={});
   const key=String(channel);
   if(limit===null||limit===undefined){
@@ -147,7 +175,7 @@ function updateParams(){
 }
 
 effectEl.onchange=()=>{updateParams();scheduleSend();};
-stripEl.onchange=()=>{applyBrightnessLimit();scheduleSend();};
+stripEl.onchange=()=>{ensureStripSelection();applyBrightnessLimit();scheduleSend();};
 briEl.addEventListener('input',()=>{
   const clamped=clampBrightness(briEl.value);
   if(clamped===null)return;
@@ -157,11 +185,13 @@ briEl.addEventListener('input',()=>{
   scheduleSend();
 });
 if(effectEl.value)updateParams();
+ensureStripSelection();
 applyBrightnessLimit();
 
 function sendCmd(brightOverride){
   const strip=activeStrip();
   if(strip===null)return;
+  if(!isValidStrip(strip))return;
   const eff=effectEl.value.trim();
   if(!eff)return;
   let bri=brightOverride!==undefined?brightOverride:parseInt(briEl.value,10);
@@ -176,6 +206,7 @@ function sendCmd(brightOverride){
 }
 
 async function persistLimit(channel,limit){
+  if(!isValidStrip(channel)){alert('Invalid strip');return;}
   try{
     const res=await post(`/api/node/{{ node.id }}/ws/brightness-limit`,{channel,limit});
     let payload=null;
@@ -206,7 +237,7 @@ async function persistLimit(channel,limit){
 
 lockBtn.addEventListener('click',()=>{
   const strip=activeStrip();
-  if(strip===null){alert('Invalid strip');return;}
+  if(strip===null||!isValidStrip(strip)){alert('Invalid strip');return;}
   const currentLimit=getLimit(strip);
   if(currentLimit!==null){
     persistLimit(strip,null);
@@ -217,21 +248,26 @@ lockBtn.addEventListener('click',()=>{
   persistLimit(strip,brightness);
 });
 
-document.getElementById('wsOn').onclick=()=>{
+if(onBtn){
+onBtn.onclick=()=>{
   const strip=activeStrip();
+  if(strip===null||!isValidStrip(strip)){alert('Invalid strip');return;}
   const limit=strip===null?null:getLimit(strip);
   const target=limit!==null?limit:255;
   briEl.value=String(target);
   sendCmd(target);
 };
-document.getElementById('wsOff').onclick=async()=>{
+}
+if(offBtn){
+offBtn.onclick=async()=>{
   const s=activeStrip();
-  if(s===null){alert('Invalid strip');return;}
+  if(s===null||!isValidStrip(s)){alert('Invalid strip');return;}
   try{
     await post(`/api/node/{{ node.id }}/ws/set`,{strip:s,effect:'solid',brightness:255,params:[0,0,0]});
   }catch(err){
     alert('Request failed');
   }
 };
+}
 </script>
 


### PR DESCRIPTION
## Summary
- expose live module/channel metadata in the node view context
- update WS/RGB/white templates to render only available indices
- guard module scripts so MQTT commands respect the provided indices and brightness limits

## Testing
- python -m compileall Server/app
- python - <<'PY' ...


------
https://chatgpt.com/codex/tasks/task_e_68cccaea5b1c83268690ca0172c9d5b5