### PR TITLE
Use live MQTT capabilities for node control

### DIFF
--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List
 from fastapi import APIRouter, HTTPException
-from .mqtt_bus import MqttBus
+from .mqtt_bus import get_bus
 from . import registry
 from .effects import WS_EFFECTS, WHITE_EFFECTS, RGB_EFFECTS
 from .presets import get_preset, apply_preset, get_room_presets
@@ -9,22 +9,67 @@ from .motion import motion_manager, SPECIAL_ROOM_PRESETS
 from .motion_schedule import motion_schedule
 from .status_monitor import status_monitor
 from .brightness_limits import brightness_limits
+from .routes_pages import _enabled_module_keys, _DEFAULT_MODULE_INDICES
 
 
 router = APIRouter()
-BUS: Optional[MqttBus] = None
-
-def get_bus() -> MqttBus:
-    global BUS
-    if BUS is None:
-        BUS = MqttBus()
-    return BUS
 
 def _valid_node(node_id: str) -> Dict[str, Any]:
     _, _, node = registry.find_node(node_id)
     if node:
         return node
     raise HTTPException(404, "Unknown node id")
+
+
+def _node_module_capabilities(
+    node_id: str, node: Dict[str, Any]
+) -> tuple[list[str], dict[str, dict[str, Any]]]:
+    capabilities = status_monitor.capabilities_for(node_id)
+    modules = capabilities.get("modules")
+    if not isinstance(modules, dict):
+        modules = {}
+    module_keys_raw = capabilities.get("module_keys")
+    module_keys: list[str] = []
+    if isinstance(module_keys_raw, list):
+        for entry in module_keys_raw:
+            key_str = str(entry).strip()
+            if key_str:
+                module_keys.append(key_str)
+    if module_keys:
+        return module_keys, modules
+    fallback_keys = _enabled_module_keys(node)
+    fallback_modules: dict[str, dict[str, Any]] = {}
+    for key in fallback_keys:
+        fallback_modules[key] = {
+            "indices": list(_DEFAULT_MODULE_INDICES.get(key, ())),
+            "enabled": True,
+        }
+    return fallback_keys, fallback_modules
+
+
+def _module_indices(metadata: dict[str, dict[str, Any]], module_key: str) -> list[int]:
+    entry = metadata.get(module_key)
+    if not isinstance(entry, dict):
+        return []
+    indices = entry.get("indices")
+    if not isinstance(indices, list):
+        return []
+    result: list[int] = []
+    for value in indices:
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            result.append(value)
+            continue
+        if isinstance(value, float) and value.is_integer():
+            result.append(int(value))
+            continue
+        if isinstance(value, str):
+            try:
+                result.append(int(value.strip()))
+            except Exception:
+                continue
+    return result
 
 
 @router.delete("/api/node/{node_id}")
@@ -110,12 +155,16 @@ def api_set_motion_schedule(house_id: str, room_id: str, payload: Dict[str, Any]
 
 @router.post("/api/node/{node_id}/ws/set")
 def api_ws_set(node_id: str, payload: Dict[str, Any]):
-    _valid_node(node_id)
+    node = _valid_node(node_id)
+    module_keys, module_caps = _node_module_capabilities(node_id, node)
     try:
         strip = int(payload.get("strip"))
     except Exception:
         raise HTTPException(400, "invalid strip")
-    if not 0 <= strip < 4:
+    if "ws" not in module_keys:
+        raise HTTPException(404, "module not available")
+    allowed_strips = _module_indices(module_caps, "ws")
+    if not allowed_strips or strip not in allowed_strips:
         raise HTTPException(400, "invalid strip")
     effect = str(payload.get("effect", "")).strip()
     if effect not in WS_EFFECTS:
@@ -144,12 +193,16 @@ def api_ws_set(node_id: str, payload: Dict[str, Any]):
 
 @router.post("/api/node/{node_id}/white/set")
 def api_white_set(node_id: str, payload: Dict[str, Any]):
-    _valid_node(node_id)
+    node = _valid_node(node_id)
+    module_keys, module_caps = _node_module_capabilities(node_id, node)
     try:
         channel = int(payload.get("channel"))
     except Exception:
         raise HTTPException(400, "invalid channel")
-    if not 0 <= channel < 4:
+    if "white" not in module_keys:
+        raise HTTPException(404, "module not available")
+    allowed_channels = _module_indices(module_caps, "white")
+    if not allowed_channels or channel not in allowed_channels:
         raise HTTPException(400, "invalid channel")
     effect = str(payload.get("effect", "")).strip()
     if effect not in WHITE_EFFECTS:
@@ -174,12 +227,16 @@ def api_white_set(node_id: str, payload: Dict[str, Any]):
 
 @router.post("/api/node/{node_id}/rgb/set")
 def api_rgb_set(node_id: str, payload: Dict[str, Any]):
-    _valid_node(node_id)
+    node = _valid_node(node_id)
+    module_keys, module_caps = _node_module_capabilities(node_id, node)
     try:
         strip = int(payload.get("strip"))
     except Exception:
         raise HTTPException(400, "invalid strip")
-    if not 0 <= strip < 4:
+    if "rgb" not in module_keys:
+        raise HTTPException(404, "module not available")
+    allowed_strips = _module_indices(module_caps, "rgb")
+    if not allowed_strips or strip not in allowed_strips:
         raise HTTPException(400, "invalid strip")
     effect = str(payload.get("effect", "")).strip()
     if effect not in RGB_EFFECTS:
@@ -215,13 +272,15 @@ def api_set_brightness_limit(node_id: str, module: str, payload: Dict[str, Any])
     module_key = str(module).lower()
     if module_key not in {"ws", "white", "rgb"}:
         raise HTTPException(404, "unsupported module")
-    if module_key not in node.get("modules", []):
+    module_keys, module_caps = _node_module_capabilities(node_id, node)
+    if module_key not in module_keys:
         raise HTTPException(404, "module not available")
     try:
         channel = int(payload.get("channel"))
     except Exception:
         raise HTTPException(400, "invalid channel")
-    if not 0 <= channel < 4:
+    allowed_indices = _module_indices(module_caps, module_key)
+    if not allowed_indices or channel not in allowed_indices:
         raise HTTPException(400, "invalid channel")
     limit = payload.get("limit")
     if limit is None:

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -1,8 +1,4 @@
 from collections import defaultdict
-from typing import Any
-
-from typing import Any, Dict, List, Optional
-
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Request
@@ -26,6 +22,7 @@ from .presets import get_room_presets
 from .motion import motion_manager, SPECIAL_ROOM_PRESETS
 from .motion_schedule import motion_schedule
 from .status_monitor import status_monitor
+from .mqtt_bus import request_status_snapshot
 from .brightness_limits import brightness_limits
 
 
@@ -131,7 +128,9 @@ _DEFAULT_MODULE_INDICES = {
 
 
 def _module_status_metadata(
-    module_keys: list[str], status_payload: Any
+    module_keys: list[str],
+    status_payload: Any,
+    capability_modules: Optional[dict[str, dict[str, Any]]] = None,
 ) -> dict[str, dict[str, Any]]:
     """Build metadata describing available indices for each module."""
 
@@ -140,37 +139,67 @@ def _module_status_metadata(
 
     for key in module_keys:
         info: dict[str, Any] = {}
-        index_field = _MODULE_INDEX_KEYS.get(key)
-        entries_data = payload_dict.get(key) if isinstance(payload_dict, dict) else None
+        cap_entry = capability_modules.get(key) if capability_modules else None
         indices: list[int] = []
-        entries: list[dict[str, Any]] = []
+        has_live_data = False
 
-        if index_field and isinstance(entries_data, list):
+        if isinstance(cap_entry, dict):
+            cap_indices = cap_entry.get("indices")
+            if isinstance(cap_indices, list) and cap_indices:
+                converted: list[int] = []
+                for value in cap_indices:
+                    if isinstance(value, bool):
+                        continue
+                    if isinstance(value, int):
+                        converted.append(value)
+                        continue
+                    if isinstance(value, float) and value.is_integer():
+                        converted.append(int(value))
+                        continue
+                    if isinstance(value, str):
+                        try:
+                            converted.append(int(value.strip()))
+                        except Exception:
+                            continue
+                if converted:
+                    indices = converted
+                    has_live_data = True
+
+        entries_data = payload_dict.get(key) if isinstance(payload_dict, dict) else None
+        index_field = _MODULE_INDEX_KEYS.get(key)
+        if not indices and index_field and isinstance(entries_data, list):
             seen: set[int] = set()
+            derived: list[int] = []
             for entry in entries_data:
                 if not isinstance(entry, dict):
                     continue
                 idx = entry.get(index_field)
-                if not isinstance(idx, int):
-                    continue
-                enabled = entry.get("enabled")
-                if enabled is not None and not _coerce_enabled(enabled):
-                    continue
-                if idx in seen:
+                if not isinstance(idx, int) or idx in seen:
                     continue
                 seen.add(idx)
-                indices.append(idx)
-                entries.append(entry)
+                derived.append(idx)
+            if derived:
+                indices = derived
+                has_live_data = True
+
+        if not indices:
+            fallback = list(_DEFAULT_MODULE_INDICES.get(key, ()))
+            indices = fallback
+            has_live_data = False
 
         if indices:
-            info["indices"] = indices
-            info["has_live_data"] = True
-        else:
-            fallback = list(_DEFAULT_MODULE_INDICES.get(key, ()))
-            info["indices"] = fallback
-            info["has_live_data"] = False
-        if entries:
-            info["status"] = entries
+            indices = list(dict.fromkeys(indices))
+        info["indices"] = indices
+        info["has_live_data"] = has_live_data
+
+        status_entries = None
+        if isinstance(cap_entry, dict) and isinstance(cap_entry.get("status"), list):
+            status_entries = cap_entry["status"]
+        elif isinstance(entries_data, list):
+            status_entries = entries_data
+        if status_entries:
+            info["status"] = status_entries
+
         metadata[key] = info
 
     return metadata
@@ -375,7 +404,7 @@ def room_page(request: Request, house_id: str, room_id: str):
     )
 
 @router.get("/node/{node_id}", response_class=HTMLResponse)
-def node_page(request: Request, node_id: str):
+async def node_page(request: Request, node_id: str):
     house, room, node = registry.find_node(node_id)
     if not node:
         return templates.TemplateResponse(
@@ -387,7 +416,31 @@ def node_page(request: Request, node_id: str):
     else:
         subtitle = None
 
-    enabled_modules = _enabled_module_keys(node)
+    capabilities: Dict[str, Any] = {}
+    try:
+        capabilities = await request_status_snapshot(node_id, timeout=1.5)
+    except Exception:
+        capabilities = status_monitor.capabilities_for(node_id)
+        capabilities["fresh"] = False
+
+    modules_data = capabilities.get("modules")
+    if not isinstance(modules_data, dict):
+        modules_data = {}
+
+    live_module_keys_raw = capabilities.get("module_keys")
+    live_module_keys: List[str] = []
+    if isinstance(live_module_keys_raw, list):
+        for entry in live_module_keys_raw:
+            key_str = str(entry).strip()
+            if key_str:
+                live_module_keys.append(key_str)
+
+    if live_module_keys:
+        enabled_modules = live_module_keys
+        capability_metadata: Optional[dict[str, dict[str, Any]]] = modules_data
+    else:
+        enabled_modules = _enabled_module_keys(node)
+        capability_metadata = None
 
     missing = [eff for eff in WS_EFFECTS if eff not in WS_PARAM_DEFS]
     if missing:
@@ -413,8 +466,13 @@ def node_page(request: Request, node_id: str):
 
     status_info = status_monitor.status_for(node["id"])
     status_initial_online = bool(status_info.get("online"))
+    status_payload = capabilities.get("payload")
+    if status_payload is None:
+        status_payload = status_info.get("payload")
     module_metadata = _module_status_metadata(
-        enabled_modules, status_info.get("payload")
+        enabled_modules,
+        status_payload,
+        capability_modules=capability_metadata,
     )
 
     return templates.TemplateResponse(

--- a/Server/app/status_monitor.py
+++ b/Server/app/status_monitor.py
@@ -4,11 +4,148 @@ from __future__ import annotations
 import json
 import threading
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Optional
 
 import paho.mqtt.client as mqtt
 
 from .config import settings
+
+
+_FALSEY_STRINGS = {"", "0", "false", "no", "off", "disabled", "inactive"}
+
+
+def _coerce_enabled(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in _FALSEY_STRINGS
+    return bool(value)
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except Exception:
+            return None
+    return None
+
+
+def _unique_ordered(values: Iterable[int]) -> list[int]:
+    seen: set[int] = set()
+    result: list[int] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _indices_from_summary(summary: Any) -> list[int]:
+    if not isinstance(summary, dict):
+        return []
+    candidates = [
+        summary.get("indices"),
+        summary.get("strips"),
+        summary.get("channels"),
+    ]
+    indices: list[int] = []
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            for item in candidate:
+                idx = _as_int(item)
+                if idx is not None:
+                    indices.append(idx)
+        if indices:
+            break
+    return _unique_ordered(indices)
+
+
+def _indices_from_entries(entries: Any, index_key: str) -> list[int]:
+    if not isinstance(entries, list):
+        return []
+    result: list[int] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        idx = _as_int(entry.get(index_key))
+        if idx is not None:
+            result.append(idx)
+    return _unique_ordered(result)
+
+
+def _normalize_capabilities(payload: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return None
+
+    modules_summary = payload.get("modules")
+    if modules_summary is not None and not isinstance(modules_summary, dict):
+        modules_summary = None
+
+    candidate_keys: list[str] = []
+    if isinstance(modules_summary, dict):
+        for key in modules_summary.keys():
+            key_str = str(key).strip()
+            if key_str:
+                candidate_keys.append(key_str)
+
+    for fallback in ("ws", "rgb", "white"):
+        if fallback in payload and fallback not in candidate_keys:
+            candidate_keys.append(fallback)
+
+    if not candidate_keys:
+        return None
+
+    modules: Dict[str, Dict[str, Any]] = {}
+    module_keys: list[str] = []
+
+    for key in candidate_keys:
+        summary_info = modules_summary.get(key) if isinstance(modules_summary, dict) else None
+        indices = _indices_from_summary(summary_info)
+
+        entry_field = "strip"
+        if key == "white":
+            entry_field = "channel"
+
+        entries = payload.get(key)
+        if indices:
+            entry_indices: list[int] = []
+        else:
+            entry_indices = _indices_from_entries(entries, entry_field)
+        if entry_indices:
+            indices = _unique_ordered(list(indices) + entry_indices)
+
+        enabled_flag: Optional[bool] = None
+        if isinstance(summary_info, dict) and "enabled" in summary_info:
+            enabled_flag = _coerce_enabled(summary_info.get("enabled"))
+        if enabled_flag is None:
+            if isinstance(entries, list):
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    if "enabled" in entry:
+                        enabled_flag = _coerce_enabled(entry.get("enabled"))
+                        break
+            if enabled_flag is None:
+                enabled_flag = bool(indices)
+
+        modules[key] = {
+            "indices": indices,
+            "enabled": bool(enabled_flag),
+        }
+        if isinstance(summary_info, dict):
+            modules[key]["summary"] = summary_info
+        if isinstance(entries, list):
+            modules[key]["status"] = entries
+        if modules[key]["enabled"]:
+            module_keys.append(key)
+
+    return {"module_keys": module_keys, "modules": modules}
 
 
 class StatusMonitor:
@@ -23,6 +160,7 @@ class StatusMonitor:
         self._last_seen: Dict[str, float] = {}
         self._last_ok: Dict[str, float] = {}
         self._last_payload: Dict[str, Any] = {}
+        self._capabilities: Dict[str, Dict[str, Any]] = {}
         self._running = False
 
     # ------------------------------------------------------------------
@@ -66,6 +204,13 @@ class StatusMonitor:
             self._last_payload[node_id] = payload
             if status_value == "ok":
                 self._last_ok[node_id] = now
+            capabilities = _normalize_capabilities(payload)
+            if capabilities is not None:
+                self._capabilities[node_id] = {
+                    "timestamp": now,
+                    "module_keys": capabilities["module_keys"],
+                    "modules": capabilities["modules"],
+                }
 
     # ------------------------------------------------------------------
     # Public helpers
@@ -111,12 +256,46 @@ class StatusMonitor:
             },
         )
 
+    def capabilities_for(self, node_id: str) -> Dict[str, Any]:
+        """Return normalized capability metadata for ``node_id``."""
+
+        with self._lock:
+            payload = self._last_payload.get(node_id)
+            record = self._capabilities.get(node_id)
+            if not record:
+                return {
+                    "timestamp": None,
+                    "module_keys": [],
+                    "modules": {},
+                    "payload": payload,
+                }
+            modules_copy: Dict[str, Dict[str, Any]] = {}
+            for key, meta in record.get("modules", {}).items():
+                copy: Dict[str, Any] = {
+                    "indices": list(meta.get("indices", [])),
+                    "enabled": bool(meta.get("enabled", False)),
+                }
+                if "status" in meta:
+                    status_entries = meta["status"]
+                    if isinstance(status_entries, list):
+                        copy["status"] = status_entries
+                if "summary" in meta:
+                    copy["summary"] = meta["summary"]
+                modules_copy[key] = copy
+            return {
+                "timestamp": record.get("timestamp"),
+                "module_keys": list(record.get("module_keys", [])),
+                "modules": modules_copy,
+                "payload": payload,
+            }
+
     def forget(self, node_id: str) -> None:
         """Drop any cached status information for ``node_id``."""
         with self._lock:
             self._last_seen.pop(node_id, None)
             self._last_ok.pop(node_id, None)
             self._last_payload.pop(node_id, None)
+            self._capabilities.pop(node_id, None)
 
 
 status_monitor = StatusMonitor()


### PR DESCRIPTION
## Summary
- cache normalized module capabilities with timestamps in the status monitor so callers can inspect live hardware support
- add an async request_status_snapshot helper on the MQTT bus and use it from the node page to render modules with current strip/channel indices
- validate API commands against reported module indices instead of hard-coded ranges to match the node's advertised capabilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccd720d47883269e6bcc81f5dcfae7