### PR TITLE
Implement dynamic module discovery

### DIFF
--- a/Server/app/node_capabilities.py
+++ b/Server/app/node_capabilities.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+"""Helpers for normalizing node module capability metadata."""
+
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+
+FALSEY_STRINGS = {"", "0", "false", "no", "off", "disabled", "inactive"}
+
+# Default index ranges when no live capability data is available.
+DEFAULT_INDEX_RANGES: Mapping[str, Sequence[int]] = {
+    "ws": range(4),
+    "rgb": range(4),
+    "white": range(4),
+}
+
+
+def _normalize_key(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _coerce_enabled(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in FALSEY_STRINGS
+    return bool(value)
+
+
+def _module_entry_enabled(config: Any) -> bool:
+    if isinstance(config, Mapping):
+        if "enabled" in config:
+            return _coerce_enabled(config.get("enabled"))
+        return True
+    return _coerce_enabled(config)
+
+
+def registry_enabled_modules(node: Mapping[str, Any]) -> list[str]:
+    """Return enabled module identifiers from a registry ``node`` entry."""
+
+    modules = node.get("modules")
+    if not modules:
+        return []
+
+    result: list[str] = []
+    seen: set[str] = set()
+
+    def _push(name: Any, cfg: Any = True) -> None:
+        key = _normalize_key(name)
+        if not key or key in seen:
+            return
+        if _module_entry_enabled(cfg):
+            result.append(key)
+            seen.add(key)
+
+    if isinstance(modules, Mapping):
+        for key, cfg in modules.items():
+            _push(key, cfg)
+        return result
+
+    if isinstance(modules, (list, tuple, set)):
+        for entry in modules:
+            if isinstance(entry, Mapping):
+                name = (
+                    entry.get("key")
+                    or entry.get("module")
+                    or entry.get("id")
+                    or entry.get("name")
+                    or entry.get("slug")
+                    or entry.get("template")
+                )
+                _push(name, entry)
+            else:
+                _push(entry)
+        return result
+
+    if isinstance(modules, str):
+        _push(modules)
+        return result
+
+    _push(modules)
+    return result
+
+
+def merge_module_lists(primary: Sequence[str], fallback: Sequence[str]) -> list[str]:
+    """Combine two module lists preserving the order of each input."""
+
+    result: list[str] = []
+    seen: set[str] = set()
+
+    for source in (primary, fallback):
+        for item in source:
+            key = _normalize_key(item)
+            if not key or key in seen:
+                continue
+            result.append(key)
+            seen.add(key)
+    return result
+
+
+def coerce_index(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        idx = int(value)
+        return idx if idx >= 0 else None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+        try:
+            idx = int(value, 10)
+        except ValueError:
+            return None
+        return idx if idx >= 0 else None
+    return None
+
+
+def sanitize_index_list(values: Any) -> list[int]:
+    if not isinstance(values, Iterable) or isinstance(values, (str, bytes)):
+        return []
+    result: list[int] = []
+    seen: set[int] = set()
+    for item in values:
+        idx = coerce_index(item)
+        if idx is None or idx in seen:
+            continue
+        seen.add(idx)
+        result.append(idx)
+    result.sort()
+    return result
+
+
+def build_index_options(
+    capability_indexes: Mapping[str, Mapping[str, Any]],
+    defaults: Mapping[str, Iterable[int]] = DEFAULT_INDEX_RANGES,
+) -> dict[str, list[int]]:
+    """Return a mapping of module -> preferred index list."""
+
+    result: dict[str, list[int]] = {}
+    for module, default_values in defaults.items():
+        result[module] = list(default_values)
+
+    for module, data in capability_indexes.items():
+        enabled = sanitize_index_list(data.get("enabled"))
+        available = sanitize_index_list(data.get("available"))
+        if enabled:
+            result[module] = enabled
+        elif available:
+            result[module] = available
+        elif module not in result:
+            result[module] = []
+
+    return result
+
+
+def copy_capability_indexes(indexes: Mapping[str, Mapping[str, Any]]) -> dict[str, dict[str, list[int]]]:
+    """Return a sanitized deep copy of capability index data."""
+
+    result: dict[str, dict[str, list[int]]] = {}
+    for module, data in indexes.items():
+        result[module] = {
+            "enabled": sanitize_index_list(data.get("enabled")),
+            "available": sanitize_index_list(data.get("available")),
+        }
+    return result
+

--- a/Server/app/status_monitor.py
+++ b/Server/app/status_monitor.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 import json
 import threading
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import paho.mqtt.client as mqtt
 
 from .config import settings
+from .node_capabilities import (
+    FALSEY_STRINGS,
+    copy_capability_indexes,
+    coerce_index,
+)
 
 
 class StatusMonitor:
@@ -20,9 +25,12 @@ class StatusMonitor:
         self.client.on_connect = self._on_connect
         self.client.on_message = self._on_message
         self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
         self._last_seen: Dict[str, float] = {}
         self._last_ok: Dict[str, float] = {}
         self._last_payload: Dict[str, Any] = {}
+        self._capabilities: Dict[str, Dict[str, Any]] = {}
+        self._capability_ts: Dict[str, float] = {}
         self._running = False
 
     # ------------------------------------------------------------------
@@ -61,18 +69,29 @@ class StatusMonitor:
         status_value: Any = None
         if isinstance(payload, dict):
             status_value = payload.get("status")
-        with self._lock:
+        modules: list[str] = []
+        indexes: Dict[str, Dict[str, Any]] = {}
+        if isinstance(payload, dict):
+            modules, indexes = self._extract_capabilities(payload)
+        with self._condition:
             self._last_seen[node_id] = now
             self._last_payload[node_id] = payload
             if status_value == "ok":
                 self._last_ok[node_id] = now
+            if modules or indexes:
+                self._capabilities[node_id] = {
+                    "modules": modules,
+                    "indexes": copy_capability_indexes(indexes),
+                }
+                self._capability_ts[node_id] = now
+            self._condition.notify_all()
 
     # ------------------------------------------------------------------
     # Public helpers
     def snapshot(self) -> Dict[str, Dict[str, Any]]:
         """Return a shallow copy of the current status information."""
         now = time.time()
-        with self._lock:
+        with self._condition:
             keys = set(self._last_seen) | set(self._last_ok)
             data: Dict[str, Dict[str, Any]] = {}
             for node_id in keys:
@@ -98,6 +117,99 @@ class StatusMonitor:
             node_id,
             {"online": False, "last_seen": None, "last_ok": None, "status": None, "payload": None},
         )
+
+    def capabilities_for(self, node_id: str) -> Dict[str, Any]:
+        """Return the latest parsed module capability data for ``node_id``."""
+
+        with self._condition:
+            return self._current_capabilities_locked(node_id)
+
+    def wait_for_capabilities(
+        self, node_id: str, after: Optional[float], timeout: float
+    ) -> Dict[str, Any]:
+        """Block until capabilities newer than ``after`` are observed or timeout."""
+
+        deadline = time.time() + max(0.0, timeout)
+        with self._condition:
+            while True:
+                updated_at = self._capability_ts.get(node_id)
+                if updated_at is not None and (after is None or updated_at > after):
+                    break
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    break
+                self._condition.wait(timeout=remaining)
+            return self._current_capabilities_locked(node_id)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _current_capabilities_locked(self, node_id: str) -> Dict[str, Any]:
+        payload = self._last_payload.get(node_id)
+        updated_at = self._capability_ts.get(node_id)
+        data = self._capabilities.get(node_id, {})
+        modules = list(data.get("modules", []))
+        indexes = copy_capability_indexes(data.get("indexes", {})) if data else {}
+        return {
+            "modules": modules,
+            "indexes": indexes,
+            "payload": payload,
+            "updated_at": updated_at,
+        }
+
+    def _extract_capabilities(
+        self, payload: Dict[str, Any]
+    ) -> tuple[list[str], Dict[str, Dict[str, Any]]]:
+        modules: list[str] = []
+        indexes: Dict[str, Dict[str, Any]] = {}
+
+        def handle(module: str, key: str, index_field: str) -> None:
+            entries = payload.get(key)
+            data = self._collect_indexes(entries, index_field)
+            if data["available"] or data["enabled"] or (
+                isinstance(entries, list) and entries
+            ):
+                indexes[module] = data
+                modules.append(module)
+
+        handle("ws", "ws", "strip")
+        handle("rgb", "rgb", "strip")
+        handle("white", "white", "channel")
+
+        if isinstance(payload.get("ota"), dict):
+            modules.append("ota")
+            indexes.setdefault("ota", {"available": [], "enabled": []})
+
+        seen: set[str] = set()
+        ordered_modules: list[str] = []
+        for module in modules:
+            if module in seen:
+                continue
+            seen.add(module)
+            ordered_modules.append(module)
+        return ordered_modules, indexes
+
+    def _collect_indexes(self, entries: Any, index_field: str) -> Dict[str, list[int]]:
+        available: set[int] = set()
+        enabled: set[int] = set()
+        if isinstance(entries, list):
+            for item in entries:
+                if not isinstance(item, dict):
+                    continue
+                idx = coerce_index(item.get(index_field))
+                if idx is None:
+                    continue
+                available.add(idx)
+                enabled_value = item.get("enabled", True)
+                if isinstance(enabled_value, str):
+                    flag = enabled_value.strip().lower() not in FALSEY_STRINGS
+                else:
+                    flag = bool(enabled_value)
+                if flag:
+                    enabled.add(idx)
+        return {
+            "available": sorted(available),
+            "enabled": sorted(enabled),
+        }
 
 
 status_monitor = StatusMonitor()

--- a/Server/app/templates/modules/rgb.html
+++ b/Server/app/templates/modules/rgb.html
@@ -2,8 +2,9 @@
   <h3 class="text-lg font-semibold mb-3">RGB Strip</h3>
   <div class="mb-2">
     <label class="text-xs opacity-70">Strip</label>
+    {% set rgb_strips = module_index_options.get('rgb', range(4)) %}
     <select id="rgbStrip" class="p-1 rounded bg-slate-900 border border-slate-700">
-      {% for i in range(4) %}
+      {% for i in rgb_strips %}
       <option value="{{ i }}">{{ i }}</option>
       {% endfor %}
     </select>

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -2,8 +2,9 @@
   <h3 class="text-lg font-semibold mb-3">White Channel</h3>
   <div class="mb-2">
     <label class="text-xs opacity-70">Channel</label>
+    {% set white_channels = module_index_options.get('white', range(4)) %}
     <select id="wChannel" class="p-1 rounded bg-slate-900 border border-slate-700">
-      {% for i in range(4) %}
+      {% for i in white_channels %}
       <option value="{{ i }}">{{ i }}</option>
       {% endfor %}
     </select>

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -2,8 +2,9 @@
   <h3 class="text-lg font-semibold mb-3">Addressable Strip</h3>
   <div class="mb-2">
     <label class="text-xs opacity-70">Strip</label>
+    {% set ws_indices = module_index_options.get('ws', range(4)) %}
     <select id="wsStrip" class="p-1 rounded bg-slate-900 border border-slate-700">
-      {% for i in range(4) %}
+      {% for i in ws_indices %}
       <option value="{{ i }}">{{ i }}</option>
       {% endfor %}
     </select>

--- a/Server/app/templates/node.html
+++ b/Server/app/templates/node.html
@@ -4,9 +4,24 @@
 <script>
   window.nodeBrightnessLimits = {{ brightness_limits|default({})|tojson }};
 </script>
+{% if node_modules %}
+{% if module_source == 'mqtt' %}
+<div class="text-xs opacity-60 mb-2">
+  Modules reported by device{% if capability_updated_at_iso %} (updated {{ capability_updated_at_iso }}){% endif %}.
+</div>
+{% else %}
+<div class="text-xs opacity-60 mb-2">
+  Using registry configuration; waiting for device capabilities.
+</div>
+{% endif %}
 <div class="grid md:grid-cols-2 gap-6">
-  {% for mod in node.modules %}
-    {% include 'modules/' ~ mod ~ '.html' %}
+  {% for mod in node_modules %}
+    {% include 'modules/' ~ mod ~ '.html' ignore missing %}
   {% endfor %}
 </div>
+{% else %}
+<div class="glass rounded-2xl p-6 text-sm opacity-70">
+  This node has no enabled modules configured.
+</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add utilities to normalize registry module entries and channel index defaults for capabilities
- update the status monitor, MQTT bus, and API routes to track live module metadata and enforce dynamic strip/channel validation
- render node pages with live capability data, including dynamic strip/channel selectors and source status messaging in the templates

## Testing
- python -m compileall Server/app

------
https://chatgpt.com/codex/tasks/task_e_68ccbe80d2dc8326905b33edc293ff8f