### PR TITLE
Include persisted params in MQTT snapshots

### DIFF
--- a/UltraNodeV5/components/ul_state/include/ul_state.h
+++ b/UltraNodeV5/components/ul_state/include/ul_state.h
@@ -3,6 +3,8 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#define UL_STATE_MAX_JSON_LEN 1024
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,6 +21,14 @@ void ul_state_init(void);
 void ul_state_record_ws(int strip, const char *payload, size_t len);
 void ul_state_record_rgb(int strip, const char *payload, size_t len);
 void ul_state_record_white(int channel, const char *payload, size_t len);
+
+// Copies the most recent persisted JSON payload for the requested target into
+// the caller-provided buffer. The copy includes the terminating null byte. The
+// buffer is cleared and false is returned if no payload has been recorded or
+// the buffer is too small.
+bool ul_state_copy_ws(int strip, char *buffer, size_t buffer_len);
+bool ul_state_copy_rgb(int strip, char *buffer, size_t buffer_len);
+bool ul_state_copy_white(int channel, char *buffer, size_t buffer_len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add helpers in `ul_state` to expose the last persisted JSON payload for each lighting target
- tag MQTT status snapshots as events and populate them with the latest params from persisted commands
- publish fresh snapshots after lighting commands so downstream consumers always see full channel state

## Testing
- idf.py build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cce953d980832682a5309f1e0972f5