### PR TITLE
Add node state snapshot API

### DIFF
--- a/Server/app/mqtt_bus.py
+++ b/Server/app/mqtt_bus.py
@@ -168,6 +168,10 @@ class MqttBus:
         """Program motion state commands on the node."""
         self.pub(topic_cmd(node_id, "sensor/motion"), states)
 
+    def status_request(self, node_id: str) -> None:
+        """Request a full status snapshot from ``node_id``."""
+        self.pub(topic_cmd(node_id, "status"), {}, retain=False)
+
     # ---- OTA ----
     def ota_check(self, node_id: str):
         """Trigger an OTA update check without retaining the command."""

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -30,6 +30,7 @@ from .brightness_limits import brightness_limits
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
+NODE_MODULE_TEMPLATES = ["ws", "rgb", "white", "sensor", "ota", "motion"]
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -286,5 +287,6 @@ def node_page(request: Request, node_id: str):
             "status_timeout": status_monitor.timeout,
             "status_initial_online": status_initial_online,
             "brightness_limits": brightness_limits.get_limits_for_node(node["id"]),
+            "module_templates": NODE_MODULE_TEMPLATES,
         },
     )

--- a/Server/app/templates/node.html
+++ b/Server/app/templates/node.html
@@ -14,17 +14,26 @@
 <script>
   window.nodeBrightnessLimits = {{ brightness_limits|default({})|tojson }};
 </script>
+{% set default_modules = node.modules or [] %}
 <div class="grid md:grid-cols-2 gap-6">
-  {% for mod in node.modules %}
-    {% include 'modules/' ~ mod ~ '.html' %}
+  {% for mod in module_templates %}
+    <div
+      data-module="{{ mod }}"
+      class="module-card{% if mod not in default_modules %} hidden{% endif %}"
+    >
+      {% include 'modules/' ~ mod ~ '.html' %}
+    </div>
   {% endfor %}
 </div>
 
 <script>
 const STATUS_NODE_ID = {{ node.id|tojson }};
 const STATUS_TIMEOUT = {{ status_timeout|tojson }};
+const DEFAULT_MODULES = new Set({{ default_modules|tojson }});
 const STATUS_URL = `/api/node/${encodeURIComponent(STATUS_NODE_ID)}/status`;
+const STATE_URL = `/api/node/${encodeURIComponent(STATUS_NODE_ID)}/state`;
 const statusDot = document.getElementById('nodeStatusDot');
+const moduleWrappers = Array.from(document.querySelectorAll('[data-module]'));
 
 function setDot(online) {
   if (!statusDot) return;
@@ -58,5 +67,43 @@ async function refreshStatus() {
 
 refreshStatus();
 setInterval(refreshStatus, 5000);
+
+function applyModuleVisibility(modulesList) {
+  let active;
+  if (Array.isArray(modulesList)) {
+    active = new Set(modulesList.map((value) => String(value)));
+  } else {
+    active = new Set(DEFAULT_MODULES);
+  }
+  moduleWrappers.forEach((wrapper) => {
+    const key = wrapper.dataset.module;
+    if (!key) return;
+    if (active.has(key)) {
+      wrapper.classList.remove('hidden');
+    } else {
+      wrapper.classList.add('hidden');
+    }
+  });
+}
+
+async function refreshState() {
+  try {
+    const res = await fetch(STATE_URL, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (data && typeof data === 'object') {
+      if (data.limits && typeof data.limits === 'object') {
+        window.nodeBrightnessLimits = data.limits;
+      }
+      applyModuleVisibility(data.available_modules);
+    }
+  } catch (err) {
+    console.error('Failed to fetch node state', err);
+    applyModuleVisibility(null);
+  }
+}
+
+applyModuleVisibility(null);
+refreshState();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add an MQTT `status_request` helper and extend the status monitor with sequence tracking plus a snapshot wait helper
- expose `/api/node/{node_id}/state` that requests a fresh snapshot, normalizes module data, and returns brightness limits
- update the node page context and script so module panels show or hide based on the API response instead of registry defaults

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cceb301c9c832680c9232540eb29c2