### PR TITLE
Fix node module loader initialization

### DIFF
--- a/Server/app/templates/node.html
+++ b/Server/app/templates/node.html
@@ -42,7 +42,7 @@ const STATE_URL = `/api/node/${encodeURIComponent(STATUS_NODE_ID)}/state`;
 const statusDot = document.getElementById('nodeStatusDot');
 const moduleWrappers = Array.from(document.querySelectorAll('[data-module]'));
 const moduleStatusMessage = document.getElementById('moduleStateMessage');
-const moduleLoaders = window.nodeModuleLoaders || {};
+const moduleLoaders = (window.nodeModuleLoaders = window.nodeModuleLoaders || {});
 
 function setModuleStateMessage(text, mode) {
   if (!moduleStatusMessage) return;


### PR DESCRIPTION
## Summary
- ensure the node state script reuses the global module loader registry so module templates can register their initializers before state data is applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccf5e6b7508326b6482c71bb73627f