### PR TITLE
Add preset management controls to room page

### DIFF
--- a/Server/app/static/app.css
+++ b/Server/app/static/app.css
@@ -198,6 +198,45 @@ label { font-size: .7rem; color: var(--muted); display: block; margin-bottom: .2
 }
 .motion-button:hover { filter: brightness(1.08); }
 .motion-button:active { transform: translateY(1px); }
+
+.preset-item {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.preset-delete {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 22px;
+  height: 22px;
+  border-radius: 9999px;
+  border: 1px solid rgba(248, 250, 252, 0.45);
+  background: rgba(15, 23, 42, 0.85);
+  color: rgba(248, 113, 113, 0.95);
+  font-size: 0.75rem;
+  line-height: 1;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform .12s ease, filter .15s ease;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.45);
+  z-index: 2;
+}
+
+.preset-delete:hover {
+  filter: brightness(1.15);
+}
+
+.preset-delete:active {
+  transform: translateY(1px);
+}
+
+.preset-item[data-custom="true"] .preset-delete {
+  display: inline-flex;
+}
 .motion-button--primary {
   background: linear-gradient(180deg, rgba(129,140,248,.85), rgba(99,102,241,.75));
   border-color: rgba(129,140,248,.6);

--- a/Server/app/static/presets.js
+++ b/Server/app/static/presets.js
@@ -1,0 +1,254 @@
+const container = document.getElementById('presetList');
+if (container) {
+  const statusEl = document.getElementById('presetStatus');
+  const saveButton = document.getElementById('presetSaveButton');
+  const baseUrl = container.dataset.apiBase || '';
+  const presetsUrl = baseUrl ? `${baseUrl}/presets` : '';
+  const applyUrlFor = (id) => `${baseUrl}/preset/${encodeURIComponent(id)}`;
+  let statusTimer = null;
+
+  const statusClasses = {
+    base: 'text-sm mb-3 opacity-80',
+    info: 'text-sm mb-3 text-slate-200 opacity-80',
+    success: 'text-sm mb-3 text-emerald-300',
+    error: 'text-sm mb-3 text-rose-300',
+  };
+
+  const setStatus = (message, tone = 'base', autoClear = false) => {
+    if (!statusEl) return;
+    if (statusTimer) {
+      window.clearTimeout(statusTimer);
+      statusTimer = null;
+    }
+    if (!message) {
+      statusEl.textContent = '';
+      statusEl.className = statusClasses.base;
+      return;
+    }
+    const cls = statusClasses[tone] || statusClasses.base;
+    statusEl.className = cls;
+    statusEl.textContent = message;
+    if (autoClear) {
+      statusTimer = window.setTimeout(() => {
+        statusEl.textContent = '';
+        statusEl.className = statusClasses.base;
+        statusTimer = null;
+      }, 2400);
+    }
+  };
+
+  const normalizePresets = (list) => {
+    if (!Array.isArray(list)) {
+      return [];
+    }
+    const normalized = [];
+    list.forEach((preset) => {
+      if (!preset || preset.id === undefined || preset.id === null) {
+        return;
+      }
+      const id = String(preset.id);
+      const nameValue = preset.name;
+      const name =
+        nameValue === undefined || nameValue === null || nameValue === ''
+          ? id
+          : String(nameValue);
+      const source = preset.source ? String(preset.source) : '';
+      normalized.push({ ...preset, id, name, source });
+    });
+    return normalized;
+  };
+
+  const sharePresets = (list) => {
+    const copy = list.map((preset) => ({ ...preset }));
+    window.UltraLights = window.UltraLights || {};
+    window.UltraLights.presets = copy;
+    window.setTimeout(() => {
+      document.dispatchEvent(
+        new CustomEvent('ultralights:presets-changed', { detail: { presets: copy } }),
+      );
+    }, 0);
+  };
+
+  let initialRaw = [];
+  if (container.dataset.initialPresets) {
+    try {
+      initialRaw = JSON.parse(container.dataset.initialPresets);
+    } catch (err) {
+      initialRaw = [];
+    }
+  }
+  const initialPresets = normalizePresets(initialRaw);
+  let presets = initialPresets;
+
+  const isCustomPreset = (preset) => preset && String(preset.source || '').toLowerCase() === 'custom';
+
+  const renderPresets = () => {
+    container.innerHTML = '';
+    if (!presets.length) {
+      const empty = document.createElement('div');
+      empty.className = 'opacity-60';
+      empty.textContent = 'No presets configured.';
+      container.appendChild(empty);
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    presets.forEach((preset) => {
+      const id = preset.id;
+      const name = preset.name || id;
+      const wrapper = document.createElement('div');
+      wrapper.className = 'preset-item';
+      wrapper.dataset.presetId = id;
+      wrapper.dataset.custom = isCustomPreset(preset) ? 'true' : 'false';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'preset preset-button glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400';
+      button.dataset.presetId = id;
+      button.dataset.custom = wrapper.dataset.custom;
+      button.textContent = name;
+      button.title = `Apply preset ${name}`;
+      wrapper.appendChild(button);
+      if (wrapper.dataset.custom === 'true') {
+        const removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.className = 'preset-delete';
+        removeButton.dataset.presetId = id;
+        removeButton.setAttribute('aria-label', `Delete preset ${name}`);
+        removeButton.textContent = '✕';
+        wrapper.appendChild(removeButton);
+      }
+      fragment.appendChild(wrapper);
+    });
+    container.appendChild(fragment);
+  };
+
+  const fetchJson = async (url, options) => {
+    const response = await fetch(url, options);
+    let data = null;
+    try {
+      data = await response.json();
+    } catch (err) {
+      data = null;
+    }
+    if (!response.ok) {
+      const detail =
+        data && (data.detail || data.error || data.message || data.reason);
+      const message = detail ? String(detail) : `Request failed (${response.status})`;
+      throw new Error(message);
+    }
+    return data;
+  };
+
+  const updateFromResponse = (data) => {
+    if (data && Array.isArray(data.presets)) {
+      presets = normalizePresets(data.presets);
+      renderPresets();
+      sharePresets(presets);
+    }
+  };
+
+  const handleApply = async (id, button) => {
+    if (!id || !baseUrl) {
+      setStatus('Unable to apply preset at this time.', 'error');
+      return;
+    }
+    try {
+      if (button) button.disabled = true;
+      setStatus('Applying preset...', 'info');
+      await fetchJson(applyUrlFor(id), { method: 'POST' });
+      setStatus('Preset applied ✓', 'success', true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to apply preset.';
+      setStatus(`Failed to apply preset: ${message}`, 'error');
+    } finally {
+      if (button) button.disabled = false;
+    }
+  };
+
+  const handleSave = async () => {
+    if (!presetsUrl) {
+      setStatus('Saving presets is not available.', 'error');
+      return;
+    }
+    const rawName = window.prompt('Save preset as:');
+    if (rawName === null) {
+      return;
+    }
+    const name = String(rawName).trim();
+    if (!name) {
+      setStatus('Preset name is required.', 'error');
+      return;
+    }
+    try {
+      if (saveButton) saveButton.disabled = true;
+      setStatus('Saving preset...', 'info');
+      const data = await fetchJson(presetsUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      updateFromResponse(data);
+      setStatus('Preset saved ✓', 'success', true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save preset.';
+      setStatus(`Failed to save preset: ${message}`, 'error');
+    } finally {
+      if (saveButton) saveButton.disabled = false;
+    }
+  };
+
+  const handleDelete = async (id, button) => {
+    if (!id || !presetsUrl) {
+      setStatus('Unable to delete preset.', 'error');
+      return;
+    }
+    const preset = presets.find((entry) => entry.id === id);
+    const label = preset ? preset.name : id;
+    if (!window.confirm(`Delete preset "${label}"?`)) {
+      return;
+    }
+    try {
+      if (button) button.disabled = true;
+      setStatus('Deleting preset...', 'info');
+      const url = `${presetsUrl}?preset_id=${encodeURIComponent(id)}`;
+      const data = await fetchJson(url, { method: 'DELETE' });
+      updateFromResponse(data);
+      setStatus('Preset deleted ✓', 'success', true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete preset.';
+      setStatus(`Failed to delete preset: ${message}`, 'error');
+    } finally {
+      if (button) button.disabled = false;
+    }
+  };
+
+  container.addEventListener('click', (event) => {
+    const deleteButton = event.target.closest('button.preset-delete');
+    if (deleteButton) {
+      event.preventDefault();
+      event.stopPropagation();
+      const id = deleteButton.dataset.presetId;
+      if (id) {
+        handleDelete(id, deleteButton);
+      }
+      return;
+    }
+    const presetButton = event.target.closest('button.preset-button');
+    if (presetButton) {
+      const id = presetButton.dataset.presetId;
+      if (id) {
+        handleApply(id, presetButton);
+      }
+    }
+  });
+
+  if (saveButton) {
+    saveButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      handleSave();
+    });
+  }
+
+  renderPresets();
+  setStatus('', 'base');
+  sharePresets(presets);
+}

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -13,11 +13,20 @@
   </a>
   {% endfor %}
 </div>
-<div class="mt-8">
-  <h2 class="text-2xl font-semibold mb-4">Presets</h2>
-  <div class="flex flex-wrap gap-2">
+<div class="mt-8" id="presetSection">
+  <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+    <h2 class="text-2xl font-semibold">Presets</h2>
+    <button id="presetSaveButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400">Save Preset</button>
+  </div>
+  <div id="presetStatus" class="text-sm mb-3 opacity-80" role="status" aria-live="polite"></div>
+  <div id="presetList" class="flex flex-wrap gap-2" data-house-id="{{ house.id }}" data-room-id="{{ room.id }}" data-api-base="/api/house/{{ house.id }}/room/{{ room.id }}" data-initial-presets='{{ presets|tojson }}'>
     {% for p in presets %}
-    <button class="preset glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400" data-id="{{ p.id }}">{{ p.name }}</button>
+    <div class="preset-item" data-preset-id="{{ p.id }}" data-custom="{{ 'true' if p.source == 'custom' else 'false' }}">
+      <button class="preset preset-button glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400" type="button" data-preset-id="{{ p.id }}">{{ p.name or p.id }}</button>
+      {% if p.source == 'custom' %}
+      <button class="preset-delete" type="button" aria-label="Delete preset {{ p.name or p.id }}" data-preset-id="{{ p.id }}">✕</button>
+      {% endif %}
+    </div>
     {% else %}
     <div class="opacity-60">No presets configured.</div>
     {% endfor %}
@@ -82,6 +91,7 @@
   <div id="motionTimerLabel" class="text-center mt-2"></div>
 </div>
 {% endif %}
+<script type="module" src="/static/presets.js"></script>
 <script>
 document.getElementById('addNode').onclick = async () => {
   const name = prompt('New node name');
@@ -91,15 +101,6 @@ document.getElementById('addNode').onclick = async () => {
   });
   if(res.ok) location.reload(); else alert('Failed to add node');
 };
-document.querySelectorAll('.preset').forEach(btn => {
-  btn.onclick = async () => {
-    const id = btn.dataset.id;
-    const res = await fetch(`/api/house/{{ house.id }}/room/{{ room.id }}/preset/${id}`, {
-      method:'POST'
-    });
-    if(!res.ok) alert('Failed to apply preset');
-  };
-});
 {% if motion_config %}
 (function(){
   const scheduleContainer = document.getElementById('motionSchedule');
@@ -112,8 +113,20 @@ document.querySelectorAll('.preset').forEach(btn => {
     if (!scheduleData.length) {
       scheduleData.push(null);
     }
-    const presetNames = {{ motion_config.preset_names|tojson }};
-    const presetColors = {{ motion_config.preset_colors|tojson }};
+    const palette = [
+      "#f97316",
+      "#38bdf8",
+      "#a855f7",
+      "#22c55e",
+      "#eab308",
+      "#f43f5e",
+      "#6366f1",
+      "#14b8a6",
+      "#ec4899",
+      "#facc15",
+    ];
+    let presetNames = {{ motion_config.preset_names|tojson }};
+    let presetColors = {{ motion_config.preset_colors|tojson }};
     const noMotionColor = "{{ motion_config.no_motion_color }}";
     const slotMinutes = parseInt(scheduleContainer.dataset.slotMinutes || "60", 10) || 60;
     const startSelect = document.getElementById('motionScheduleStart');
@@ -299,6 +312,111 @@ document.querySelectorAll('.preset').forEach(btn => {
       }
       updateSlotHighlight();
     };
+
+    const rebuildPresetSelectOptions = (list) => {
+      if (!presetSelect) return;
+      const previous = presetSelect.value;
+      presetSelect.innerHTML = '';
+      const defaultOption = document.createElement('option');
+      defaultOption.value = '';
+      defaultOption.textContent = 'No Motion';
+      presetSelect.appendChild(defaultOption);
+      if (Array.isArray(list)) {
+        list.forEach((preset) => {
+          if (!preset || preset.id === undefined || preset.id === null) {
+            return;
+          }
+          const id = String(preset.id);
+          const name = preset.name ? String(preset.name) : id;
+          const opt = document.createElement('option');
+          opt.value = id;
+          opt.textContent = name;
+          presetSelect.appendChild(opt);
+        });
+      }
+      if (Array.from(presetSelect.options).some((opt) => opt.value === previous)) {
+        presetSelect.value = previous;
+      } else {
+        presetSelect.value = '';
+      }
+    };
+
+    const updateMotionPresets = (list) => {
+      const normalized = [];
+      if (Array.isArray(list)) {
+        list.forEach((preset) => {
+          if (!preset || preset.id === undefined || preset.id === null) {
+            return;
+          }
+          const id = String(preset.id);
+          const name = preset.name ? String(preset.name) : id;
+          normalized.push({ id, name });
+        });
+      }
+      const required = new Set(
+        Array.isArray(scheduleData)
+          ? scheduleData.filter((value) => value !== null && value !== undefined && value !== '')
+          : []
+      );
+      const newNames = { '': 'No Motion' };
+      normalized.forEach((preset) => {
+        newNames[preset.id] = preset.name;
+      });
+      required.forEach((id) => {
+        if (!newNames[id]) {
+          const fallback = presetNames[id] || String(id);
+          newNames[id] = fallback;
+        }
+      });
+      const newColors = {};
+      const usedColors = new Set();
+      normalized.forEach((preset, index) => {
+        const existing = presetColors[preset.id];
+        if (existing) {
+          newColors[preset.id] = existing;
+          usedColors.add(existing);
+          return;
+        }
+        let assigned = null;
+        for (let offset = 0; offset < palette.length; offset++) {
+          const candidate = palette[(index + offset) % palette.length];
+          if (!usedColors.has(candidate)) {
+            assigned = candidate;
+            break;
+          }
+        }
+        if (!assigned) {
+          assigned = palette[index % palette.length];
+        }
+        newColors[preset.id] = assigned;
+        usedColors.add(assigned);
+      });
+      required.forEach((id) => {
+        if (!newColors[id] && presetColors[id]) {
+          newColors[id] = presetColors[id];
+          usedColors.add(presetColors[id]);
+          if (!newNames[id]) {
+            newNames[id] = presetNames[id] || String(id);
+          }
+        }
+      });
+      presetNames = newNames;
+      presetColors = newColors;
+      rebuildPresetSelectOptions(normalized);
+      renderSchedule();
+      updateSelection(selectedSlot);
+    };
+
+    document.addEventListener('ultralights:presets-changed', (event) => {
+      if (!event || !event.detail || !Array.isArray(event.detail.presets)) {
+        return;
+      }
+      updateMotionPresets(event.detail.presets);
+    });
+
+    if (window.UltraLights && Array.isArray(window.UltraLights.presets)) {
+      updateMotionPresets(window.UltraLights.presets);
+    }
 
     const setStatus = (message, cls) => {
       if (!statusEl) return;


### PR DESCRIPTION
## Summary
- add a save preset control and status messaging to the room template while wiring presets through a dataset
- introduce a presets.js module to handle saving, applying, deleting presets and refreshing the list from API responses
- refresh motion-schedule preset options and styling so custom presets show a delete affordance without breaking existing behavior

## Testing
- not run (UI updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cd31d8ef00832696f1cc48812e9f11