### PR TITLE
Set node page status indicator to green on snapshot

### DIFF
--- a/Server/app/templates/node.html
+++ b/Server/app/templates/node.html
@@ -127,6 +127,8 @@ async function refreshState() {
     if (!data || typeof data !== 'object') {
       throw new Error('Invalid state payload');
     }
+    // A successful state fetch indicates we received a snapshot message.
+    setDot(true);
     const limits = data.limits && typeof data.limits === 'object' ? data.limits : {};
     window.nodeBrightnessLimits = limits;
     const modules = data.modules && typeof data.modules === 'object' ? data.modules : {};


### PR DESCRIPTION
## Summary
- ensure the node page connection indicator turns green once a snapshot response is received

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda8c0eb888326b2fdc08f1942b5af