### PR TITLE
Track PIR rooms for motion schedule

### DIFF
--- a/Server/app/motion.py
+++ b/Server/app/motion.py
@@ -1,5 +1,7 @@
+import json
 import threading
-from typing import Dict, Any
+import time
+from typing import Any, Dict, Optional, Tuple
 
 import paho.mqtt.client as mqtt
 from .config import settings
@@ -32,8 +34,13 @@ class MotionManager:
         # "preset_on".
         self.active: Dict[str, Dict[str, Any]] = {}
         self.config: Dict[str, Dict[str, Any]] = {}
+        # (house_id, room_id) -> {"house_id": str, "room_id": str,
+        #   "room_name": str, "nodes": {node_id: {"node_id": str,
+        #   "node_name": str, "config": {...}, "sensors": {...}}}}
+        self.room_sensors: Dict[Tuple[str, str], Dict[str, Any]] = {}
 
     def start(self) -> None:
+        self._seed_room_sensors_from_config()
         self.client.connect(settings.BROKER_HOST, settings.BROKER_PORT, keepalive=30)
         self.client.loop_start()
 
@@ -49,17 +56,41 @@ class MotionManager:
         self.active.clear()
 
     def configure_node(self, node_id: str, enabled: bool, duration: int) -> None:
-        self.config[node_id] = {"enabled": enabled, "duration": max(1, int(duration))}
+        clean_duration = max(1, int(duration))
+        config = {"enabled": bool(enabled), "duration": clean_duration}
+        self.config[node_id] = config
+        self._ensure_room_sensor_entry(node_id, config=config)
+
+    def forget_node(self, node_id: str) -> None:
+        self.config.pop(node_id, None)
+        for key, entry in list(self.room_sensors.items()):
+            nodes = entry.get("nodes", {})
+            if node_id in nodes:
+                nodes.pop(node_id, None)
+                if not nodes:
+                    self.room_sensors.pop(key, None)
 
     # MQTT callbacks -------------------------------------------------
     def _on_connect(self, client, userdata, flags, rc) -> None:
         client.subscribe("ul/+/evt/+/motion")
+        client.subscribe("ul/+/evt/status")
 
     def _on_message(self, client, userdata, msg: mqtt.MQTTMessage) -> None:
-        parts = msg.topic.split("/")
+        topic = msg.topic or ""
+        parts = topic.split("/")
+        if len(parts) < 4 or parts[0] != "ul" or parts[2] != "evt":
+            return
+        node_id = parts[1]
+        if len(parts) == 4 and parts[3] == "status":
+            self._handle_status_message(node_id, msg)
+            return
         if len(parts) < 5:
             return
-        node_id, sensor = parts[1], parts[3]
+        sensor = parts[3]
+        if parts[4] != "motion":
+            return
+        if sensor == "pir":
+            self._record_motion_event(node_id, sensor, msg.payload)
         if sensor != "pir":
             return
         cfg = self.config.get(node_id, {"enabled": True, "duration": 30})
@@ -151,5 +182,193 @@ class MotionManager:
                 apply_preset(self.bus, preset)
         if not timers:
             self.active.pop(room_id, None)
+
+    # Internal helpers -----------------------------------------------
+    def _seed_room_sensors_from_config(self) -> None:
+        for node_id in list(self.config.keys()):
+            self._ensure_room_sensor_entry(node_id)
+
+    def _handle_status_message(self, node_id: str, msg: mqtt.MQTTMessage) -> None:
+        payload = self._decode_json(msg.payload)
+        if not isinstance(payload, dict):
+            return
+        sensors = self._extract_sensor_states(payload)
+        if not sensors:
+            return
+        for sensor_id, sensor_payload in sensors.items():
+            self._record_sensor_status(node_id, str(sensor_id), sensor_payload)
+
+    def _record_sensor_status(self, node_id: str, sensor_id: str, payload: Any) -> None:
+        node_entry = self._ensure_room_sensor_entry(node_id)
+        if not node_entry:
+            return
+        sensors = node_entry.setdefault("sensors", {})
+        entry = sensors.setdefault(sensor_id, {})
+        normalized = self._normalize_sensor_payload(payload)
+        entry["last_status"] = time.time()
+        entry["raw"] = payload
+        data = normalized.get("data")
+        if data is not None:
+            entry["data"] = data
+        active = normalized.get("active")
+        if active is not None:
+            entry["active"] = active
+
+    def _record_motion_event(self, node_id: str, sensor: str, payload: bytes) -> None:
+        node_entry = self._ensure_room_sensor_entry(node_id)
+        if not node_entry:
+            return
+        sensors = node_entry.setdefault("sensors", {})
+        entry = sensors.setdefault(sensor, {})
+        decoded = self._decode_json(payload)
+        state_value: Optional[Any] = None
+        if isinstance(decoded, dict):
+            state_value = decoded.get("state")
+            entry["event_payload"] = decoded
+        else:
+            try:
+                text = payload.decode("utf-8")
+            except Exception:
+                text = ""
+            if text:
+                state_value = text
+        entry["last_event"] = time.time()
+        if state_value is not None:
+            entry["state"] = state_value
+            active = self._normalize_active_value(state_value)
+            if active is not None:
+                entry["active"] = active
+                if active:
+                    entry["last_detected"] = entry["last_event"]
+
+    def _normalize_sensor_payload(self, payload: Any) -> Dict[str, Any]:
+        data: Any = None
+        if isinstance(payload, dict):
+            data = dict(payload)
+        active: Optional[bool] = None
+        if isinstance(payload, dict):
+            for key in ("active", "state", "status", "value", "motion", "present"):
+                if key in payload:
+                    active = self._normalize_active_value(payload[key])
+                    if active is not None:
+                        break
+        else:
+            active = self._normalize_active_value(payload)
+        return {"active": active, "data": data if data is not None else payload}
+
+    def _normalize_active_value(self, value: Any) -> Optional[bool]:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            text = value.strip().lower()
+            if text in {
+                "1",
+                "true",
+                "yes",
+                "on",
+                "active",
+                "motion",
+                "motion_detected",
+                "motion_detect",
+                "detected",
+            }:
+                return True
+            if text in {
+                "0",
+                "false",
+                "no",
+                "off",
+                "inactive",
+                "clear",
+                "motion_clear",
+                "none",
+            }:
+                return False
+        return None
+
+    def _extract_sensor_states(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        sensors: Dict[str, Any] = {}
+        raw_sensors = payload.get("sensors")
+        if isinstance(raw_sensors, dict):
+            for key, value in raw_sensors.items():
+                sensors[str(key)] = value
+        modules = payload.get("modules")
+        if isinstance(modules, dict):
+            motion_state = modules.get("motion")
+            if isinstance(motion_state, dict):
+                module_sensors = motion_state.get("sensors")
+                if isinstance(module_sensors, dict):
+                    for key, value in module_sensors.items():
+                        sensors.setdefault(str(key), value)
+        motion = payload.get("motion")
+        if isinstance(motion, dict):
+            for key, value in motion.items():
+                sensors.setdefault(str(key), value)
+        sensor_info = payload.get("sensor")
+        if isinstance(sensor_info, dict):
+            sensor_id = sensor_info.get("id") or sensor_info.get("sid")
+            if sensor_id:
+                sensors.setdefault(str(sensor_id), sensor_info)
+        sid = payload.get("sid")
+        state = payload.get("state")
+        if sid is not None and state is not None:
+            sensors.setdefault(str(sid), payload)
+        if "pir" in payload and "pir" not in sensors:
+            sensors["pir"] = payload.get("pir")
+        return sensors
+
+    def _decode_json(self, payload: bytes) -> Any:
+        try:
+            text = payload.decode("utf-8")
+        except Exception:
+            return None
+        if not text:
+            return None
+        try:
+            return json.loads(text)
+        except Exception:
+            return None
+
+    def _ensure_room_sensor_entry(
+        self, node_id: str, *, config: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
+        house, room, node = registry.find_node(node_id)
+        if not house or not room or not node:
+            return None
+        house_id = house.get("id")
+        room_id = room.get("id")
+        if not house_id or not room_id:
+            return None
+        key = (house_id, room_id)
+        entry = self.room_sensors.setdefault(
+            key,
+            {
+                "house_id": house_id,
+                "room_id": room_id,
+                "room_name": room.get("name") or room_id,
+                "nodes": {},
+            },
+        )
+        nodes = entry.setdefault("nodes", {})
+        node_entry = nodes.setdefault(
+            node_id,
+            {
+                "node_id": node_id,
+                "node_name": node.get("name") or node_id,
+                "sensors": {},
+            },
+        )
+        node_entry["node_name"] = node.get("name") or node_id
+        config_data = config or self.config.get(node_id)
+        if config_data:
+            node_entry["config"] = {
+                "enabled": bool(config_data.get("enabled", True)),
+                "duration": int(config_data.get("duration", 30)),
+            }
+        else:
+            node_entry.setdefault("config", {"enabled": True, "duration": 30})
+        return node_entry
 
 motion_manager = MotionManager()

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -87,8 +87,34 @@
 </div>
 <div class="mt-8">
   <h2 class="text-2xl font-semibold mb-4">Motion Timer</h2>
-  <input type="range" id="motionTimer" min="10" max="3600" step="10" value="{{ motion_config.duration }}" data-node="{{ motion_config.node_id }}" class="w-full" />
-  <div id="motionTimerLabel" class="text-center mt-2"></div>
+  {% if motion_config.sensors %}
+  <div id="motionTimerList" class="space-y-4">
+    {% for sensor in motion_config.sensors %}
+    <div class="glass rounded-xl p-4 motion-timer" data-node="{{ sensor.node_id }}">
+      <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div>
+          <div class="text-lg font-semibold">{{ sensor.node_name }}</div>
+          <div class="text-xs uppercase tracking-wide opacity-60">
+            {{ 'Enabled' if sensor.enabled else 'Disabled' }}
+          </div>
+        </div>
+        <div class="motion-timer-label text-sm font-semibold"></div>
+      </div>
+      <input type="range"
+             id="motionTimer-{{ loop.index0 }}"
+             class="motion-timer-slider w-full"
+             min="10"
+             max="3600"
+             step="10"
+             value="{{ sensor.duration }}"
+             data-node="{{ sensor.node_id }}"
+             data-enabled="{{ 'true' if sensor.enabled else 'false' }}" />
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="opacity-60">No PIR sensors reported.</div>
+  {% endif %}
 </div>
 {% endif %}
 <script type="module" src="/static/presets.js"></script>
@@ -542,30 +568,43 @@ document.getElementById('addNode').onclick = async () => {
     }
   }
 
-  const timerSlider = document.getElementById('motionTimer');
-  if (timerSlider) {
-    const timerLabel = document.getElementById('motionTimerLabel');
-    const timerNodeId = timerSlider.dataset.node;
+  const timerSliders = document.querySelectorAll('.motion-timer-slider');
+  if (timerSliders.length) {
     const fmtTime = (sec) => {
+      if (!Number.isInteger(sec)) return '';
       if (sec < 60) return `${sec}s`;
       const m = Math.floor(sec / 60);
       const s = sec % 60;
       return s ? `${m}m ${s}s` : `${m}m`;
     };
-    const updateTimer = () => {
-      timerLabel.textContent = fmtTime(parseInt(timerSlider.value, 10));
-    };
-    timerSlider.addEventListener('input', updateTimer);
-    timerSlider.addEventListener('change', async () => {
-      const duration = parseInt(timerSlider.value, 10);
-      const res = await fetch(`/api/node/${timerNodeId}/motion`, {
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({enabled:true, duration})
+    timerSliders.forEach((slider) => {
+      const container = slider.closest('.motion-timer');
+      const label = container ? container.querySelector('.motion-timer-label') : null;
+      const nodeId = slider.dataset.node;
+      if (!nodeId) {
+        return;
+      }
+      const enabled = slider.dataset.enabled !== 'false';
+      const updateTimer = () => {
+        if (!label) return;
+        const duration = parseInt(slider.value, 10);
+        label.textContent = fmtTime(Number.isInteger(duration) ? duration : 0);
+      };
+      slider.addEventListener('input', updateTimer);
+      slider.addEventListener('change', async () => {
+        const duration = parseInt(slider.value, 10);
+        if (!Number.isInteger(duration)) {
+          return;
+        }
+        const res = await fetch(`/api/node/${nodeId}/motion`, {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({enabled, duration})
+        });
+        if(!res.ok) alert('Failed to update timer');
       });
-      if(!res.ok) alert('Failed to update timer');
+      updateTimer();
     });
-    updateTimer();
   }
 })();
 {% endif %}

--- a/Server/tests/test_motion.py
+++ b/Server/tests/test_motion.py
@@ -63,6 +63,7 @@ def _build_manager(module):
     manager.bus = _RecordingBus()
     manager.active = {}
     manager.config = {}
+    manager.room_sensors = {}
     return manager
 
 

--- a/Server/tests/test_room_page.py
+++ b/Server/tests/test_room_page.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+class _NoopBus:
+    def pub(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def ws_set(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def rgb_set(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def white_set(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def sensor_motion_program(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def status_request(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def ota_check(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def all_off(self):  # pragma: no cover - noop
+        pass
+
+
+@pytest.fixture()
+def app_modules(monkeypatch: pytest.MonkeyPatch) -> Iterator[Tuple[object, object]]:
+    import app.mqtt_bus
+
+    monkeypatch.setattr(app.mqtt_bus, "MqttBus", lambda *args, **kwargs: _NoopBus())
+    for module_name in ["app.motion", "app.routes_pages"]:
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+    motion = importlib.import_module("app.motion")
+    routes_pages = importlib.import_module("app.routes_pages")
+    try:
+        yield motion, routes_pages
+    finally:
+        for module_name in ["app.routes_pages", "app.motion"]:
+            if module_name in sys.modules:
+                del sys.modules[module_name]
+
+
+def test_room_page_motion_config_respects_room_sensors(app_modules) -> None:
+    motion_module, routes_pages = app_modules
+    from app.config import settings
+
+    original_registry = deepcopy(settings.DEVICE_REGISTRY)
+    original_config = deepcopy(motion_module.motion_manager.config)
+    original_room_sensors = deepcopy(motion_module.motion_manager.room_sensors)
+
+    test_registry = [
+        {
+            "id": "test-house",
+            "name": "Test House",
+            "rooms": [
+                {
+                    "id": "with-motion",
+                    "name": "Motion Room",
+                    "nodes": [
+                        {
+                            "id": "sensor-node",
+                            "name": "Sensor Node",
+                            "modules": ["white"],
+                        }
+                    ],
+                },
+                {
+                    "id": "no-motion",
+                    "name": "Plain Room",
+                    "nodes": [
+                        {
+                            "id": "plain-node",
+                            "name": "Plain Node",
+                            "modules": ["white"],
+                        }
+                    ],
+                },
+            ],
+        }
+    ]
+
+    try:
+        settings.DEVICE_REGISTRY = deepcopy(test_registry)
+        manager = motion_module.motion_manager
+        manager.config = {"sensor-node": {"enabled": True, "duration": 90}}
+        manager.room_sensors = {
+            ("test-house", "with-motion"): {
+                "house_id": "test-house",
+                "room_id": "with-motion",
+                "room_name": "Motion Room",
+                "nodes": {
+                    "sensor-node": {
+                        "node_id": "sensor-node",
+                        "node_name": "Sensor Node",
+                        "config": {"enabled": True, "duration": 90},
+                        "sensors": {"pir": {"active": True}},
+                    }
+                },
+            }
+        }
+
+        presets = []
+        motion_config = routes_pages._build_motion_config("test-house", "with-motion", presets)
+        assert motion_config is not None
+        assert motion_config["sensors"][0]["node_id"] == "sensor-node"
+        assert motion_config["sensors"][0]["duration"] == 90
+
+        motion_config_none = routes_pages._build_motion_config("test-house", "no-motion", presets)
+        assert motion_config_none is None
+    finally:
+        settings.DEVICE_REGISTRY = original_registry
+        motion_module.motion_manager.config = original_config
+        motion_module.motion_manager.room_sensors = original_room_sensors


### PR DESCRIPTION
## Summary
- extend the motion manager to track PIR sensor rooms and consume status updates
- derive room motion schedule configuration from the tracked sensors and support multiple nodes in the UI
- add coverage ensuring rooms with detected PIR sensors expose the schedule while others do not

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdca89b05c8326b5283c7c32271a44