### PR TITLE
Handle motion status command and cache PIR capability

### DIFF
--- a/Server/app/mqtt_bus.py
+++ b/Server/app/mqtt_bus.py
@@ -198,6 +198,15 @@ class MqttBus:
         """Program motion state commands on the node."""
         self.pub(topic_cmd(node_id, "sensor/motion"), states)
 
+    def motion_status_request(self, node_id: str, *, rate_limited: bool = False) -> None:
+        """Request the motion module status from ``node_id``."""
+        self.pub(
+            topic_cmd(node_id, "motion/status"),
+            {},
+            retain=False,
+            rate_limited=rate_limited,
+        )
+
     def status_request(self, node_id: str) -> None:
         """Request a full status snapshot from ``node_id``."""
         self.pub(topic_cmd(node_id, "status"), {}, retain=False)

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -46,6 +46,7 @@ def _build_motion_config(
     house_id: str, room_id: str, presets: List[Dict[str, Any]]
 ) -> Optional[Dict[str, Any]]:
     room_key = (house_id, room_id)
+    motion_manager.ensure_room_loaded(house_id, room_id)
     sensor_entry = motion_manager.room_sensors.get(room_key)
     sensor_nodes: List[Dict[str, Any]] = []
     if sensor_entry:
@@ -63,14 +64,18 @@ def _build_motion_config(
                     node_name = node_id
             duration = int(node_config.get("duration", 30)) if node_config else 30
             enabled = bool(node_config.get("enabled", True)) if node_config else True
-            sensor_nodes.append(
-                {
-                    "node_id": node_id,
-                    "node_name": node_name,
-                    "enabled": enabled,
-                    "duration": duration,
-                }
-            )
+            pir_enabled = None
+            if node_config is not None and "pir_enabled" in node_config:
+                pir_enabled = bool(node_config.get("pir_enabled"))
+            node_entry: Dict[str, Any] = {
+                "node_id": node_id,
+                "node_name": node_name,
+                "enabled": enabled,
+                "duration": duration,
+            }
+            if pir_enabled is not None:
+                node_entry["pir_enabled"] = pir_enabled
+            sensor_nodes.append(node_entry)
     if not sensor_nodes:
         return None
     sensor_nodes.sort(key=lambda item: item["node_name"].lower())

--- a/Server/tests/test_room_page.py
+++ b/Server/tests/test_room_page.py
@@ -32,6 +32,9 @@ class _NoopBus:
     def status_request(self, *args, **kwargs):  # pragma: no cover - noop
         pass
 
+    def motion_status_request(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
     def ota_check(self, *args, **kwargs):  # pragma: no cover - noop
         pass
 
@@ -99,7 +102,7 @@ def test_room_page_motion_config_respects_room_sensors(app_modules) -> None:
     try:
         settings.DEVICE_REGISTRY = deepcopy(test_registry)
         manager = motion_module.motion_manager
-        manager.config = {"sensor-node": {"enabled": True, "duration": 90}}
+        manager.config = {"sensor-node": {"enabled": True, "duration": 90, "pir_enabled": True}}
         manager.room_sensors = {
             ("test-house", "with-motion"): {
                 "house_id": "test-house",
@@ -109,7 +112,7 @@ def test_room_page_motion_config_respects_room_sensors(app_modules) -> None:
                     "sensor-node": {
                         "node_id": "sensor-node",
                         "node_name": "Sensor Node",
-                        "config": {"enabled": True, "duration": 90},
+                        "config": {"enabled": True, "duration": 90, "pir_enabled": True},
                         "sensors": {"pir": {"active": True}},
                     }
                 },
@@ -121,6 +124,7 @@ def test_room_page_motion_config_respects_room_sensors(app_modules) -> None:
         assert motion_config is not None
         assert motion_config["sensors"][0]["node_id"] == "sensor-node"
         assert motion_config["sensors"][0]["duration"] == 90
+        assert motion_config["sensors"][0]["pir_enabled"] is True
 
         motion_config_none = routes_pages._build_motion_config("test-house", "no-motion", presets)
         assert motion_config_none is None

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -11,6 +11,7 @@ All topics are rooted at `ul/<node-id>/`. The node subscribes to commands addres
 | → node | `ul/<node-id>/cmd/...` | Control commands |
 | ← node | `ul/<node-id>/evt/status` | Status updates and snapshots |
 | ← node | `ul/<node-id>/evt/sensor/motion` | Motion events |
+| ← node | `ul/<node-id>/evt/motion/status` | Motion module capabilities |
 | ← node | `ul/<node-id>/evt/ota` | OTA check and update progress |
 
 `<node-id>` is set at build time by `ul_core_get_node_id()`.
@@ -174,6 +175,16 @@ Motion state meanings:
 1. `0` – no motion
 2. `1` – motion detected
 
+`ul/<node-id>/cmd/motion/status` – request the motion module capabilities. The
+node responds on `ul/<node-id>/evt/motion/status` with:
+
+```json
+{ "pir_enabled": <bool> }
+```
+
+`pir_enabled` reports whether the firmware was built with the PIR task enabled
+and ready to publish motion events.
+
 `ul/<node-id>/cmd/ota/check` – empty JSON `{}` triggers an OTA manifest check.
 
 OTA progress events are published on `ul/<node-id>/evt/ota` with payload
@@ -189,6 +200,9 @@ Most commands produce a short acknowledgement on `ul/<node-id>/evt/status`:
 * `ws/set` echoes the chosen effect and its parameters.
 
 To retrieve the full device state, publish an empty JSON object to `ul/<node-id>/cmd/status`. The node then responds on `ul/<node-id>/evt/status` with a detailed snapshot describing each strip and channel. The `color` fields in the `ws` and `rgb` sections are meaningful only when the corresponding strip effect is `solid`.
+
+Snapshots also include `"pir_enabled": <bool>` so controllers can detect
+whether motion events are expected from the node.
 
 ## Publishing from Python
 


### PR DESCRIPTION
## Summary
- have the firmware publish pir_enabled in status snapshots and respond to motion/status commands
- document the new motion status command/event pair
- teach the server to request motion status, cache pir availability, and expose the value to the room page
- add tests covering the motion status handling and UI integration

## Testing
- pytest tests/test_motion.py tests/test_room_page.py

------
https://chatgpt.com/codex/tasks/task_e_68cdd3f8b6908326a5e4341b59b79419