### PR TITLE
Add motion immunity preferences and UI controls

### DIFF
--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -72,6 +72,12 @@ class Settings:
             str(Path(__file__).with_name("custom_presets.json")),
         )
     )
+    MOTION_PREFS_FILE = Path(
+        os.getenv(
+            "MOTION_PREFS_FILE",
+            str(Path(__file__).with_name("motion_prefs.json")),
+        )
+    )
     BRIGHTNESS_LIMITS_FILE = Path(
         os.getenv(
             "BRIGHTNESS_LIMITS_FILE",

--- a/Server/app/motion_prefs.py
+++ b/Server/app/motion_prefs.py
@@ -1,0 +1,178 @@
+"""Persistence helpers for motion automation preferences.
+
+The :class:`MotionPreferencesStore` keeps track of per-room node immunity
+settings for motion automation.  Immunity is represented as the set of node IDs
+that should be ignored whenever a motion preset is applied.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Dict, Iterable, Set
+
+from .config import settings
+
+
+class MotionPreferencesStore:
+    """Persist motion automation preferences to disk."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._lock = threading.RLock()
+        self._data = self._load()
+
+    def _load(self) -> Dict[str, Dict[str, Set[str]]]:
+        if not self.path.exists():
+            return {}
+        try:
+            raw = json.loads(self.path.read_text())
+        except Exception:
+            return {}
+
+        data: Dict[str, Dict[str, Set[str]]] = {}
+        if not isinstance(raw, dict):
+            return data
+
+        for house_id, rooms in raw.items():
+            if not isinstance(rooms, dict):
+                continue
+            house_key = str(house_id)
+            house_entry: Dict[str, Set[str]] = {}
+            for room_id, nodes in rooms.items():
+                node_set: Set[str] = set()
+                if isinstance(nodes, list):
+                    for node in nodes:
+                        node_text = str(node).strip()
+                        if node_text:
+                            node_set.add(node_text)
+                elif isinstance(nodes, set):
+                    for node in nodes:
+                        node_text = str(node).strip()
+                        if node_text:
+                            node_set.add(node_text)
+                if node_set:
+                    house_entry[str(room_id)] = node_set
+            if house_entry:
+                data[house_key] = house_entry
+        return data
+
+    def _serialize(self) -> Dict[str, Dict[str, list[str]]]:
+        serialized: Dict[str, Dict[str, list[str]]] = {}
+        for house_id, rooms in self._data.items():
+            clean_rooms: Dict[str, list[str]] = {}
+            for room_id, nodes in rooms.items():
+                if not nodes:
+                    continue
+                clean_rooms[room_id] = sorted(nodes)
+            if clean_rooms:
+                serialized[house_id] = clean_rooms
+        return serialized
+
+    def _save_locked(self) -> None:
+        payload = json.dumps(self._serialize(), indent=2)
+        tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path.write_text(payload)
+        tmp_path.replace(self.path)
+
+    def save(self) -> None:
+        with self._lock:
+            self._save_locked()
+
+    def get_room_immune_nodes(self, house_id: str, room_id: str) -> Set[str]:
+        house_key = str(house_id)
+        room_key = str(room_id)
+        with self._lock:
+            rooms = self._data.get(house_key)
+            if not rooms:
+                return set()
+            nodes = rooms.get(room_key)
+            if not nodes:
+                return set()
+            return set(nodes)
+
+    def set_room_immune_nodes(
+        self, house_id: str, room_id: str, nodes: Iterable[str]
+    ) -> Set[str]:
+        house_key = str(house_id)
+        room_key = str(room_id)
+        clean: Set[str] = set()
+        for node in nodes:
+            node_text = str(node).strip()
+            if node_text:
+                clean.add(node_text)
+
+        with self._lock:
+            if not clean:
+                rooms = self._data.get(house_key)
+                if rooms and room_key in rooms:
+                    rooms.pop(room_key, None)
+                    if not rooms:
+                        self._data.pop(house_key, None)
+                    self._save_locked()
+                return set()
+
+            rooms = self._data.setdefault(house_key, {})
+            rooms[room_key] = set(clean)
+            self._save_locked()
+            return set(clean)
+
+    def add_room_immune_node(
+        self, house_id: str, room_id: str, node_id: str
+    ) -> Set[str]:
+        node_key = str(node_id).strip()
+        if not node_key:
+            return self.get_room_immune_nodes(house_id, room_id)
+        with self._lock:
+            rooms = self._data.setdefault(str(house_id), {})
+            nodes = rooms.setdefault(str(room_id), set())
+            nodes.add(node_key)
+            self._save_locked()
+            return set(nodes)
+
+    def remove_room_immune_node(
+        self, house_id: str, room_id: str, node_id: str
+    ) -> Set[str]:
+        node_key = str(node_id).strip()
+        with self._lock:
+            rooms = self._data.get(str(house_id))
+            if not rooms:
+                return set()
+            nodes = rooms.get(str(room_id))
+            if not nodes or node_key not in nodes:
+                return set(nodes or set())
+            nodes.discard(node_key)
+            if not nodes:
+                rooms.pop(str(room_id), None)
+            if not rooms:
+                self._data.pop(str(house_id), None)
+            self._save_locked()
+            return set(nodes)
+
+    def remove_node(self, node_id: str) -> None:
+        node_key = str(node_id).strip()
+        if not node_key:
+            return
+        changed = False
+        with self._lock:
+            for house_id in list(self._data.keys()):
+                rooms = self._data[house_id]
+                for room_id in list(rooms.keys()):
+                    nodes = rooms[room_id]
+                    if node_key in nodes:
+                        nodes.discard(node_key)
+                        changed = True
+                    if not nodes:
+                        rooms.pop(room_id, None)
+                        changed = True
+                if not rooms:
+                    self._data.pop(house_id, None)
+                    changed = True
+            if changed:
+                self._save_locked()
+
+
+motion_preferences = MotionPreferencesStore(settings.MOTION_PREFS_FILE)
+

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -85,6 +85,33 @@
     </div>
   </div>
 </div>
+<div class="mt-8" id="motionImmunity" data-fetch-url="/api/house/{{ house.id }}/room/{{ room.id }}/motion-immune" data-save-url="/api/house/{{ house.id }}/room/{{ room.id }}/motion-immune">
+  <h2 class="text-2xl font-semibold mb-4">Motion Immunity</h2>
+  <div class="glass rounded-xl p-4">
+    <p class="text-sm opacity-80 mb-3">Select nodes to ignore when motion automations run.</p>
+    <div class="motion-immunity-status text-sm opacity-80 mb-3" role="status" aria-live="polite"></div>
+    {% if room.nodes %}
+    <div class="space-y-3" id="motionImmunityList" role="group" aria-label="Motion immunity nodes">
+      {% for n in room.nodes %}
+      <label class="flex items-center gap-3 motion-immunity-option">
+        <input type="checkbox"
+               class="motion-immunity-checkbox"
+               value="{{ n.id }}"
+               data-node-id="{{ n.id }}"
+               aria-label="Ignore {{ n.name }} ({{ n.id }})" />
+        <span>
+          <span class="font-semibold">{{ n.name }}</span>
+          <span class="block text-xs uppercase tracking-wide opacity-60">ID: {{ n.id }}</span>
+        </span>
+      </label>
+      {% endfor %}
+    </div>
+    <button type="button" class="motion-button motion-button--primary mt-4 motion-immunity-save">Save Changes</button>
+    {% else %}
+    <div class="opacity-60">No nodes available for motion immunity.</div>
+    {% endif %}
+  </div>
+</div>
 <div class="mt-8">
   <h2 class="text-2xl font-semibold mb-4">Motion Timer</h2>
   {% if motion_config.sensors %}
@@ -566,6 +593,166 @@ document.getElementById('addNode').onclick = async () => {
         }
       });
     }
+  }
+
+  const immunityContainer = document.getElementById('motionImmunity');
+  if (immunityContainer) {
+    const fetchUrl = immunityContainer.dataset.fetchUrl || '';
+    const saveUrl = immunityContainer.dataset.saveUrl || fetchUrl;
+    const statusEl = immunityContainer.querySelector('.motion-immunity-status');
+    const checkboxes = Array.from(
+      immunityContainer.querySelectorAll('.motion-immunity-checkbox')
+    );
+    const saveButton = immunityContainer.querySelector('.motion-immunity-save');
+    const statusClasses = {
+      base: 'motion-immunity-status text-sm opacity-80 mb-3',
+      info: 'motion-immunity-status text-sm text-slate-200 opacity-80 mb-3',
+      success: 'motion-immunity-status text-sm text-emerald-300 mb-3',
+      error: 'motion-immunity-status text-sm text-rose-300 mb-3',
+    };
+    let statusTimer = null;
+
+    const setStatus = (message, tone = 'base', autoClear = false) => {
+      if (!statusEl) return;
+      if (statusTimer) {
+        clearTimeout(statusTimer);
+        statusTimer = null;
+      }
+      if (!message) {
+        statusEl.textContent = '';
+        statusEl.className = statusClasses.base;
+        return;
+      }
+      const cls = statusClasses[tone] || statusClasses.base;
+      statusEl.className = cls;
+      statusEl.textContent = message;
+      if (autoClear) {
+        statusTimer = setTimeout(() => {
+          statusEl.textContent = '';
+          statusEl.className = statusClasses.base;
+          statusTimer = null;
+        }, 2200);
+      }
+    };
+
+    const normalizeList = (values) => {
+      const clean = [];
+      const seen = new Set();
+      if (Array.isArray(values)) {
+        values.forEach((value) => {
+          const text = value === undefined || value === null ? '' : String(value).trim();
+          if (text && !seen.has(text)) {
+            seen.add(text);
+            clean.push(text);
+          }
+        });
+      }
+      return clean;
+    };
+
+    const applyImmuneState = (values) => {
+      const immuneSet = new Set(values);
+      checkboxes.forEach((checkbox) => {
+        const nodeId = String(checkbox.value || '').trim();
+        checkbox.checked = immuneSet.has(nodeId);
+      });
+    };
+
+    const collectSelected = () => {
+      const selected = [];
+      const seen = new Set();
+      checkboxes.forEach((checkbox) => {
+        if (!checkbox.checked) {
+          return;
+        }
+        const value = String(checkbox.value || '').trim();
+        if (value && !seen.has(value)) {
+          seen.add(value);
+          selected.push(value);
+        }
+      });
+      return selected;
+    };
+
+    const loadImmunity = async () => {
+      if (!fetchUrl) {
+        return;
+      }
+      if (checkboxes.length) {
+        setStatus('Loading immunity...', 'info');
+      }
+      try {
+        const response = await fetch(fetchUrl);
+        let data = null;
+        try {
+          data = await response.json();
+        } catch (err) {
+          data = null;
+        }
+        if (!response.ok) {
+          const detail = data && (data.detail || data.error || data.message || data.reason);
+          const message = detail ? String(detail) : `Request failed (${response.status})`;
+          throw new Error(message);
+        }
+        const immune = normalizeList(data && data.immune);
+        applyImmuneState(immune);
+        setStatus('', 'base');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to load immunity.';
+        setStatus(`Failed to load immunity: ${message}`, 'error');
+      }
+    };
+
+    if (saveButton) {
+      if (!checkboxes.length || !saveUrl) {
+        saveButton.disabled = true;
+      }
+      saveButton.addEventListener('click', async () => {
+        if (!saveUrl) {
+          setStatus('Saving immunity is not available.', 'error');
+          return;
+        }
+        const selected = collectSelected();
+        try {
+          saveButton.disabled = true;
+          setStatus('Saving immunity...', 'info');
+          const response = await fetch(saveUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ immune: selected }),
+          });
+          let data = null;
+          try {
+            data = await response.json();
+          } catch (err) {
+            data = null;
+          }
+          if (!response.ok) {
+            const detail = data && (data.detail || data.error || data.message || data.reason);
+            const message = detail ? String(detail) : `Request failed (${response.status})`;
+            throw new Error(message);
+          }
+          const immune = normalizeList(data && data.immune);
+          applyImmuneState(immune);
+          setStatus('Immunity saved ✓', 'success', true);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to save immunity.';
+          setStatus(`Failed to save immunity: ${message}`, 'error');
+        } finally {
+          saveButton.disabled = !checkboxes.length || !saveUrl;
+        }
+      });
+    }
+
+    if (checkboxes.length) {
+      checkboxes.forEach((checkbox) => {
+        checkbox.addEventListener('change', () => {
+          setStatus('Unsaved changes – click save to persist.', 'info');
+        });
+      });
+    }
+
+    loadImmunity();
   }
 
   const timerSliders = document.querySelectorAll('.motion-timer-slider');

--- a/Server/tests/test_motion.py
+++ b/Server/tests/test_motion.py
@@ -40,18 +40,64 @@ class _NoopBus:
         pass
 
 
+class _TestMotionPrefs:
+    def __init__(self) -> None:
+        self.rooms: Dict[Tuple[str, str], set[str]] = {}
+
+    def get_room_immune_nodes(self, house_id: str, room_id: str) -> set[str]:
+        return set(self.rooms.get((house_id, room_id), set()))
+
+    def set_room_immune_nodes(
+        self, house_id: str, room_id: str, nodes
+    ) -> set[str]:
+        clean: set[str] = set()
+        for node in nodes:
+            text = str(node).strip()
+            if text:
+                clean.add(text)
+        key = (house_id, room_id)
+        if clean:
+            self.rooms[key] = set(clean)
+        else:
+            self.rooms.pop(key, None)
+        return set(clean)
+
+    def remove_node(self, node_id: str) -> None:
+        text = str(node_id).strip()
+        if not text:
+            return
+        to_delete: list[Tuple[str, str]] = []
+        for key, nodes in self.rooms.items():
+            if text in nodes:
+                nodes.discard(text)
+            if not nodes:
+                to_delete.append(key)
+        for key in to_delete:
+            self.rooms.pop(key, None)
+
+
 @pytest.fixture()
 def motion_module(monkeypatch: pytest.MonkeyPatch):
     """Return a freshly imported ``app.motion`` module with a stubbed bus."""
 
     import app.mqtt_bus
+    import app.motion_prefs
 
     monkeypatch.setattr(app.mqtt_bus, "MqttBus", lambda *args, **kwargs: _NoopBus())
     sys.modules.pop("app.motion", None)
     module = importlib.import_module("app.motion")
+    test_prefs = _TestMotionPrefs()
+    original_prefs = app.motion_prefs.motion_preferences
+    app.motion_prefs.motion_preferences = test_prefs
+    module.motion_preferences = test_prefs
+    module.motion_manager.motion_preferences = test_prefs
     try:
         yield module
     finally:
+        app.motion_prefs.motion_preferences = original_prefs
+        module.motion_preferences = original_prefs
+        if "motion_manager" in vars(module):
+            module.motion_manager.motion_preferences = original_prefs
         sys.modules.pop("app.motion", None)
 
 
@@ -75,8 +121,87 @@ def _build_manager(module):
     manager.room_sensors = {}
     manager._status_request_lock = threading.Lock()
     manager._status_request_times = {}
+    manager.motion_preferences = _TestMotionPrefs()
     return manager
 
+
+def test_motion_preferences_round_trip(tmp_path):
+    from app.motion_prefs import MotionPreferencesStore
+
+    prefs_path = tmp_path / "motion_prefs.json"
+    store = MotionPreferencesStore(prefs_path)
+
+    assert store.get_room_immune_nodes("house", "room") == set()
+
+    saved = store.set_room_immune_nodes(
+        "house", "room", [" node-a ", "node-b", "node-a", ""]
+    )
+    assert saved == {"node-a", "node-b"}
+
+    reloaded = MotionPreferencesStore(prefs_path)
+    assert reloaded.get_room_immune_nodes("house", "room") == {"node-a", "node-b"}
+
+    cleared = reloaded.set_room_immune_nodes("house", "room", [])
+    assert cleared == set()
+    assert reloaded.get_room_immune_nodes("house", "room") == set()
+
+    reloaded.set_room_immune_nodes("house", "other", ["node-b"])
+    reloaded.remove_node("node-b")
+    assert reloaded.get_room_immune_nodes("house", "other") == set()
+
+    final = MotionPreferencesStore(prefs_path)
+    assert final.get_room_immune_nodes("house", "room") == set()
+    assert final.get_room_immune_nodes("house", "other") == set()
+
+
+def test_apply_motion_preset_filters_actions(monkeypatch: pytest.MonkeyPatch, motion_module):
+    manager = _build_manager(motion_module)
+    manager.motion_preferences.set_room_immune_nodes(
+        "house", "room", ["immune-node"]
+    )
+
+    def preset_factory():
+        return {
+            "id": "motion-test",
+            "actions": [
+                {"module": "white", "node": "immune-node", "channel": 0, "effect": "off"},
+                {"module": "white", "node": "active-node", "channel": 1, "effect": "on"},
+                {"module": "white", "channel": 2, "effect": "dim"},
+            ],
+        }
+
+    preset = preset_factory()
+    captured: List[Dict[str, Any]] = []
+    monkeypatch.setattr(
+        motion_module,
+        "apply_preset",
+        lambda bus, payload: captured.append(payload),
+    )
+
+    applied = manager._apply_motion_preset("house", "room", preset)
+    assert applied is True
+    assert len(captured) == 1
+    filtered_actions = captured[0]["actions"]
+    assert len(filtered_actions) == 2
+    nodes = [action.get("node") for action in filtered_actions if isinstance(action, dict)]
+    assert "immune-node" not in nodes
+    assert "active-node" in nodes
+    assert len(preset["actions"]) == 3
+
+    captured.clear()
+    manager.motion_preferences.set_room_immune_nodes(
+        "house", "room", ["immune-node", "active-node"]
+    )
+    immune_only = {
+        "id": "immune-only",
+        "actions": [
+            {"module": "white", "node": "immune-node"},
+            {"module": "white", "node": "active-node"},
+        ],
+    }
+    applied = manager._apply_motion_preset("house", "room", immune_only)
+    assert applied is False
+    assert captured == []
 
 def test_turn_off_special_prefers_off_preset(monkeypatch: pytest.MonkeyPatch, motion_module):
     manager = _build_manager(motion_module)
@@ -117,6 +242,85 @@ def test_turn_off_special_falls_back_to_hint(monkeypatch: pytest.MonkeyPatch, mo
     assert applied == []
     assert manager.bus.published == [(expected_topic, {"hint": "swell-off"}, False)]
     assert room_id not in manager.active
+
+
+def test_motion_event_skips_immune_nodes(monkeypatch: pytest.MonkeyPatch, motion_module):
+    manager = _build_manager(motion_module)
+    house = {"id": "house-1", "name": "House"}
+    room = {
+        "id": "room-1",
+        "name": "Room",
+        "nodes": [{"id": "node-1", "name": "Node"}],
+    }
+    node = room["nodes"][0]
+
+    manager.config["node-1"] = {"enabled": True, "duration": 45}
+    manager.motion_preferences.set_room_immune_nodes("house-1", "room-1", ["node-1"])
+
+    monkeypatch.setattr(
+        motion_module.registry,
+        "find_node",
+        lambda node_id: (house, room, node) if node_id == "node-1" else (None, None, None),
+    )
+
+    applied: List[Dict[str, Any]] = []
+
+    def fake_get_preset(house_id: str, room_id: str, preset_id: str):
+        if (house_id, room_id, preset_id) == ("house-1", "room-1", "motion-far"):
+            return {
+                "id": preset_id,
+                "actions": [{"module": "white", "node": "node-1"}],
+            }
+        if (house_id, room_id, preset_id) == ("house-1", "room-1", "motion-far-off"):
+            return {
+                "id": preset_id,
+                "actions": [{"module": "white", "node": "node-1"}],
+            }
+        return None
+
+    class DummyTimer:
+        def __init__(self, interval, func, args=None, kwargs=None):
+            self.interval = interval
+            self.func = func
+            self.args = args or ()
+            self.kwargs = kwargs or {}
+            self.started = False
+            self.cancelled = False
+
+        def start(self) -> None:
+            self.started = True
+
+        def cancel(self) -> None:  # pragma: no cover - simple stub
+            self.cancelled = True
+
+    monkeypatch.setattr(motion_module, "get_preset", fake_get_preset)
+    monkeypatch.setattr(
+        motion_module,
+        "apply_preset",
+        lambda bus, preset: applied.append(preset),
+    )
+    monkeypatch.setattr(motion_module.threading, "Timer", DummyTimer)
+
+    message = types.SimpleNamespace(
+        topic="ul/node-1/evt/pir/motion",
+        payload=b'{"state": true}',
+    )
+
+    manager._on_message(None, None, message)
+
+    assert applied == []
+    assert room["id"] in manager.active
+    entry = manager.active[room["id"]]
+    assert entry["house_id"] == house["id"]
+    assert entry["current"] == "pir"
+    assert "pir" in entry["timers"]
+    timer = entry["timers"]["pir"]
+    assert isinstance(timer, DummyTimer)
+    assert timer.started is True
+    assert timer.interval == 45
+
+    manager._clear_sensor(room["id"], "pir")
+    assert applied == []
 
 
 def test_motion_status_updates_config(monkeypatch: pytest.MonkeyPatch, motion_module) -> None:


### PR DESCRIPTION
## Summary
- add a motion preferences store for per-room immunity and plug it into the motion manager
- expose API endpoints for reading/updating immune node lists and surface controls on the room page
- skip immune nodes when applying motion presets and cover the behavior with new tests

## Testing
- pytest Server/tests

------
https://chatgpt.com/codex/tasks/task_e_68cdd9f2b05083269eebfe4df73282b5