### PR TITLE
Allow removing rooms from house admin panel

### DIFF
--- a/Server/app/motion_schedule.py
+++ b/Server/app/motion_schedule.py
@@ -107,6 +107,20 @@ class MotionScheduleStore:
             self.save()
             return list(clean)
 
+    def remove_room(self, house_id: str, room_id: str) -> None:
+        """Forget any stored schedule for ``house_id``/``room_id``."""
+
+        with self._lock:
+            house = self._data.get(str(house_id))
+            if not house:
+                return
+            removed = house.pop(str(room_id), None)
+            if removed is None:
+                return
+            if not house:
+                self._data.pop(str(house_id), None)
+            self.save()
+
     def active_preset(
         self,
         house_id: str,

--- a/Server/app/registry.py
+++ b/Server/app/registry.py
@@ -118,3 +118,23 @@ def remove_node(node_id: str) -> Node:
                     save_registry()
                     return removed
     raise KeyError("node not found")
+
+
+def remove_room(house_id: str, room_id: str) -> Room:
+    """Remove ``room_id`` from ``house_id`` and return the removed room."""
+
+    house = find_house(house_id)
+    if not house:
+        raise KeyError("house not found")
+
+    rooms = house.get("rooms")
+    if not isinstance(rooms, list):
+        raise KeyError("room not found")
+
+    for idx, room in enumerate(rooms):
+        if room.get("id") == room_id:
+            removed = rooms.pop(idx)
+            save_registry()
+            return removed
+
+    raise KeyError("room not found")

--- a/Server/app/templates/admin.html
+++ b/Server/app/templates/admin.html
@@ -1,13 +1,64 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="mb-6 flex flex-col md:flex-row md:items-end md:justify-between gap-2">
+<div class="mb-6 flex flex-col md:flex-row md:items-start md:justify-between gap-4">
   <div>
     <h2 class="text-3xl font-semibold">{{ heading }}</h2>
     <p class="text-sm opacity-70">{{ description }}</p>
   </div>
-  <div class="text-xs opacity-70">
-    <div>Healthy if last <code>{"status": "ok"}</code> within {{ status_timeout }}s.</div>
-    <div id="statusRefresh" class="mt-1">Waiting for update…</div>
+  <div class="flex flex-col md:items-end gap-3 w-full md:w-auto">
+    {% if house_rooms is not none %}
+    <div class="relative md:self-end w-full md:w-auto" data-room-menu>
+      <button
+        type="button"
+        class="flex items-center justify-between gap-2 w-full md:w-auto px-4 py-2 pill bg-slate-800 hover:bg-slate-700 text-sm font-semibold transition"
+        data-room-menu-toggle
+        aria-haspopup="true"
+        aria-expanded="false">
+        <span>Manage Rooms</span>
+        <span aria-hidden="true" class="text-xs opacity-70">▾</span>
+      </button>
+      <div
+        class="absolute right-0 mt-2 w-full md:w-80 glass rounded-xl p-4 shadow-xl z-20 hidden"
+        data-room-menu-panel>
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <div class="text-sm font-semibold">Rooms</div>
+            <div class="text-xs opacity-60">Remove rooms from this house.</div>
+          </div>
+        </div>
+        <div class="mt-3 flex flex-col gap-3 max-h-64 overflow-y-auto" data-room-menu-list>
+          {% if house_rooms %}
+          {% for room in house_rooms %}
+          <div class="flex items-start justify-between gap-3" data-room-entry="{{ room.id }}">
+            <div class="min-w-0">
+              <div class="text-sm font-semibold leading-snug truncate">{{ room.name }}</div>
+              <div class="text-xs opacity-60 leading-snug break-words">
+                ID: {{ room.id }}{% if room.node_count is not none %} • {{ room.node_count }} node{% if room.node_count != 1 %}s{% endif %}{% endif %}
+              </div>
+            </div>
+            <button
+              type="button"
+              class="px-3 py-1 pill text-xs font-semibold bg-rose-600 hover:bg-rose-500 transition disabled:opacity-40 disabled:cursor-not-allowed"
+              data-room-remove="{{ room.id }}"
+              data-room-name="{{ room.name }}">
+              Delete
+            </button>
+          </div>
+          {% endfor %}
+          {% else %}
+          <div class="text-xs opacity-60">No rooms configured.</div>
+          {% endif %}
+        </div>
+        <div class="mt-3 text-xs opacity-60">
+          Removing a room also removes all of its nodes.
+        </div>
+      </div>
+    </div>
+    {% endif %}
+    <div class="text-xs opacity-70 md:text-right">
+      <div>Healthy if last <code>{"status": "ok"}</code> within {{ status_timeout }}s.</div>
+      <div id="statusRefresh" class="mt-1">Waiting for update…</div>
+    </div>
   </div>
 </div>
 
@@ -164,6 +215,93 @@ async function refreshStatuses() {
 
 refreshStatuses();
 setInterval(refreshStatuses, 5000);
+
+const roomMenuContainer = document.querySelector('[data-room-menu]');
+if (roomMenuContainer) {
+  const toggle = roomMenuContainer.querySelector('[data-room-menu-toggle]');
+  const panel = roomMenuContainer.querySelector('[data-room-menu-panel]');
+  let menuOpen = false;
+
+  const setExpanded = (value) => {
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', value ? 'true' : 'false');
+    }
+  };
+
+  const openMenu = () => {
+    if (!panel) return;
+    panel.classList.remove('hidden');
+    setExpanded(true);
+    menuOpen = true;
+  };
+
+  const closeMenu = () => {
+    if (!panel) return;
+    panel.classList.add('hidden');
+    setExpanded(false);
+    menuOpen = false;
+  };
+
+  if (toggle && panel) {
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (menuOpen || !panel.classList.contains('hidden')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+
+    panel.addEventListener('click', (event) => {
+      event.stopPropagation();
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!roomMenuContainer.contains(event.target)) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+      }
+    });
+  }
+
+  if (panel) {
+    panel.querySelectorAll('[data-room-remove]').forEach((btn) => {
+      btn.addEventListener('click', async (event) => {
+        event.stopPropagation();
+        if (btn.disabled) return;
+        if (!STATUS_HOUSE_ID) {
+          alert('Missing house identifier.');
+          return;
+        }
+        const roomId = btn.dataset.roomRemove;
+        if (!roomId) return;
+        const roomName = btn.dataset.roomName || roomId;
+        if (!confirm(`Delete ${roomName}? All nodes in this room will also be removed.`)) {
+          return;
+        }
+        const original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = 'Deleting…';
+        try {
+          const res = await fetch(`/api/house/${encodeURIComponent(STATUS_HOUSE_ID)}/rooms/${encodeURIComponent(roomId)}`, { method: 'DELETE' });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          location.reload();
+        } catch (err) {
+          console.error('Failed to delete room', err);
+          btn.disabled = false;
+          btn.textContent = original;
+          alert(`Failed to delete ${roomName}.`);
+        }
+      });
+    });
+  }
+}
 
 document.querySelectorAll('[data-node-ota]').forEach((btn) => {
   const hasOta = btn.dataset.hasOta === 'true';

--- a/Server/tests/test_admin_api.py
+++ b/Server/tests/test_admin_api.py
@@ -1,0 +1,161 @@
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import List
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+class _NoopBus:
+    def pub(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def ws_set(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def rgb_set(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def white_set(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def sensor_motion_program(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def status_request(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def motion_status_request(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def ota_check(self, *args, **kwargs):  # pragma: no cover - noop
+        pass
+
+    def all_off(self):  # pragma: no cover - noop
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _stub_mqtt(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.mqtt_bus
+
+    monkeypatch.setattr(app.mqtt_bus, "MqttBus", lambda *args, **kwargs: _NoopBus())
+
+
+def test_registry_remove_room(monkeypatch, tmp_path):
+    from app import registry
+    from app.config import settings
+
+    test_registry = [
+        {
+            "id": "house",
+            "name": "House",
+            "rooms": [
+                {"id": "room-a", "name": "Room A", "nodes": [{"id": "node-1"}]},
+                {"id": "room-b", "name": "Room B", "nodes": []},
+            ],
+        }
+    ]
+
+    monkeypatch.setattr(settings, "REGISTRY_FILE", tmp_path / "registry.json")
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", deepcopy(test_registry))
+
+    removed = registry.remove_room("house", "room-a")
+    assert removed["id"] == "room-a"
+    remaining = settings.DEVICE_REGISTRY[0]["rooms"]
+    assert [room["id"] for room in remaining] == ["room-b"]
+
+    with pytest.raises(KeyError):
+        registry.remove_room("house", "missing")
+
+
+def test_api_delete_room_cleans_up(monkeypatch, tmp_path):
+    import app.routes_api as routes_api
+    from app.config import settings
+
+    test_registry = [
+        {
+            "id": "house",
+            "name": "House",
+            "rooms": [
+                {
+                    "id": "room-a",
+                    "name": "Room A",
+                    "nodes": [
+                        {"id": "node-1", "name": "Node 1"},
+                        {"id": "node-2", "name": "Node 2"},
+                    ],
+                },
+                {"id": "room-b", "name": "Room B", "nodes": []},
+            ],
+        }
+    ]
+
+    monkeypatch.setattr(settings, "REGISTRY_FILE", tmp_path / "registry.json")
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", deepcopy(test_registry))
+
+    class Manager:
+        def __init__(self) -> None:
+            self.node_calls: List[str] = []
+            self.room_calls: List[tuple[str, str]] = []
+
+        def forget_node(self, node_id: str) -> None:
+            self.node_calls.append(node_id)
+
+        def forget_room(self, house_id: str, room_id: str) -> None:
+            self.room_calls.append((house_id, room_id))
+
+    class Status:
+        def __init__(self) -> None:
+            self.calls: List[str] = []
+
+        def forget(self, node_id: str) -> None:
+            self.calls.append(node_id)
+
+    class Schedule:
+        def __init__(self) -> None:
+            self.calls: List[tuple[str, str]] = []
+
+        def remove_room(self, house_id: str, room_id: str) -> None:
+            self.calls.append((house_id, room_id))
+
+    manager = Manager()
+    status = Status()
+    schedule = Schedule()
+
+    monkeypatch.setattr(routes_api, "motion_manager", manager)
+    monkeypatch.setattr(routes_api, "status_monitor", status)
+    monkeypatch.setattr(routes_api, "motion_schedule", schedule)
+
+    result = routes_api.api_delete_room("house", "room-a")
+
+    assert result["ok"] is True
+    assert result["room"]["id"] == "room-a"
+    assert result["removed_nodes"] == ["node-1", "node-2"]
+
+    remaining = settings.DEVICE_REGISTRY[0]["rooms"]
+    assert [room["id"] for room in remaining] == ["room-b"]
+
+    assert manager.node_calls == ["node-1", "node-2"]
+    assert manager.room_calls == [("house", "room-a")]
+    assert status.calls == ["node-1", "node-2"]
+    assert schedule.calls == [("house", "room-a")]
+
+
+def test_api_delete_room_missing(monkeypatch):
+    import app.routes_api as routes_api
+    from app.config import settings
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", [
+        {"id": "house", "rooms": []}
+    ])
+
+    with pytest.raises(HTTPException) as excinfo:
+        routes_api.api_delete_room("house", "room-a")
+
+    assert excinfo.value.status_code == 404


### PR DESCRIPTION
## Summary
- add registry and motion helpers plus an API endpoint to delete rooms and clean up related state
- add a Manage Rooms menu to the house admin page that calls the new delete endpoint
- cover the new room deletion flow with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cde793da40832698dfe4b35a31beba