### PR TITLE
Send motion off command when clearing sensors

### DIFF
--- a/Server/app/mqtt_bus.py
+++ b/Server/app/mqtt_bus.py
@@ -207,6 +207,16 @@ class MqttBus:
             rate_limited=rate_limited,
         )
 
+    def motion_off(self, node_id: str, payload: Dict[str, object]) -> None:
+        """Publish a motion clear command for ``node_id`` without rate limiting."""
+
+        self.pub(
+            topic_cmd(node_id, "motion/off"),
+            payload,
+            retain=False,
+            rate_limited=False,
+        )
+
     def status_request(self, node_id: str) -> None:
         """Request a full status snapshot from ``node_id``."""
         self.pub(topic_cmd(node_id, "status"), {}, retain=False)

--- a/Server/app/presets/__init__.py
+++ b/Server/app/presets/__init__.py
@@ -6,13 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from ..config import settings
 from ..mqtt_bus import MqttBus
-from .action_registry import (
-    ActionDict,
-    action_registry,
-    register_action,
-    reverse_action,
-    with_action_type,
-)
+from .action_registry import ActionDict, action_registry, register_action
 from .custom_store import CustomPresetStore
 
 
@@ -26,10 +20,8 @@ __all__ = [
     "get_room_presets",
     "list_custom_presets",
     "register_action",
-    "reverse_preset",
     "save_custom_preset",
     "snapshot_to_actions",
-    "with_action_type",
 ]
 
 
@@ -71,23 +63,6 @@ def get_preset(house_id: str, room_id: str, preset_id: str) -> Optional[Dict[str
         if preset.get("id") == preset_id:
             return preset
     return None
-
-
-def reverse_preset(preset: Dict[str, Any]) -> Dict[str, Any]:
-    """Return a deep-copied ``preset`` with each action reversed."""
-
-    reversed_preset = deepcopy(preset)
-    reversed_actions: List[Dict[str, Any]] = []
-
-    for action in preset.get("actions", []):
-        try:
-            reversed_action = reverse_action(action)
-        except (KeyError, TypeError, ValueError):
-            reversed_action = deepcopy(action)
-        reversed_actions.append(reversed_action)
-
-    reversed_preset["actions"] = reversed_actions
-    return reversed_preset
 
 
 def _coerce_int(value: Any, default: int = 0) -> int:


### PR DESCRIPTION
## Summary
- send a motion/off command to eligible room nodes when motion clears, using the agreed fade timing
- expose a dedicated MqttBus.motion_off helper and stop exporting reversal helpers from the presets package
- refresh motion tests to cover the new command path instead of preset reversal

## Testing
- PYTHONPATH=. pytest tests/test_motion.py

------
https://chatgpt.com/codex/tasks/task_e_68cdf5b72aa48326830620fa66d36459