### PR TITLE
Enable drag-and-drop room reordering

### DIFF
--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -291,6 +291,20 @@ def api_add_room(house_id: str, payload: Dict[str, str]):
     return {"ok": True, "room": room}
 
 
+@router.post("/api/house/{house_id}/rooms/reorder")
+def api_reorder_rooms(house_id: str, payload: Dict[str, Any]):
+    order = payload.get("order")
+    if not isinstance(order, list):
+        raise HTTPException(400, "missing order")
+    try:
+        new_order = registry.reorder_rooms(house_id, order)
+    except KeyError:
+        raise HTTPException(404, "Unknown house")
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+    return {"ok": True, "order": [str(room.get("id")) for room in new_order]}
+
+
 @router.delete("/api/house/{house_id}/rooms/{room_id}")
 def api_delete_room(house_id: str, room_id: str):
     house, room = registry.find_room(house_id, room_id)

--- a/Server/app/templates/house.html
+++ b/Server/app/templates/house.html
@@ -7,9 +7,9 @@
     <button id="addRoom" class="w-12 h-12 flex items-center justify-center text-2xl rounded-full bg-indigo-600 hover:bg-indigo-500">+</button>
   </div>
 </div>
-<div class="grid md:grid-cols-3 gap-4">
+<div class="grid md:grid-cols-3 gap-4" data-room-grid>
   {% for r in house.rooms %}
-  <a href="/house/{{ house.id }}/room/{{ r.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400">
+  <a href="/house/{{ house.id }}/room/{{ r.id }}" data-room-card data-room-id="{{ r.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400 cursor-move">
     <div class="text-xl font-semibold">{{ r.name }}</div>
     <div class="opacity-60 text-xs mt-2">ID: {{ r.id }}</div>
     <div class="text-sm mt-2">{{ r.nodes|length }} nodes</div>
@@ -25,5 +25,90 @@ document.getElementById('addRoom').onclick = async () => {
   });
   if(res.ok) location.reload(); else alert('Failed to add room');
 };
+
+const grid = document.querySelector('[data-room-grid]');
+if(grid){
+  const cards = grid.querySelectorAll('[data-room-card]');
+  let dragging = null;
+  let dropOccurred = false;
+  let saving = false;
+
+  const persistOrder = async () => {
+    const order = Array.from(grid.querySelectorAll('[data-room-card]'))
+      .map(card => card.dataset.roomId)
+      .filter(id => !!id);
+    if(order.length <= 1){
+      return;
+    }
+    try {
+      const res = await fetch('/api/house/{{ house.id }}/rooms/reorder', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({order})
+      });
+      if(!res.ok){
+        throw new Error(await res.text());
+      }
+    } catch (err) {
+      console.error('Failed to save room order', err);
+      alert('Failed to save room order. Reloading previous layout.');
+      location.reload();
+    }
+  };
+
+  cards.forEach(card => {
+    card.setAttribute('draggable', 'true');
+    card.setAttribute('aria-grabbed', 'false');
+    card.addEventListener('dragstart', event => {
+      dragging = card;
+      dropOccurred = false;
+      card.classList.add('opacity-60', 'dragging');
+      card.setAttribute('aria-grabbed', 'true');
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', card.dataset.roomId || '');
+    });
+    card.addEventListener('dragend', async () => {
+      card.classList.remove('opacity-60', 'dragging');
+      card.setAttribute('aria-grabbed', 'false');
+      const shouldSave = dropOccurred;
+      dropOccurred = false;
+      dragging = null;
+      if(shouldSave && !saving){
+        saving = true;
+        await persistOrder();
+        saving = false;
+      }
+    });
+  });
+
+  grid.addEventListener('dragover', event => {
+    if(!dragging) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    const targetElement = event.target instanceof Element ? event.target.closest('[data-room-card]') : null;
+    if(!targetElement){
+      if(dragging && dragging !== grid.lastElementChild){
+        grid.appendChild(dragging);
+      }
+      return;
+    }
+    if(targetElement === dragging){
+      return;
+    }
+    const rect = targetElement.getBoundingClientRect();
+    const isAfter = event.clientY > rect.top + rect.height / 2;
+    if(isAfter){
+      targetElement.after(dragging);
+    } else {
+      targetElement.before(dragging);
+    }
+  });
+
+  grid.addEventListener('drop', event => {
+    if(!dragging) return;
+    event.preventDefault();
+    dropOccurred = true;
+  });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add registry utility and API route to persist room ordering updates
- enable drag-and-drop reordering for room cards on the house page
- cover the new behavior with unit tests for both the registry and API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce188527f483268cc8f491d75da5e1