### PR TITLE
Make white and color swell effects parameterless

### DIFF
--- a/Server/app/custom_presets.json
+++ b/Server/app/custom_presets.json
@@ -11,11 +11,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              5000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -24,11 +20,7 @@
             "channel": 1,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              5000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -37,11 +29,7 @@
             "channel": 2,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              5000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -50,11 +38,7 @@
             "channel": 3,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              5000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -63,11 +47,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              5000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -76,11 +56,7 @@
             "channel": 1,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              5000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -89,11 +65,7 @@
             "channel": 2,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              5000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -102,11 +74,7 @@
             "channel": 3,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              5000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -124,11 +92,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -137,11 +101,7 @@
             "channel": 1,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -150,11 +110,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -169,12 +125,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              150,
-              3000
-            ],
+            "brightness": 150,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -182,12 +134,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              150,
-              3000
-            ],
+            "brightness": 150,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -195,12 +143,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              150,
-              3000
-            ],
+            "brightness": 150,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -215,12 +159,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              255,
-              0,
-              1000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -228,12 +168,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              255,
-              0,
-              1000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -241,12 +177,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              255,
-              0,
-              1000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -261,12 +193,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              4,
-              2000
-            ],
+            "brightness": 4,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -274,12 +202,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              0,
-              2000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -297,11 +221,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -310,11 +230,7 @@
             "channel": 1,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -329,12 +245,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              0,
-              1000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -342,12 +254,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              0,
-              1000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -362,12 +270,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              50,
-              2000
-            ],
+            "brightness": 50,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -375,12 +279,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              50,
-              2000
-            ],
+            "brightness": 50,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -395,12 +295,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              100,
-              2000
-            ],
+            "brightness": 100,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -408,12 +304,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              5,
-              1000
-            ],
+            "brightness": 5,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -428,12 +320,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              4,
-              2000
-            ],
+            "brightness": 4,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -451,11 +339,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -464,11 +348,7 @@
             "channel": 1,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -484,14 +364,7 @@
             "strip": 0,
             "effect": "color_swell",
             "brightness": 255,
-            "params": [
-              20.0,
-              0.0,
-              255.0,
-              0,
-              255,
-              3000
-            ],
+            "params": [20, 0, 255],
             "_action_type": "ws.color_swell"
           }
         ],
@@ -507,11 +380,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -519,12 +388,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              6,
-              3000
-            ],
+            "brightness": 6,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -540,11 +405,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -552,12 +413,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              0,
-              3000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -572,12 +429,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              50,
-              2000
-            ],
+            "brightness": 50,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -585,12 +438,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              0,
-              2000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -618,12 +467,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              0,
-              2000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -631,12 +476,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              0,
-              2000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -656,11 +497,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -669,11 +506,7 @@
             "channel": 1,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -682,11 +515,7 @@
             "channel": 0,
             "effect": "swell",
             "brightness": 255,
-            "params": [
-              0,
-              255,
-              3000
-            ],
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -701,12 +530,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              150,
-              3000
-            ],
+            "brightness": 150,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -714,12 +539,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              150,
-              3000
-            ],
+            "brightness": 150,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -727,12 +548,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              150,
-              3000
-            ],
+            "brightness": 150,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -747,12 +564,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              255,
-              0,
-              1000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -760,12 +573,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              255,
-              0,
-              1000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -773,12 +582,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              255,
-              0,
-              1000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],
@@ -793,12 +598,8 @@
             "module": "white",
             "channel": 0,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              4,
-              2000
-            ],
+            "brightness": 4,
+            "params": [],
             "_action_type": "white.swell"
           },
           {
@@ -806,12 +607,8 @@
             "module": "white",
             "channel": 1,
             "effect": "swell",
-            "brightness": 255,
-            "params": [
-              0,
-              0,
-              2000
-            ],
+            "brightness": 0,
+            "params": [],
             "_action_type": "white.swell"
           }
         ],

--- a/Server/app/effects.py
+++ b/Server/app/effects.py
@@ -127,9 +127,6 @@ WS_PARAM_DEFS = {
     ],
     "color_swell": [
         {"type": "color", "label": "Base Color"},
-        {"type": "slider", "label": "Start Brightness", "min": 0, "max": 255, "value": 0},
-        {"type": "slider", "label": "End Brightness", "min": 0, "max": 255, "value": 255},
-        {"type": "slider", "label": "Time (ms)", "min": 0, "max": 10000, "value": 1000},
     ],
 }
 
@@ -137,11 +134,7 @@ WHITE_PARAM_DEFS = {
     "breathe": [
         {"type": "slider", "label": "Period (ms)", "min": 100, "max": 5000, "value": 1000},
     ],
-    "swell": [
-        {"type": "slider", "label": "Start Brightness", "min": 0, "max": 255, "value": 0},
-        {"type": "slider", "label": "End Brightness", "min": 0, "max": 255, "value": 255},
-        {"type": "slider", "label": "Time (ms)", "min": 0, "max": 10000, "value": 1000},
-    ],
+    "swell": [],
 }
 
 # ``solid`` is fundamental and must always exist for the web interface. Ensure
@@ -154,9 +147,6 @@ RGB_PARAM_DEFS = {
     ],
     "color_swell": [
         {"type": "color", "label": "Base Color"},
-        {"type": "slider", "label": "Start Brightness", "min": 0, "max": 255, "value": 0},
-        {"type": "slider", "label": "End Brightness", "min": 0, "max": 255, "value": 255},
-        {"type": "slider", "label": "Time (ms)", "min": 0, "max": 10000, "value": 1000},
     ],
 }
 

--- a/Server/docs/presets.md
+++ b/Server/docs/presets.md
@@ -30,7 +30,8 @@ MQTT during playback.
 ``custom_presets.json`` bundles a few seeded presets that mirror the original
 catalog.  The entry below shows how a snapshot that swells all white channels can
 be represented.  Triggering this preset causes each node's white channels (0–3)
-to fade from brightness 0 to 100 in five seconds and hold that final level.
+to brighten from off to their configured master brightness over three seconds
+before holding that output level.
 
 ```json
 {
@@ -41,21 +42,21 @@ to fade from brightness 0 to 100 in five seconds and hold that final level.
         "name": "White Swell 0→100",
         "actions": [
           {"module": "white", "node": "del-sur-room-1-node1", "channel": 0,
-           "effect": "swell", "brightness": 255, "params": [0, 255, 5000]},
+           "effect": "swell", "brightness": 255, "params": []},
           {"module": "white", "node": "del-sur-room-1-node1", "channel": 1,
-           "effect": "swell", "brightness": 255, "params": [0, 255, 5000]},
+           "effect": "swell", "brightness": 255, "params": []},
           {"module": "white", "node": "del-sur-room-1-node1", "channel": 2,
-           "effect": "swell", "brightness": 255, "params": [0, 255, 5000]},
+           "effect": "swell", "brightness": 255, "params": []},
           {"module": "white", "node": "del-sur-room-1-node1", "channel": 3,
-           "effect": "swell", "brightness": 255, "params": [0, 255, 5000]},
+           "effect": "swell", "brightness": 255, "params": []},
           {"module": "white", "node": "node", "channel": 0,
-           "effect": "swell", "brightness": 255, "params": [0, 255, 5000]},
+           "effect": "swell", "brightness": 255, "params": []},
           {"module": "white", "node": "node", "channel": 1,
-           "effect": "swell", "brightness": 255, "params": [0, 255, 5000]},
+           "effect": "swell", "brightness": 255, "params": []},
           {"module": "white", "node": "node", "channel": 2,
-           "effect": "swell", "brightness": 255, "params": [0, 255, 5000]},
+           "effect": "swell", "brightness": 255, "params": []},
           {"module": "white", "node": "node", "channel": 3,
-           "effect": "swell", "brightness": 255, "params": [0, 255, 5000]}
+           "effect": "swell", "brightness": 255, "params": []}
         ],
         "source": "seed"
       }
@@ -69,11 +70,12 @@ to fade from brightness 0 to 100 in five seconds and hold that final level.
 Both houses include a ``kitchen`` room with several predefined presets showcasing
 more targeted swells:
 
-* **Swell On** – channels 0‑2 swell from 0 to 100 over five seconds.
-* **Midnight Snack** – channel 0 swells 0→10 and channel 1 swells 0→50.
-* **Kitchen's Closed** – channel 2 swells 100→255 while channels 0 and 1 dim
-  from 100 to 0.
-* **Normal** – channels 0‑2 swell from 0 to 150 over five seconds.
+* **Swell On** – channels 0‑2 swell from off to full brightness.
+* **Midnight Snack** – channel 0 swells from off to a night-light level while
+  channel 1 remains dim.
+* **Kitchen's Closed** – channel 2 swells to full while channels 0 and 1 stay
+  off.
+* **Normal** – channels 0‑2 swell from off to a comfortable mid-level.
 
 These definitions live in ``custom_presets.json`` exactly as the UI captured
 them.  Operators can overwrite them at any time by saving new presets through

--- a/Server/tests/test_custom_presets.py
+++ b/Server/tests/test_custom_presets.py
@@ -134,8 +134,8 @@ class CustomPresetRoundTripTests(unittest.TestCase):
                     "channel": 0,
                     "effect": "swell",
                     "brightness": "200",
-                    "params": [10, "200", 1500],
-                    "ms": "1500",
+                    "params": [],
+                    "ms": "3000",
                 },
                 {
                     "channel": "1",
@@ -202,7 +202,7 @@ class CustomPresetRoundTripTests(unittest.TestCase):
                 self.assertEqual(
                     bus.white_calls,
                     [
-                        ("node-1", 0, "swell", 200, [10, "200", 1500], False),
+                        ("node-1", 0, "swell", 200, [], False),
                         ("node-1", 1, "solid", 0, [], False),
                     ],
                 )

--- a/UltraNodeV5/components/ul_rgb_engine/effects_rgb/color_swell.c
+++ b/UltraNodeV5/components/ul_rgb_engine/effects_rgb/color_swell.c
@@ -5,14 +5,13 @@
 #include "effect.h"
 #include "cJSON.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 #define RGB_STRIP_MAX 4
 
+#define COLOR_SWELL_DURATION_MS 3000
+
 static uint8_t s_color[RGB_STRIP_MAX][3];
-static uint8_t s_start[RGB_STRIP_MAX];
-static uint8_t s_end[RGB_STRIP_MAX];
-static int s_frames[RGB_STRIP_MAX];
-static int s_progress[RGB_STRIP_MAX];
 static bool s_initialized;
 
 static inline bool valid_strip(int strip) {
@@ -25,21 +24,12 @@ static inline uint8_t clamp_u8(int value) {
     return (uint8_t)value;
 }
 
-static inline int clamp_frames(int frames) {
-    if (frames < 1) return 1;
-    return frames;
-}
-
 static void ensure_initialized(void) {
     if (s_initialized) return;
     for (int i = 0; i < RGB_STRIP_MAX; ++i) {
         s_color[i][0] = 255;
         s_color[i][1] = 255;
         s_color[i][2] = 255;
-        s_start[i] = 0;
-        s_end[i] = 255;
-        s_frames[i] = 1;
-        s_progress[i] = 0;
     }
     s_initialized = true;
 }
@@ -48,22 +38,17 @@ void rgb_color_swell_init(void) {
     ensure_initialized();
 }
 
-static uint8_t read_color_component(const cJSON* item) {
-    if (!item || !cJSON_IsNumber(item)) return 0;
-    return clamp_u8(item->valueint);
+static int compute_total_frames(void) {
+    int frames = (COLOR_SWELL_DURATION_MS * CONFIG_UL_RGB_SMOOTH_HZ) / 1000;
+    if (frames < 1) {
+        frames = 1;
+    }
+    return frames;
 }
 
-static uint8_t read_brightness(const cJSON* item, uint8_t fallback) {
+static uint8_t read_color_component(const cJSON* item, uint8_t fallback) {
     if (!item || !cJSON_IsNumber(item)) return fallback;
     return clamp_u8(item->valueint);
-}
-
-static int read_frames(const cJSON* item, int fallback) {
-    if (!item || !cJSON_IsNumber(item)) return clamp_frames(fallback);
-    int ms = item->valueint;
-    if (ms < 0) ms = 0;
-    int frames = (ms * CONFIG_UL_RGB_SMOOTH_HZ) / 1000;
-    return clamp_frames(frames);
 }
 
 void rgb_color_swell_apply_params(int strip, const cJSON* params) {
@@ -71,31 +56,28 @@ void rgb_color_swell_apply_params(int strip, const cJSON* params) {
     if (!valid_strip(strip)) return;
     if (!params || !cJSON_IsArray(params)) return;
 
-    s_color[strip][0] = read_color_component(cJSON_GetArrayItem(params, 0));
-    s_color[strip][1] = read_color_component(cJSON_GetArrayItem(params, 1));
-    s_color[strip][2] = read_color_component(cJSON_GetArrayItem(params, 2));
-    s_start[strip] = read_brightness(cJSON_GetArrayItem(params, 3), s_start[strip]);
-    s_end[strip] = read_brightness(cJSON_GetArrayItem(params, 4), s_end[strip]);
-    s_frames[strip] = read_frames(cJSON_GetArrayItem(params, 5), s_frames[strip]);
-    s_progress[strip] = 0;
+    s_color[strip][0] = read_color_component(cJSON_GetArrayItem(params, 0), s_color[strip][0]);
+    s_color[strip][1] = read_color_component(cJSON_GetArrayItem(params, 1), s_color[strip][1]);
+    s_color[strip][2] = read_color_component(cJSON_GetArrayItem(params, 2), s_color[strip][2]);
 }
 
 void rgb_color_swell_render(int strip, uint8_t out_rgb[3], int frame_idx) {
-    (void)frame_idx;
     ensure_initialized();
     if (!valid_strip(strip)) return;
 
-    uint8_t start = s_start[strip];
-    uint8_t end = s_end[strip];
-    int frames = s_frames[strip];
-    int progress = s_progress[strip];
-
-    int value = end;
-    if (progress < frames) {
-        float t = frames ? (float)progress / (float)frames : 1.0f;
-        value = (int)(start + (end - start) * t + 0.5f);
-        value = clamp_u8(value);
-        s_progress[strip]++;
+    int frames = compute_total_frames();
+    int value = 255;
+    if (frame_idx <= 0) {
+        value = 0;
+    } else if (frame_idx < frames) {
+        int64_t scaled = ((int64_t)frame_idx * 255 + frames / 2) / frames;
+        if (scaled < 0) {
+            scaled = 0;
+        }
+        if (scaled > 255) {
+            scaled = 255;
+        }
+        value = (int)scaled;
     }
 
     out_rgb[0] = (uint8_t)((s_color[strip][0] * value) / 255);

--- a/UltraNodeV5/components/ul_white_engine/effects_white/registry.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/registry.c
@@ -13,12 +13,11 @@ uint8_t white_solid_render(int frame_idx);
 
 void white_swell_init(void);
 uint8_t white_swell_render(int frame_idx);
-void white_swell_apply_params(int ch, const cJSON* params);
 
 static const white_effect_t effects[] = {
     {"solid", white_solid_init, white_solid_render, NULL},
     {"breathe", white_breathe_init, white_breathe_render, white_breathe_apply_params},
-    {"swell", white_swell_init, white_swell_render, white_swell_apply_params},
+    {"swell", white_swell_init, white_swell_render, NULL},
 };
 
 const white_effect_t* ul_white_get_effects(int* count) {

--- a/UltraNodeV5/components/ul_white_engine/effects_white/swell.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/swell.c
@@ -3,68 +3,39 @@
 #if CONFIG_UL_WHT0_ENABLED || CONFIG_UL_WHT1_ENABLED || CONFIG_UL_WHT2_ENABLED || CONFIG_UL_WHT3_ENABLED
 
 #include "effect.h"
-#include "cJSON.h"
-#include <stdbool.h>
+#include <stdint.h>
 
-static uint8_t s_start[4];
-static uint8_t s_end[4];
-static int s_frames[4];
-static int s_progress[4];
-static bool s_initialized;
+#define WHITE_SWELL_DURATION_MS 3000
+
+static int compute_total_frames(void) {
+    int frames = (WHITE_SWELL_DURATION_MS * CONFIG_UL_WHITE_SMOOTH_HZ) / 1000;
+    if (frames < 1) {
+        frames = 1;
+    }
+    return frames;
+}
 
 void white_swell_init(void) {
-    if (!s_initialized) {
-        for (int i = 0; i < 4; ++i) {
-            s_start[i] = 0;
-            s_end[i] = 255;
-            s_frames[i] = 1;
-            s_progress[i] = 0;
-        }
-        s_initialized = true;
-    }
+    // No per-channel state is required; the frame index drives the swell.
 }
 
 uint8_t white_swell_render(int frame_idx) {
-    (void)frame_idx;
-    int ch = ul_white_effect_current_channel();
-    if (ch < 0 || ch > 3) return 0;
-    if (s_progress[ch] < s_frames[ch]) {
-        float t = s_frames[ch] ? (float)s_progress[ch] / (float)s_frames[ch] : 1.0f;
-        int v = (int)(s_start[ch] + (s_end[ch] - s_start[ch]) * t + 0.5f);
-        s_progress[ch]++;
-        if (v < 0) v = 0;
-        if (v > 255) v = 255;
-        return (uint8_t)v;
+    int frames = compute_total_frames();
+    if (frame_idx <= 0) {
+        return 0;
     }
-    return s_end[ch];
-}
+    if (frame_idx >= frames) {
+        return 255;
+    }
 
-void white_swell_apply_params(int ch, const cJSON* params) {
-    if (ch < 0 || ch > 3) return;
-    if (!params || !cJSON_IsArray(params)) return;
-    const cJSON* p0 = cJSON_GetArrayItem(params, 0);
-    const cJSON* p1 = cJSON_GetArrayItem(params, 1);
-    const cJSON* p2 = cJSON_GetArrayItem(params, 2);
-    if (p0 && cJSON_IsNumber(p0)) {
-        int x = p0->valueint;
-        if (x < 0) x = 0;
-        if (x > 255) x = 255;
-        s_start[ch] = (uint8_t)x;
+    int value = (int)((((int64_t)frame_idx) * 255 + frames / 2) / frames);
+    if (value < 0) {
+        value = 0;
     }
-    if (p1 && cJSON_IsNumber(p1)) {
-        int y = p1->valueint;
-        if (y < 0) y = 0;
-        if (y > 255) y = 255;
-        s_end[ch] = (uint8_t)y;
+    if (value > 255) {
+        value = 255;
     }
-    if (p2 && cJSON_IsNumber(p2)) {
-        int ms = p2->valueint;
-        if (ms < 0) ms = 0;
-        int f = (ms * CONFIG_UL_WHITE_SMOOTH_HZ) / 1000;
-        if (f < 1) f = 1;
-        s_frames[ch] = f;
-    }
-    s_progress[ch] = 0;
+    return (uint8_t)value;
 }
 
 #endif

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/color_swell.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/color_swell.c
@@ -5,13 +5,12 @@
 #include "effect.h"
 #include "cJSON.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 static uint8_t s_color[2][3];
-static uint8_t s_start[2];
-static uint8_t s_end[2];
-static int s_frames[2];
-static int s_progress[2];
 static bool s_initialized;
+
+#define COLOR_SWELL_DURATION_MS 3000
 
 static inline bool valid_strip(int strip) {
     return strip >= 0 && strip < 2;
@@ -23,21 +22,12 @@ static inline uint8_t clamp_u8(int value) {
     return (uint8_t)value;
 }
 
-static inline int clamp_frames(int frames) {
-    if (frames < 1) return 1;
-    return frames;
-}
-
 static void ensure_initialized(void) {
     if (s_initialized) return;
     for (int i = 0; i < 2; ++i) {
         s_color[i][0] = 255;
         s_color[i][1] = 255;
         s_color[i][2] = 255;
-        s_start[i] = 0;
-        s_end[i] = 255;
-        s_frames[i] = 1;
-        s_progress[i] = 0;
     }
     s_initialized = true;
 }
@@ -46,22 +36,17 @@ void color_swell_init(void) {
     ensure_initialized();
 }
 
-static uint8_t read_color_component(const cJSON* item) {
-    if (!item || !cJSON_IsNumber(item)) return 0;
-    return clamp_u8(item->valueint);
+static int compute_total_frames(void) {
+    int frames = (COLOR_SWELL_DURATION_MS * CONFIG_UL_WS2812_FPS) / 1000;
+    if (frames < 1) {
+        frames = 1;
+    }
+    return frames;
 }
 
-static uint8_t read_brightness(const cJSON* item, uint8_t fallback) {
+static uint8_t read_color_component(const cJSON* item, uint8_t fallback) {
     if (!item || !cJSON_IsNumber(item)) return fallback;
     return clamp_u8(item->valueint);
-}
-
-static int read_frames(const cJSON* item, int fallback) {
-    if (!item || !cJSON_IsNumber(item)) return clamp_frames(fallback);
-    int ms = item->valueint;
-    if (ms < 0) ms = 0;
-    int frames = (ms * CONFIG_UL_WS2812_FPS) / 1000;
-    return clamp_frames(frames);
 }
 
 void color_swell_apply_params(int strip, const cJSON* params) {
@@ -69,32 +54,29 @@ void color_swell_apply_params(int strip, const cJSON* params) {
     if (!valid_strip(strip)) return;
     if (!params || !cJSON_IsArray(params)) return;
 
-    s_color[strip][0] = read_color_component(cJSON_GetArrayItem(params, 0));
-    s_color[strip][1] = read_color_component(cJSON_GetArrayItem(params, 1));
-    s_color[strip][2] = read_color_component(cJSON_GetArrayItem(params, 2));
-    s_start[strip] = read_brightness(cJSON_GetArrayItem(params, 3), s_start[strip]);
-    s_end[strip] = read_brightness(cJSON_GetArrayItem(params, 4), s_end[strip]);
-    s_frames[strip] = read_frames(cJSON_GetArrayItem(params, 5), s_frames[strip]);
-    s_progress[strip] = 0;
+    s_color[strip][0] = read_color_component(cJSON_GetArrayItem(params, 0), s_color[strip][0]);
+    s_color[strip][1] = read_color_component(cJSON_GetArrayItem(params, 1), s_color[strip][1]);
+    s_color[strip][2] = read_color_component(cJSON_GetArrayItem(params, 2), s_color[strip][2]);
 }
 
 void color_swell_render(uint8_t* frame_rgb, int pixels, int frame_idx) {
-    (void)frame_idx;
     ensure_initialized();
     int strip = ul_ws_effect_current_strip();
     if (!valid_strip(strip)) return;
 
-    uint8_t start = s_start[strip];
-    uint8_t end = s_end[strip];
-    int frames = s_frames[strip];
-    int progress = s_progress[strip];
-
-    int value = end;
-    if (progress < frames) {
-        float t = frames ? (float)progress / (float)frames : 1.0f;
-        value = (int)(start + (end - start) * t + 0.5f);
-        value = clamp_u8(value);
-        s_progress[strip]++;
+    int frames = compute_total_frames();
+    int value = 255;
+    if (frame_idx <= 0) {
+        value = 0;
+    } else if (frame_idx < frames) {
+        int64_t scaled = ((int64_t)frame_idx * 255 + frames / 2) / frames;
+        if (scaled < 0) {
+            scaled = 0;
+        }
+        if (scaled > 255) {
+            scaled = 255;
+        }
+        value = (int)scaled;
     }
 
     for (int i = 0; i < pixels; ++i) {

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -43,6 +43,7 @@ The contents of `params` depend on the chosen effect:
 
 * `rainbow` – one integer `[wavelength]` controlling the color cycle in pixels
 * `solid` – RGB `[r,g,b]` values
+* `color_swell` – RGB `[r,g,b]` base colour that swells from 0 to the configured brightness over 3 000 ms before holding steady
 * `triple_wave` – fifteen numbers defining three sine waves `[r1,g1,b1,w1,f1,r2,g2,b2,w2,f2,r3,g3,b3,w3,f3]`
 * `spacewaves` – nine integers specifying three RGB waves `[r1,g1,b1,r2,g2,b2,r3,g3,b3]`
 * `fire` – intensity and colour gradient `[intensity,r1,g1,b1,r2,g2,b2]`. Values above `10` are treated as percentages (the web UI sends `0-200` for convenience). Requires PSRAM-enabled firmware.
@@ -124,10 +125,13 @@ RGB parameters `[0, 0, 0]`.
 }
 ```
 
-Analog strips expose three PWM channels and currently ship with a single
-`solid` effect that accepts RGB parameters `[r, g, b]`.  Publish with
-`brightness: 0` to turn a strip off while preserving its colour for the next
-command.
+Analog strips expose three PWM channels and support two effects:
+
+* `solid` – static RGB `[r, g, b]` output.
+* `color_swell` – RGB `[r, g, b]` base colour that swells from 0 to the master brightness over 3 000 ms, then holds that level.
+
+Publish with `brightness: 0` to turn a strip off while preserving its colour for
+the next command.
 
 ### White PWM channels (`white`)
 
@@ -150,7 +154,8 @@ separately.
 Registered effects: `solid`, `breathe`, and `swell`.
 * `solid` – static output with no parameters.
 * `breathe` – optional params: `[period_ms]` to control the breath cycle length.
-* `swell` – params `[x, y, t_ms]` fade from brightness `x` to `y` over `t_ms` milliseconds then hold at `y`.
+* `swell` – no parameters. Brightens from 0 to full output over 3 000 ms and then holds the final level. The master brightness
+  scales the curve so a brightness of 128 yields a 0→128 swell.
 
 ### Sensor and OTA commands
 


### PR DESCRIPTION
## Summary
- hard-code the white-channel swell effect to a 3s 0→255 ramp that no longer consumes per-channel parameters
- drop swell-specific parameter controls from the server, updating docs, tests, and seeded presets to rely only on master brightness
- align both RGB and WS color_swell effects with the same fixed 3 000 ms 0→255 swell so they only require a base colour, updating firmware, UI metadata, docs, and seeded presets accordingly

## Testing
- pytest Server/tests/test_custom_presets.py

------
https://chatgpt.com/codex/tasks/task_e_68ce1bf4fe508326829b4196ea2595c8