### PR TITLE
Add drag reordering to room presets edit mode

### DIFF
--- a/Server/app/static/app.css
+++ b/Server/app/static/app.css
@@ -205,6 +205,42 @@ label { font-size: .7rem; color: var(--muted); display: block; margin-bottom: .2
   align-items: center;
 }
 
+#presetList.is-editing .preset-item.is-draggable,
+#presetList[data-editing="true"] .preset-item.is-draggable {
+  cursor: grab;
+}
+
+#presetList.is-editing .preset-item.is-draggable.is-dragging,
+#presetList[data-editing="true"] .preset-item.is-draggable.is-dragging {
+  cursor: grabbing;
+  opacity: 0.7;
+}
+
+#presetList.is-editing .preset-item.drop-target-before::before,
+#presetList.is-editing .preset-item.drop-target-after::after,
+#presetList[data-editing="true"] .preset-item.drop-target-before::before,
+#presetList[data-editing="true"] .preset-item.drop-target-after::after {
+  content: '';
+  position: absolute;
+  top: -8px;
+  bottom: -8px;
+  width: 4px;
+  border-radius: 9999px;
+  background: rgba(129, 140, 248, 0.85);
+  box-shadow: 0 0 10px rgba(99, 102, 241, 0.55);
+  z-index: 1;
+}
+
+#presetList.is-editing .preset-item.drop-target-before::before,
+#presetList[data-editing="true"] .preset-item.drop-target-before::before {
+  left: -6px;
+}
+
+#presetList.is-editing .preset-item.drop-target-after::after,
+#presetList[data-editing="true"] .preset-item.drop-target-after::after {
+  right: -6px;
+}
+
 .preset-delete {
   position: absolute;
   top: -8px;
@@ -234,7 +270,8 @@ label { font-size: .7rem; color: var(--muted); display: block; margin-bottom: .2
   transform: translateY(1px);
 }
 
-.preset-item[data-custom="true"] .preset-delete {
+#presetList.is-editing .preset-item[data-custom="true"] .preset-delete,
+#presetList[data-editing="true"] .preset-item[data-custom="true"] .preset-delete {
   display: inline-flex;
 }
 .motion-button--primary {

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -16,7 +16,10 @@
 <div class="mt-8" id="presetSection">
   <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
     <h2 class="text-2xl font-semibold">Presets</h2>
-    <button id="presetSaveButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400">Save Preset</button>
+    <div class="flex items-center gap-2">
+      <button id="presetSaveButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400">Save Preset</button>
+      <button id="presetEditButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400" aria-pressed="false" aria-controls="presetList">Edit</button>
+    </div>
   </div>
   <div id="presetStatus" class="text-sm mb-3 opacity-80" role="status" aria-live="polite"></div>
   <div id="presetList" class="flex flex-wrap gap-2" data-house-id="{{ house.id }}" data-room-id="{{ room.id }}" data-api-base="/api/house/{{ house.id }}/room/{{ room.id }}" data-initial-presets='{{ presets|tojson }}'>


### PR DESCRIPTION
## Summary
- extend the preset editor to manage drag state and allow reordering presets in edit mode
- update preset list rendering and sharing so the UI reflects the new order after a drag
- add styling cues for draggable presets and drop targets while editing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce65b38cf88326b86079c450d64bf6