### PR TITLE
Add drag reordering to room presets edit mode

### DIFF
--- a/Server/app/static/app.css
+++ b/Server/app/static/app.css
@@ -205,6 +205,42 @@ label { font-size: .7rem; color: var(--muted); display: block; margin-bottom: .2
   align-items: center;
 }
 
+#presetList.is-editing .preset-item.is-draggable,
+#presetList[data-editing="true"] .preset-item.is-draggable {
+  cursor: grab;
+}
+
+#presetList.is-editing .preset-item.is-draggable.is-dragging,
+#presetList[data-editing="true"] .preset-item.is-draggable.is-dragging {
+  cursor: grabbing;
+  opacity: 0.7;
+}
+
+#presetList.is-editing .preset-item.drop-target-before::before,
+#presetList.is-editing .preset-item.drop-target-after::after,
+#presetList[data-editing="true"] .preset-item.drop-target-before::before,
+#presetList[data-editing="true"] .preset-item.drop-target-after::after {
+  content: '';
+  position: absolute;
+  top: -8px;
+  bottom: -8px;
+  width: 4px;
+  border-radius: 9999px;
+  background: rgba(129, 140, 248, 0.85);
+  box-shadow: 0 0 10px rgba(99, 102, 241, 0.55);
+  z-index: 1;
+}
+
+#presetList.is-editing .preset-item.drop-target-before::before,
+#presetList[data-editing="true"] .preset-item.drop-target-before::before {
+  left: -6px;
+}
+
+#presetList.is-editing .preset-item.drop-target-after::after,
+#presetList[data-editing="true"] .preset-item.drop-target-after::after {
+  right: -6px;
+}
+
 .preset-delete {
   position: absolute;
   top: -8px;
@@ -234,7 +270,8 @@ label { font-size: .7rem; color: var(--muted); display: block; margin-bottom: .2
   transform: translateY(1px);
 }
 
-.preset-item[data-custom="true"] .preset-delete {
+#presetList.is-editing .preset-item[data-custom="true"] .preset-delete,
+#presetList[data-editing="true"] .preset-item[data-custom="true"] .preset-delete {
   display: inline-flex;
 }
 .motion-button--primary {

--- a/Server/app/static/presets.js
+++ b/Server/app/static/presets.js
@@ -2,6 +2,7 @@ const container = document.getElementById('presetList');
 if (container) {
   const statusEl = document.getElementById('presetStatus');
   const saveButton = document.getElementById('presetSaveButton');
+  const editButton = document.getElementById('presetEditButton');
   const baseUrl = container.dataset.apiBase || '';
   const presetsUrl = baseUrl ? `${baseUrl}/presets` : '';
   const applyUrlFor = (id) => `${baseUrl}/preset/${encodeURIComponent(id)}`;
@@ -79,6 +80,116 @@ if (container) {
   }
   const initialPresets = normalizePresets(initialRaw);
   let presets = initialPresets;
+  let editing = false;
+
+  const dragState = { id: null, index: -1 };
+  let currentDropTarget = null;
+  let currentDropPosition = null;
+
+  const resetDragState = () => {
+    dragState.id = null;
+    dragState.index = -1;
+  };
+
+  const clearDropIndicators = () => {
+    if (currentDropTarget) {
+      currentDropTarget.classList.remove('drop-target-before', 'drop-target-after');
+    }
+    currentDropTarget = null;
+    currentDropPosition = null;
+  };
+
+  const setDropIndicator = (target, position) => {
+    if (currentDropTarget === target && currentDropPosition === position) {
+      return;
+    }
+    clearDropIndicators();
+    if (target && position) {
+      const cls = position === 'after' ? 'drop-target-after' : 'drop-target-before';
+      target.classList.add(cls);
+      currentDropTarget = target;
+      currentDropPosition = position;
+    }
+  };
+
+  const findPresetIndex = (id) => presets.findIndex((entry) => entry.id === id);
+
+  const dropPositionForEvent = (event, element) => {
+    if (!element) return 'after';
+    const rect = element.getBoundingClientRect();
+    const horizontal = rect.width >= rect.height;
+    if (horizontal) {
+      return event.clientX - rect.left > rect.width / 2 ? 'after' : 'before';
+    }
+    return event.clientY - rect.top > rect.height / 2 ? 'after' : 'before';
+  };
+
+  const movePreset = (fromIndex, toIndex) => {
+    if (fromIndex < 0 || fromIndex >= presets.length) {
+      return false;
+    }
+    if (toIndex < 0) {
+      toIndex = 0;
+    }
+    if (toIndex > presets.length) {
+      toIndex = presets.length;
+    }
+    if (fromIndex === toIndex || (fromIndex + 1 === toIndex && fromIndex < toIndex)) {
+      return false;
+    }
+    const [moved] = presets.splice(fromIndex, 1);
+    let insertIndex = toIndex;
+    if (fromIndex < toIndex) {
+      insertIndex -= 1;
+    }
+    if (insertIndex < 0) {
+      insertIndex = 0;
+    }
+    if (insertIndex > presets.length) {
+      insertIndex = presets.length;
+    }
+    presets.splice(insertIndex, 0, moved);
+    return insertIndex !== fromIndex;
+  };
+
+  const updateEditingUI = () => {
+    container.dataset.editing = editing ? 'true' : 'false';
+    if (editing) {
+      container.classList.add('is-editing');
+    } else {
+      container.classList.remove('is-editing');
+    }
+    const deleteButtons = container.querySelectorAll('button.preset-delete');
+    deleteButtons.forEach((button) => {
+      button.hidden = !editing;
+      if (editing) {
+        button.removeAttribute('aria-hidden');
+        button.removeAttribute('tabindex');
+      } else {
+        button.setAttribute('aria-hidden', 'true');
+        button.setAttribute('tabindex', '-1');
+      }
+    });
+    const presetItems = container.querySelectorAll('.preset-item');
+    presetItems.forEach((item) => {
+      if (editing) {
+        item.setAttribute('draggable', 'true');
+        item.classList.add('is-draggable');
+      } else {
+        item.removeAttribute('draggable');
+        item.classList.remove('is-draggable', 'is-dragging', 'drop-target-before', 'drop-target-after');
+      }
+    });
+    if (!editing) {
+      clearDropIndicators();
+      resetDragState();
+    }
+    if (editButton) {
+      editButton.textContent = editing ? 'Done' : 'Edit';
+      editButton.setAttribute('aria-pressed', editing ? 'true' : 'false');
+      editButton.title = editing ? 'Finish editing presets' : 'Edit presets';
+    }
+  };
 
   const isCustomPreset = (preset) => preset && String(preset.source || '').toLowerCase() === 'custom';
 
@@ -114,6 +225,14 @@ if (container) {
         removeButton.dataset.presetId = id;
         removeButton.setAttribute('aria-label', `Delete preset ${name}`);
         removeButton.textContent = '✕';
+        removeButton.hidden = !editing;
+        if (editing) {
+          removeButton.removeAttribute('aria-hidden');
+          removeButton.removeAttribute('tabindex');
+        } else {
+          removeButton.setAttribute('aria-hidden', 'true');
+          removeButton.setAttribute('tabindex', '-1');
+        }
         wrapper.appendChild(removeButton);
       }
       fragment.appendChild(wrapper);
@@ -142,9 +261,111 @@ if (container) {
     if (data && Array.isArray(data.presets)) {
       presets = normalizePresets(data.presets);
       renderPresets();
+      updateEditingUI();
       sharePresets(presets);
     }
   };
+
+  container.addEventListener('dragstart', (event) => {
+    const item = event.target.closest('.preset-item');
+    if (!item) {
+      return;
+    }
+    if (!editing) {
+      event.preventDefault();
+      return;
+    }
+    const id = item.dataset.presetId;
+    if (!id) {
+      event.preventDefault();
+      return;
+    }
+    const index = findPresetIndex(id);
+    if (index === -1) {
+      event.preventDefault();
+      return;
+    }
+    dragState.id = id;
+    dragState.index = index;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', id);
+    }
+    window.requestAnimationFrame(() => {
+      item.classList.add('is-dragging');
+    });
+  });
+
+  container.addEventListener('dragend', (event) => {
+    const item = event.target.closest('.preset-item');
+    if (item) {
+      item.classList.remove('is-dragging');
+    }
+    clearDropIndicators();
+    resetDragState();
+  });
+
+  container.addEventListener('dragover', (event) => {
+    if (!editing || !dragState.id) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+    const item = event.target.closest('.preset-item');
+    if (!item || item.dataset.presetId === dragState.id) {
+      clearDropIndicators();
+      return;
+    }
+    const position = dropPositionForEvent(event, item);
+    setDropIndicator(item, position);
+  });
+
+  container.addEventListener('dragleave', (event) => {
+    if (!editing || !dragState.id) {
+      return;
+    }
+    const related = event.relatedTarget;
+    if (!related || !container.contains(related)) {
+      clearDropIndicators();
+    }
+  });
+
+  container.addEventListener('drop', (event) => {
+    if (!editing || !dragState.id) {
+      return;
+    }
+    event.preventDefault();
+    const fromIndex = dragState.index;
+    if (fromIndex === -1) {
+      clearDropIndicators();
+      resetDragState();
+      return;
+    }
+    const activeItem = container.querySelector('.preset-item.is-dragging');
+    if (activeItem) {
+      activeItem.classList.remove('is-dragging');
+    }
+    const target = event.target.closest('.preset-item');
+    let toIndex = presets.length;
+    if (target) {
+      const targetId = target.dataset.presetId;
+      const targetIndex = targetId ? findPresetIndex(targetId) : -1;
+      if (targetIndex !== -1) {
+        const position = dropPositionForEvent(event, target);
+        toIndex = position === 'after' ? targetIndex + 1 : targetIndex;
+      }
+    }
+    const moved = movePreset(fromIndex, toIndex);
+    clearDropIndicators();
+    resetDragState();
+    if (moved) {
+      renderPresets();
+      updateEditingUI();
+      sharePresets(presets);
+    }
+  });
 
   const handleApply = async (id, button) => {
     if (!id || !baseUrl) {
@@ -224,6 +445,9 @@ if (container) {
   container.addEventListener('click', (event) => {
     const deleteButton = event.target.closest('button.preset-delete');
     if (deleteButton) {
+      if (!editing) {
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
       const id = deleteButton.dataset.presetId;
@@ -241,6 +465,14 @@ if (container) {
     }
   });
 
+  if (editButton) {
+    editButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      editing = !editing;
+      updateEditingUI();
+    });
+  }
+
   if (saveButton) {
     saveButton.addEventListener('click', (event) => {
       event.preventDefault();
@@ -249,6 +481,7 @@ if (container) {
   }
 
   renderPresets();
+  updateEditingUI();
   setStatus('', 'base');
   sharePresets(presets);
 }

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -16,15 +16,18 @@
 <div class="mt-8" id="presetSection">
   <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
     <h2 class="text-2xl font-semibold">Presets</h2>
-    <button id="presetSaveButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400">Save Preset</button>
+    <div class="flex items-center gap-2">
+      <button id="presetSaveButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400">Save Preset</button>
+      <button id="presetEditButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400" aria-pressed="false" aria-controls="presetList">Edit</button>
+    </div>
   </div>
   <div id="presetStatus" class="text-sm mb-3 opacity-80" role="status" aria-live="polite"></div>
-  <div id="presetList" class="flex flex-wrap gap-2" data-house-id="{{ house.id }}" data-room-id="{{ room.id }}" data-api-base="/api/house/{{ house.id }}/room/{{ room.id }}" data-initial-presets='{{ presets|tojson }}'>
+  <div id="presetList" class="flex flex-wrap gap-2" data-editing="false" data-house-id="{{ house.id }}" data-room-id="{{ room.id }}" data-api-base="/api/house/{{ house.id }}/room/{{ room.id }}" data-initial-presets='{{ presets|tojson }}'>
     {% for p in presets %}
     <div class="preset-item" data-preset-id="{{ p.id }}" data-custom="{{ 'true' if p.source == 'custom' else 'false' }}">
       <button class="preset preset-button glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400" type="button" data-preset-id="{{ p.id }}">{{ p.name or p.id }}</button>
       {% if p.source == 'custom' %}
-      <button class="preset-delete" type="button" aria-label="Delete preset {{ p.name or p.id }}" data-preset-id="{{ p.id }}">✕</button>
+      <button class="preset-delete" type="button" aria-hidden="true" tabindex="-1" hidden aria-label="Delete preset {{ p.name or p.id }}" data-preset-id="{{ p.id }}">✕</button>
       {% endif %}
     </div>
     {% else %}


### PR DESCRIPTION
## Summary
- extend the preset editor to manage drag state and allow reordering presets in edit mode
- update preset list rendering and sharing so the UI reflects the new order after a drag
- add styling cues for draggable presets and drop targets while editing
- make the edit toggle explicitly show and hide preset delete controls for accessibility and clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce65b38cf88326b86079c450d64bf6