### PR TITLE
Persist room preset reordering

### DIFF
--- a/Server/app/presets/__init__.py
+++ b/Server/app/presets/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from ..config import settings
 from ..mqtt_bus import MqttBus
@@ -19,6 +19,7 @@ __all__ = [
     "get_preset",
     "get_room_presets",
     "list_custom_presets",
+    "reorder_custom_presets",
     "save_custom_preset",
     "snapshot_to_actions",
 ]
@@ -53,6 +54,16 @@ def delete_custom_preset(house_id: str, room_id: str, preset_id: str) -> bool:
     """Remove the custom preset ``preset_id`` from ``house_id``/``room_id``."""
 
     return _custom_presets.delete_preset(str(house_id), str(room_id), str(preset_id))
+
+
+def reorder_custom_presets(
+    house_id: str, room_id: str, preset_order: Iterable[Any]
+) -> List[Dict[str, Any]]:
+    """Reorder presets for ``house_id``/``room_id`` to match ``preset_order``."""
+
+    return _custom_presets.reorder_presets(
+        str(house_id), str(room_id), preset_order
+    )
 
 
 def get_preset(house_id: str, room_id: str, preset_id: str) -> Optional[Dict[str, Any]]:

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -10,6 +10,7 @@ from .presets import (
     get_room_presets,
     save_custom_preset,
     delete_custom_preset,
+    reorder_custom_presets,
     snapshot_to_actions,
 )
 from .motion import motion_manager
@@ -492,6 +493,26 @@ def api_delete_room_preset(house_id: str, room_id: str, preset_id: str):
         raise HTTPException(404, "Unknown preset")
 
     presets = get_room_presets(house_id, room_id)
+    return {"ok": True, "presets": presets}
+
+
+@router.post("/api/house/{house_id}/room/{room_id}/presets/reorder")
+def api_reorder_room_presets(house_id: str, room_id: str, payload: Dict[str, Any]):
+    house, room = registry.find_room(house_id, room_id)
+    if not house or not room:
+        raise HTTPException(404, "Unknown room")
+
+    order = payload.get("order")
+    if not isinstance(order, list):
+        raise HTTPException(400, "order must be provided as a list")
+
+    try:
+        presets = reorder_custom_presets(house_id, room_id, order)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except KeyError:
+        raise HTTPException(404, "Unknown preset")
+
     return {"ok": True, "presets": presets}
 
 

--- a/Server/app/static/presets.js
+++ b/Server/app/static/presets.js
@@ -5,6 +5,7 @@ if (container) {
   const editButton = document.getElementById('presetEditButton');
   const baseUrl = container.dataset.apiBase || '';
   const presetsUrl = baseUrl ? `${baseUrl}/presets` : '';
+  const reorderUrl = presetsUrl ? `${presetsUrl}/reorder` : '';
   const applyUrlFor = (id) => `${baseUrl}/preset/${encodeURIComponent(id)}`;
   let statusTimer = null;
 
@@ -81,6 +82,25 @@ if (container) {
   const initialPresets = normalizePresets(initialRaw);
   let presets = initialPresets;
   let editing = false;
+  let orderDirty = false;
+
+  const ordersEqual = (a, b) => {
+    if (!Array.isArray(a) || !Array.isArray(b)) {
+      return false;
+    }
+    if (a.length !== b.length) {
+      return false;
+    }
+    for (let index = 0; index < a.length; index += 1) {
+      if (a[index] !== b[index]) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const currentOrder = () => presets.map((preset) => preset.id);
+  let lastKnownOrder = currentOrder();
 
   const dragState = { id: null, index: -1 };
   let currentDropTarget = null;
@@ -262,6 +282,8 @@ if (container) {
       presets = normalizePresets(data.presets);
       renderPresets();
       updateEditingUI();
+      lastKnownOrder = currentOrder();
+      orderDirty = false;
       sharePresets(presets);
     }
   };
@@ -363,6 +385,7 @@ if (container) {
     if (moved) {
       renderPresets();
       updateEditingUI();
+      orderDirty = !ordersEqual(currentOrder(), lastKnownOrder);
       sharePresets(presets);
     }
   });
@@ -442,6 +465,46 @@ if (container) {
     }
   };
 
+  const persistPresetOrder = async () => {
+    if (!orderDirty) {
+      return true;
+    }
+    if (!reorderUrl) {
+      setStatus('Saving preset order is not available.', 'error');
+      return false;
+    }
+    const order = currentOrder();
+    if (order.length < 2) {
+      orderDirty = false;
+      lastKnownOrder = order;
+      return true;
+    }
+    try {
+      if (editButton) {
+        editButton.disabled = true;
+      }
+      setStatus('Saving preset order...', 'info');
+      const data = await fetchJson(reorderUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order }),
+      });
+      updateFromResponse(data);
+      lastKnownOrder = currentOrder();
+      orderDirty = false;
+      setStatus('Preset order saved ✓', 'success', true);
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update preset order.';
+      setStatus(`Failed to update preset order: ${message}`, 'error');
+      return false;
+    } finally {
+      if (editButton) {
+        editButton.disabled = false;
+      }
+    }
+  };
+
   container.addEventListener('click', (event) => {
     const deleteButton = event.target.closest('button.preset-delete');
     if (deleteButton) {
@@ -466,10 +529,16 @@ if (container) {
   });
 
   if (editButton) {
-    editButton.addEventListener('click', (event) => {
+    editButton.addEventListener('click', async (event) => {
       event.preventDefault();
-      editing = !editing;
-      updateEditingUI();
+      if (editing) {
+        editing = false;
+        updateEditingUI();
+        await persistPresetOrder();
+      } else {
+        editing = true;
+        updateEditingUI();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- allow room preset drag-and-drop ordering to persist by calling a reorder endpoint
- add persistence helpers and API route to store custom preset order
- exercise the new ordering behavior with custom store and API tests

## Testing
- pytest Server/tests

------
https://chatgpt.com/codex/tasks/task_e_68cf591bc5a883269fe7bd4abcdbaf19