### PR TITLE
Fix preset reorder persistence

### DIFF
--- a/Server/app/presets/__init__.py
+++ b/Server/app/presets/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from ..config import settings
 from ..mqtt_bus import MqttBus
@@ -19,6 +19,7 @@ __all__ = [
     "get_preset",
     "get_room_presets",
     "list_custom_presets",
+    "reorder_custom_presets",
     "save_custom_preset",
     "snapshot_to_actions",
 ]
@@ -53,6 +54,16 @@ def delete_custom_preset(house_id: str, room_id: str, preset_id: str) -> bool:
     """Remove the custom preset ``preset_id`` from ``house_id``/``room_id``."""
 
     return _custom_presets.delete_preset(str(house_id), str(room_id), str(preset_id))
+
+
+def reorder_custom_presets(
+    house_id: str, room_id: str, preset_order: Iterable[Any]
+) -> List[Dict[str, Any]]:
+    """Reorder presets for ``house_id``/``room_id`` to match ``preset_order``."""
+
+    return _custom_presets.reorder_presets(
+        str(house_id), str(room_id), preset_order
+    )
 
 
 def get_preset(house_id: str, room_id: str, preset_id: str) -> Optional[Dict[str, Any]]:

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -10,6 +10,7 @@ from .presets import (
     get_room_presets,
     save_custom_preset,
     delete_custom_preset,
+    reorder_custom_presets,
     snapshot_to_actions,
 )
 from .motion import motion_manager
@@ -492,6 +493,26 @@ def api_delete_room_preset(house_id: str, room_id: str, preset_id: str):
         raise HTTPException(404, "Unknown preset")
 
     presets = get_room_presets(house_id, room_id)
+    return {"ok": True, "presets": presets}
+
+
+@router.post("/api/house/{house_id}/room/{room_id}/presets/reorder")
+def api_reorder_room_presets(house_id: str, room_id: str, payload: Dict[str, Any]):
+    house, room = registry.find_room(house_id, room_id)
+    if not house or not room:
+        raise HTTPException(404, "Unknown room")
+
+    order = payload.get("order")
+    if not isinstance(order, list):
+        raise HTTPException(400, "order must be provided as a list")
+
+    try:
+        presets = reorder_custom_presets(house_id, room_id, order)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except KeyError:
+        raise HTTPException(404, "Unknown preset")
+
     return {"ok": True, "presets": presets}
 
 


### PR DESCRIPTION
## Summary
- detect preset order changes when leaving edit mode so saving always runs when positions move
- keep the interface in edit mode if saving the new order fails so users can retry immediately

## Testing
- pytest Server/tests

------
https://chatgpt.com/codex/tasks/task_e_68cf591bc5a883269fe7bd4abcdbaf19