### PR TITLE
Remove daily reboot timer

### DIFF
--- a/UltraNodeV5/components/ul_core/include/ul_core.h
+++ b/UltraNodeV5/components/ul_core/include/ul_core.h
@@ -12,7 +12,6 @@ bool ul_core_wait_for_ip(TickType_t timeout);
 bool ul_core_is_connected(void);
 void ul_core_wifi_stop(void); // Call before reinitializing or shutting down networking
 void ul_core_sntp_start(void);
-void ul_core_schedule_daily_reboot(void);
 const char *ul_core_get_node_id(void);
 
 typedef void (*ul_core_conn_cb_t)(bool connected, void *ctx);

--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -81,7 +81,6 @@ void app_main(void) {
     ESP_LOGE(TAG, "Failed to obtain IP address");
   }
   ul_core_sntp_start();
-  ul_core_schedule_daily_reboot();
 
   // Status heartbeat via MQTT
   while (true) {


### PR DESCRIPTION
## Summary
- remove the core reboot timer and its scheduling so SNTP sync no longer re-arms a noon restart
- stop invoking the daily reboot from app_main so the node only restarts for explicit maintenance events

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d28bfeefb48326ac3cd88dba9784ed