### PR TITLE
Handle SNTP resync task creation failures with retries

### DIFF
--- a/UltraNodeV5/components/ul_core/include/ul_core.h
+++ b/UltraNodeV5/components/ul_core/include/ul_core.h
@@ -2,6 +2,7 @@
 #include "esp_err.h"
 #include "freertos/FreeRTOS.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +14,10 @@ bool ul_core_is_connected(void);
 void ul_core_wifi_stop(void); // Call before reinitializing or shutting down networking
 void ul_core_sntp_start(void);
 const char *ul_core_get_node_id(void);
+bool ul_core_is_sntp_resync_active(void);
+uint32_t ul_core_get_sntp_retry_attempts(void);
+uint64_t ul_core_get_sntp_first_failure_us(void);
+uint64_t ul_core_get_sntp_last_failure_us(void);
 
 typedef void (*ul_core_conn_cb_t)(bool connected, void *ctx);
 void ul_core_register_connectivity_cb(ul_core_conn_cb_t cb, void *ctx);


### PR DESCRIPTION
## Summary
- add retry tracking and timer-backed reattempts when the SNTP resync task cannot be created
- expose SNTP resync status so the health monitor can report prolonged creation failures
- log persistent SNTP resync task creation problems from the health task for easier diagnosis

## Testing
- idf.py build *(fails: idf.py not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f1b33ad883268798a96ad4da930e