### PR TITLE
Handle MQTT init failures with retry

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/test/test_ul_mqtt_retry.c
+++ b/UltraNodeV5/components/ul_mqtt/test/test_ul_mqtt_retry.c
@@ -1,0 +1,186 @@
+#include <assert.h>
+#include <stdio.h>
+
+#define UL_MQTT_TESTING 1
+#include "ul_mqtt_test_stubs.h"
+
+static bool g_core_connected = true;
+static int g_health_notify_calls = 0;
+static bool g_health_last_state = true;
+static int g_init_calls = 0;
+static int g_register_calls = 0;
+static int g_start_calls = 0;
+static int g_stop_calls = 0;
+static int g_destroy_calls = 0;
+static int g_vtaskdelay_last = -1;
+static int g_init_failures_remaining = 1;
+
+struct ul_mqtt_test_client {
+  int placeholder;
+};
+
+static struct ul_mqtt_test_client g_client = {0};
+static esp_event_handler_t g_registered_handler = NULL;
+
+static esp_timer_t g_timer = {0};
+static bool g_timer_created = false;
+
+bool ul_core_is_connected(void) { return g_core_connected; }
+
+void ul_health_notify_mqtt(bool connected) {
+  g_health_notify_calls++;
+  g_health_last_state = connected;
+}
+
+esp_err_t esp_timer_create(const esp_timer_create_args_t *args,
+                           esp_timer_handle_t *out_handle) {
+  g_timer_created = true;
+  g_timer.callback = args ? args->callback : NULL;
+  g_timer.arg = args ? args->arg : NULL;
+  g_timer.active = false;
+  g_timer.timeout_us = 0;
+  if (out_handle)
+    *out_handle = &g_timer;
+  return ESP_OK;
+}
+
+esp_err_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us) {
+  if (!timer)
+    return ESP_FAIL;
+  timer->active = true;
+  timer->timeout_us = timeout_us;
+  return ESP_OK;
+}
+
+esp_err_t esp_timer_stop(esp_timer_handle_t timer) {
+  if (!timer)
+    return ESP_FAIL;
+  if (!timer->active)
+    return ESP_ERR_INVALID_STATE;
+  timer->active = false;
+  return ESP_OK;
+}
+
+esp_mqtt_client_handle_t esp_mqtt_client_init(const esp_mqtt_client_config_t *cfg) {
+  (void)cfg;
+  g_init_calls++;
+  if (g_init_failures_remaining > 0) {
+    g_init_failures_remaining--;
+    return NULL;
+  }
+  return &g_client;
+}
+
+esp_err_t esp_mqtt_client_register_event(esp_mqtt_client_handle_t client,
+                                         int32_t event_id,
+                                         esp_event_handler_t handler,
+                                         void *event_data) {
+  (void)client;
+  (void)event_id;
+  (void)event_data;
+  g_register_calls++;
+  g_registered_handler = handler;
+  return ESP_OK;
+}
+
+esp_err_t esp_mqtt_client_start(esp_mqtt_client_handle_t client) {
+  (void)client;
+  g_start_calls++;
+  return ESP_OK;
+}
+
+esp_err_t esp_mqtt_client_stop(esp_mqtt_client_handle_t client) {
+  (void)client;
+  g_stop_calls++;
+  return ESP_OK;
+}
+
+esp_err_t esp_mqtt_client_destroy(esp_mqtt_client_handle_t client) {
+  (void)client;
+  g_destroy_calls++;
+  return ESP_OK;
+}
+
+void vTaskDelay(int ticks) { g_vtaskdelay_last = ticks; }
+
+void motion_fade_cancel(void) {}
+
+void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id,
+                        void *event_data) {
+  (void)handler_args;
+  (void)base;
+  (void)event_id;
+  (void)event_data;
+}
+
+#include "../ul_mqtt.c"
+
+static void fire_retry_timer(void) {
+  assert(g_timer_created);
+  if (g_timer.active && g_timer.callback) {
+    esp_timer_cb_t cb = g_timer.callback;
+    void *arg = g_timer.arg;
+    g_timer.active = false;
+    cb(arg);
+  }
+}
+
+static void reset_state(void) {
+  g_health_notify_calls = 0;
+  g_health_last_state = true;
+  g_init_calls = 0;
+  g_register_calls = 0;
+  g_start_calls = 0;
+  g_stop_calls = 0;
+  g_destroy_calls = 0;
+  g_vtaskdelay_last = -1;
+  g_init_failures_remaining = 1;
+  g_timer_created = false;
+  g_timer.callback = NULL;
+  g_timer.arg = NULL;
+  g_timer.active = false;
+  g_timer.timeout_us = 0;
+  g_registered_handler = NULL;
+}
+
+int main(void) {
+  reset_state();
+  g_core_connected = true;
+
+  ul_mqtt_start();
+
+  assert(g_init_calls == 1);
+  assert(ul_mqtt_test_get_client_handle() == NULL);
+  assert(g_register_calls == 0);
+  assert(g_start_calls == 0);
+  assert(g_health_notify_calls == 1);
+  assert(g_health_last_state == false);
+  assert(g_timer_created);
+  assert(ul_mqtt_test_retry_pending());
+  assert(g_timer.active);
+
+  g_init_failures_remaining = 0;
+
+  fire_retry_timer();
+
+  assert(g_init_calls == 2);
+  assert(g_register_calls == 1);
+  assert(g_start_calls == 1);
+  assert(g_registered_handler != NULL);
+  assert(ul_mqtt_test_get_client_handle() == &g_client);
+  assert(!ul_mqtt_test_retry_pending());
+  assert(!g_timer.active);
+  assert(g_health_notify_calls == 2);
+  assert(g_health_last_state == false);
+
+  ul_mqtt_stop();
+  assert(ul_mqtt_test_get_client_handle() == NULL);
+  assert(g_stop_calls == 1);
+  assert(g_destroy_calls == 1);
+  assert(g_health_notify_calls == 3);
+  assert(g_health_last_state == false);
+
+  printf("ul_mqtt_retry_test passed\n");
+  return 0;
+}
+

--- a/UltraNodeV5/components/ul_mqtt/test/test_ul_mqtt_retry.py
+++ b/UltraNodeV5/components/ul_mqtt/test/test_ul_mqtt_retry.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Build and execute the ul_mqtt retry behaviour test."""
+
+import subprocess
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    test_dir = Path(__file__).resolve().parent
+    project_root = test_dir.parents[3]
+    build_dir = project_root / "build-tests"
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    source = test_dir / "test_ul_mqtt_retry.c"
+    executable = build_dir / "test_ul_mqtt_retry"
+
+    compile_cmd = [
+        "gcc",
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-I",
+        str(test_dir),
+        str(source),
+        "-o",
+        str(executable),
+    ]
+
+    subprocess.run(compile_cmd, check=True)
+    subprocess.run([str(executable)], check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
+++ b/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef int esp_err_t;
+
+#define ESP_OK 0
+#define ESP_FAIL -1
+#define ESP_ERR_INVALID_STATE 0x0103
+
+#define ESP_LOGI(tag, fmt, ...) do { (void)(tag); (void)(fmt); } while (0)
+#define ESP_LOGW(tag, fmt, ...) do { (void)(tag); (void)(fmt); } while (0)
+#define ESP_LOGE(tag, fmt, ...) do { (void)(tag); (void)(fmt); } while (0)
+
+#define CONFIG_UL_MQTT_URI "test://broker"
+#define CONFIG_UL_MQTT_USER "test_user"
+#define CONFIG_UL_MQTT_PASS "test_pass"
+
+#define ESP_EVENT_ANY_ID (-1)
+
+typedef void *esp_event_base_t;
+typedef void (*esp_event_handler_t)(void *handler_args, esp_event_base_t base,
+                                    int32_t event_id, void *event_data);
+
+typedef void (*esp_timer_cb_t)(void *);
+
+typedef struct esp_timer {
+  esp_timer_cb_t callback;
+  void *arg;
+  bool active;
+  uint64_t timeout_us;
+} esp_timer_t;
+
+typedef esp_timer_t *esp_timer_handle_t;
+
+typedef struct {
+  esp_timer_cb_t callback;
+  void *arg;
+  const char *name;
+} esp_timer_create_args_t;
+
+esp_err_t esp_timer_create(const esp_timer_create_args_t *args,
+                           esp_timer_handle_t *out_handle);
+esp_err_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us);
+esp_err_t esp_timer_stop(esp_timer_handle_t timer);
+
+struct ul_mqtt_test_client;
+typedef struct ul_mqtt_test_client *esp_mqtt_client_handle_t;
+
+typedef struct {
+  struct {
+    struct {
+      const char *uri;
+    } address;
+  } broker;
+  struct {
+    const char *username;
+    struct {
+      const char *password;
+    } authentication;
+  } credentials;
+  struct {
+    int priority;
+    int stack_size;
+  } task;
+} esp_mqtt_client_config_t;
+
+esp_mqtt_client_handle_t esp_mqtt_client_init(const esp_mqtt_client_config_t *cfg);
+esp_err_t esp_mqtt_client_register_event(esp_mqtt_client_handle_t client,
+                                         int32_t event_id,
+                                         esp_event_handler_t handler,
+                                         void *event_data);
+esp_err_t esp_mqtt_client_start(esp_mqtt_client_handle_t client);
+esp_err_t esp_mqtt_client_stop(esp_mqtt_client_handle_t client);
+esp_err_t esp_mqtt_client_destroy(esp_mqtt_client_handle_t client);
+
+bool ul_core_is_connected(void);
+void ul_health_notify_mqtt(bool connected);
+
+#define pdMS_TO_TICKS(ms) (ms)
+void vTaskDelay(int ticks);
+
+void motion_fade_cancel(void);
+void mqtt_event_handler(void *handler_args, esp_event_base_t base,
+                        int32_t event_id, void *event_data);
+
+esp_mqtt_client_handle_t ul_mqtt_test_get_client_handle(void);
+bool ul_mqtt_test_retry_pending(void);
+


### PR DESCRIPTION
## Summary
- guard `ul_mqtt_start` against null client handles, notify health, and schedule a retry timer
- add a lightweight test harness with stubs to exercise MQTT init failure and recovery logic

## Testing
- python UltraNodeV5/components/ul_mqtt/test/test_ul_mqtt_retry.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f1b286408326a01ec71838f3c48c