### PR TITLE
Handle Wi-Fi event group failure gracefully

### DIFF
--- a/UltraNodeV5/tests/ul_core/stubs/esp_event.h
+++ b/UltraNodeV5/tests/ul_core/stubs/esp_event.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "esp_err.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef const char *esp_event_base_t;
+typedef void (*esp_event_handler_t)(void *arg, esp_event_base_t event_base,
+                                    int32_t event_id, void *event_data);
+
+esp_err_t esp_event_handler_register(esp_event_base_t event_base,
+                                     int32_t event_id,
+                                     esp_event_handler_t event_handler,
+                                     void *event_handler_arg);
+esp_err_t esp_event_handler_unregister(esp_event_base_t event_base,
+                                       int32_t event_id,
+                                       esp_event_handler_t event_handler);
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5/tests/ul_core/stubs/esp_netif.h
+++ b/UltraNodeV5/tests/ul_core/stubs/esp_netif.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <stdint.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  struct {
+    struct {
+      uint32_t addr;
+    } ip;
+  } ip_info;
+} ip_event_got_ip_t;
+
+static inline void *esp_netif_create_default_wifi_sta(void) { return (void *)1; }
+
+#define IPSTR "%d.%d.%d.%d"
+#define IP2STR(ip) 0, 0, 0, 0
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5/tests/ul_core/stubs/esp_netif_sntp.h
+++ b/UltraNodeV5/tests/ul_core/stubs/esp_netif_sntp.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  const char *server_from_dhcp;
+} esp_sntp_config_t;
+
+#define ESP_NETIF_SNTP_DEFAULT_CONFIG(server) \
+  (esp_sntp_config_t){ .server_from_dhcp = (server) }
+
+esp_err_t esp_netif_sntp_init(const esp_sntp_config_t *config);
+esp_err_t esp_netif_sntp_start(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5/tests/ul_core/stubs/esp_sntp.h
+++ b/UltraNodeV5/tests/ul_core/stubs/esp_sntp.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <sys/time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void esp_sntp_set_time_sync_notification_cb(void (*cb)(struct timeval *tv));
+void esp_sntp_stop(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5/tests/ul_core/stubs/esp_timer.h
+++ b/UltraNodeV5/tests/ul_core/stubs/esp_timer.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*esp_timer_cb_t)(void *);
+
+typedef struct {
+  esp_timer_cb_t callback;
+  const char *name;
+} esp_timer_create_args_t;
+
+typedef void *esp_timer_handle_t;
+
+esp_err_t esp_timer_create(const esp_timer_create_args_t *args,
+                           esp_timer_handle_t *out_handle);
+esp_err_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us);
+esp_err_t esp_timer_stop(esp_timer_handle_t timer);
+esp_err_t esp_timer_delete(esp_timer_handle_t timer);
+bool esp_timer_is_active(esp_timer_handle_t timer);
+uint64_t esp_timer_get_time(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5/tests/ul_core/stubs/esp_wifi.h
+++ b/UltraNodeV5/tests/ul_core/stubs/esp_wifi.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "esp_err.h"
+#include "esp_event.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  int dummy;
+} wifi_init_config_t;
+
+#define WIFI_INIT_CONFIG_DEFAULT() (wifi_init_config_t){0}
+
+#define WIFI_MODE_STA 0
+#define WIFI_IF_STA 0
+#define WIFI_AUTH_WPA2_PSK 1
+
+typedef struct {
+  struct {
+    uint8_t ssid[32];
+    uint8_t password[64];
+    struct {
+      int authmode;
+    } threshold;
+  } sta;
+} wifi_config_t;
+
+esp_err_t esp_wifi_init(const wifi_init_config_t *cfg);
+esp_err_t esp_wifi_set_mode(int mode);
+esp_err_t esp_wifi_set_config(int interface, wifi_config_t *config);
+esp_err_t esp_wifi_start(void);
+esp_err_t esp_wifi_stop(void);
+esp_err_t esp_wifi_deinit(void);
+esp_err_t esp_wifi_connect(void);
+
+#define WIFI_EVENT ((esp_event_base_t)"WIFI_EVENT")
+#define IP_EVENT ((esp_event_base_t)"IP_EVENT")
+#define WIFI_EVENT_STA_START 0
+#define WIFI_EVENT_STA_DISCONNECTED 1
+#define IP_EVENT_STA_GOT_IP 2
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5/tests/ul_core/stubs/freertos/event_groups.h
+++ b/UltraNodeV5/tests/ul_core/stubs/freertos/event_groups.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "freertos/FreeRTOS.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct EventGroupStub *EventGroupHandle_t;
+
+EventGroupHandle_t xEventGroupCreate(void);
+EventBits_t xEventGroupWaitBits(EventGroupHandle_t event_group,
+                                EventBits_t bits_to_wait_for,
+                                BaseType_t clear_on_exit,
+                                BaseType_t wait_for_all_bits,
+                                TickType_t ticks_to_wait);
+EventBits_t xEventGroupSetBits(EventGroupHandle_t event_group,
+                               EventBits_t bits_to_set);
+EventBits_t xEventGroupClearBits(EventGroupHandle_t event_group,
+                                 EventBits_t bits_to_clear);
+EventBits_t xEventGroupGetBits(EventGroupHandle_t event_group);
+void vEventGroupDelete(EventGroupHandle_t event_group);
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5/tests/ul_core/test_ul_core_wifi_event_group_failure.c
+++ b/UltraNodeV5/tests/ul_core/test_ul_core_wifi_event_group_failure.c
@@ -1,0 +1,348 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_netif_sntp.h"
+#include "esp_sntp.h"
+#include "esp_timer.h"
+#include "esp_wifi.h"
+#include "sdkconfig.h"
+#include "ul_task.h"
+
+struct EventGroupStub {
+  EventBits_t bits;
+};
+
+typedef struct {
+  bool deleted;
+} stub_semaphore_t;
+
+typedef struct {
+  bool active;
+  esp_timer_cb_t cb;
+} stub_timer_t;
+
+static bool g_force_event_group_failure;
+static int g_event_group_create_calls;
+static int g_event_group_wait_calls;
+static int g_event_group_set_calls;
+static int g_event_group_clear_calls;
+static int g_event_group_delete_calls;
+static int g_timer_stop_calls;
+static int g_timer_delete_calls;
+static int g_mutex_delete_calls;
+static int g_wifi_connect_calls;
+
+static struct EventGroupStub g_event_group_instance;
+static stub_semaphore_t g_mutex_instance;
+static stub_semaphore_t g_binary_semaphore_instance;
+static stub_timer_t g_existing_timer;
+static stub_timer_t g_created_timer;
+
+EventGroupHandle_t xEventGroupCreate(void) {
+  g_event_group_create_calls++;
+  if (g_force_event_group_failure)
+    return NULL;
+  g_event_group_instance.bits = 0;
+  return &g_event_group_instance;
+}
+
+EventBits_t xEventGroupWaitBits(EventGroupHandle_t event_group,
+                                EventBits_t bits_to_wait_for,
+                                BaseType_t clear_on_exit,
+                                BaseType_t wait_for_all_bits,
+                                TickType_t ticks_to_wait) {
+  (void)clear_on_exit;
+  (void)wait_for_all_bits;
+  (void)ticks_to_wait;
+  g_event_group_wait_calls++;
+  if (!event_group)
+    return 0;
+  EventBits_t value = event_group->bits & bits_to_wait_for;
+  if (clear_on_exit)
+    event_group->bits &= ~bits_to_wait_for;
+  return value;
+}
+
+EventBits_t xEventGroupSetBits(EventGroupHandle_t event_group,
+                               EventBits_t bits_to_set) {
+  g_event_group_set_calls++;
+  if (!event_group)
+    return 0;
+  event_group->bits |= bits_to_set;
+  return event_group->bits;
+}
+
+EventBits_t xEventGroupClearBits(EventGroupHandle_t event_group,
+                                 EventBits_t bits_to_clear) {
+  g_event_group_clear_calls++;
+  if (!event_group)
+    return 0;
+  event_group->bits &= ~bits_to_clear;
+  return event_group->bits;
+}
+
+EventBits_t xEventGroupGetBits(EventGroupHandle_t event_group) {
+  if (!event_group)
+    return 0;
+  return event_group->bits;
+}
+
+void vEventGroupDelete(EventGroupHandle_t event_group) {
+  if (event_group)
+    g_event_group_delete_calls++;
+}
+
+SemaphoreHandle_t xSemaphoreCreateBinary(void) {
+  g_binary_semaphore_instance.deleted = false;
+  return &g_binary_semaphore_instance;
+}
+
+SemaphoreHandle_t xSemaphoreCreateMutex(void) {
+  g_mutex_instance.deleted = false;
+  return &g_mutex_instance;
+}
+
+BaseType_t xSemaphoreTake(SemaphoreHandle_t sem, TickType_t ticks) {
+  (void)sem;
+  (void)ticks;
+  return pdTRUE;
+}
+
+BaseType_t xSemaphoreGive(SemaphoreHandle_t sem) {
+  (void)sem;
+  return pdTRUE;
+}
+
+void vSemaphoreDelete(SemaphoreHandle_t sem) {
+  if (sem) {
+    ((stub_semaphore_t *)sem)->deleted = true;
+    g_mutex_delete_calls++;
+  }
+}
+
+TickType_t xTaskGetTickCount(void) {
+  static TickType_t fake_ticks;
+  return fake_ticks++;
+}
+
+void vTaskDelayUntil(TickType_t *const previous, TickType_t increment) {
+  if (previous)
+    *previous += increment;
+}
+
+void vTaskDelay(TickType_t ticks) {
+  (void)ticks;
+}
+
+void vTaskDelete(TaskHandle_t task) {
+  (void)task;
+}
+
+BaseType_t ul_task_create(TaskFunction_t task_func, const char *name,
+                          const uint32_t stack_depth, void *params,
+                          UBaseType_t priority, TaskHandle_t *task_handle,
+                          BaseType_t core_id) {
+  (void)task_func;
+  (void)name;
+  (void)stack_depth;
+  (void)params;
+  (void)priority;
+  (void)task_handle;
+  (void)core_id;
+  return pdPASS;
+}
+
+esp_err_t esp_timer_create(const esp_timer_create_args_t *args,
+                           esp_timer_handle_t *out_handle) {
+  g_created_timer.active = false;
+  g_created_timer.cb = args ? args->callback : NULL;
+  if (out_handle)
+    *out_handle = &g_created_timer;
+  return ESP_OK;
+}
+
+esp_err_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us) {
+  (void)timeout_us;
+  if (timer)
+    ((stub_timer_t *)timer)->active = true;
+  return ESP_OK;
+}
+
+esp_err_t esp_timer_stop(esp_timer_handle_t timer) {
+  g_timer_stop_calls++;
+  if (timer)
+    ((stub_timer_t *)timer)->active = false;
+  return ESP_OK;
+}
+
+esp_err_t esp_timer_delete(esp_timer_handle_t timer) {
+  (void)timer;
+  g_timer_delete_calls++;
+  return ESP_OK;
+}
+
+bool esp_timer_is_active(esp_timer_handle_t timer) {
+  if (!timer)
+    return false;
+  return ((stub_timer_t *)timer)->active;
+}
+
+uint64_t esp_timer_get_time(void) {
+  static uint64_t now;
+  return now += 1000;
+}
+
+esp_err_t esp_event_handler_register(esp_event_base_t event_base,
+                                     int32_t event_id,
+                                     esp_event_handler_t event_handler,
+                                     void *event_handler_arg) {
+  (void)event_base;
+  (void)event_id;
+  (void)event_handler;
+  (void)event_handler_arg;
+  return ESP_OK;
+}
+
+esp_err_t esp_event_handler_unregister(esp_event_base_t event_base,
+                                       int32_t event_id,
+                                       esp_event_handler_t event_handler) {
+  (void)event_base;
+  (void)event_id;
+  (void)event_handler;
+  return ESP_OK;
+}
+
+esp_err_t esp_wifi_init(const wifi_init_config_t *cfg) {
+  (void)cfg;
+  return ESP_OK;
+}
+
+esp_err_t esp_wifi_set_mode(int mode) {
+  (void)mode;
+  return ESP_OK;
+}
+
+esp_err_t esp_wifi_set_config(int interface, wifi_config_t *config) {
+  (void)interface;
+  (void)config;
+  return ESP_OK;
+}
+
+esp_err_t esp_wifi_start(void) { return ESP_OK; }
+
+esp_err_t esp_wifi_stop(void) { return ESP_OK; }
+
+esp_err_t esp_wifi_deinit(void) { return ESP_OK; }
+
+esp_err_t esp_wifi_connect(void) {
+  g_wifi_connect_calls++;
+  return ESP_OK;
+}
+
+const char *esp_err_to_name(esp_err_t err) {
+  return err == ESP_OK ? "ESP_OK" : "ERR";
+}
+
+esp_err_t esp_netif_sntp_init(const esp_sntp_config_t *config) {
+  (void)config;
+  return ESP_OK;
+}
+
+esp_err_t esp_netif_sntp_start(void) { return ESP_OK; }
+
+void esp_sntp_set_time_sync_notification_cb(void (*cb)(struct timeval *tv)) {
+  (void)cb;
+}
+
+void esp_sntp_stop(void) {}
+
+#include "../../components/ul_core/ul_core.c"
+
+static void reset_test_state(void) {
+  g_force_event_group_failure = false;
+  g_event_group_create_calls = 0;
+  g_event_group_wait_calls = 0;
+  g_event_group_set_calls = 0;
+  g_event_group_clear_calls = 0;
+  g_event_group_delete_calls = 0;
+  g_timer_stop_calls = 0;
+  g_timer_delete_calls = 0;
+  g_mutex_delete_calls = 0;
+  g_wifi_connect_calls = 0;
+  g_event_group_instance.bits = 0;
+  g_mutex_instance.deleted = false;
+  g_binary_semaphore_instance.deleted = false;
+  g_existing_timer.active = false;
+  g_existing_timer.cb = NULL;
+  g_created_timer.active = false;
+  g_created_timer.cb = NULL;
+  s_wifi_event_group = NULL;
+  s_reconnect_timer = NULL;
+  s_wifi_restart_mutex = NULL;
+  s_conn_cb = NULL;
+  s_time_sync_cb = NULL;
+  s_time_sync_ctx = NULL;
+  s_sntp_task = NULL;
+  if (s_sntp_retry_timer) {
+    esp_timer_delete(s_sntp_retry_timer);
+    s_sntp_retry_timer = NULL;
+  }
+  s_sntp_retry_attempts = 0;
+  s_sntp_first_failure_us = 0;
+  s_sntp_last_failure_us = 0;
+  s_sntp_retry_delay_ms = SNTP_RETRY_INITIAL_DELAY_MS;
+}
+
+static void test_event_group_create_failure(void) {
+  reset_test_state();
+  g_force_event_group_failure = true;
+  s_reconnect_timer = &g_existing_timer;
+  s_wifi_restart_mutex = &g_mutex_instance;
+
+  ul_core_wifi_start();
+
+  assert(g_event_group_create_calls == 1);
+  assert(s_wifi_event_group == NULL);
+  assert(s_reconnect_timer == NULL);
+  assert(s_wifi_restart_mutex == NULL);
+  assert(g_timer_stop_calls == 1);
+  assert(g_timer_delete_calls == 1);
+  assert(g_mutex_delete_calls == 1);
+  assert(g_wifi_connect_calls == 0);
+  assert(g_event_group_delete_calls == 0);
+
+  bool got_ip = ul_core_wait_for_ip(pdMS_TO_TICKS(100));
+  assert(!got_ip);
+  assert(g_event_group_wait_calls == 0);
+  assert(!ul_core_is_connected());
+
+  wifi_event_handler(NULL, WIFI_EVENT, WIFI_EVENT_STA_START, NULL);
+  wifi_event_handler(NULL, WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, NULL);
+  wifi_event_handler(NULL, IP_EVENT, IP_EVENT_STA_GOT_IP, NULL);
+  assert(g_wifi_connect_calls == 0);
+  assert(g_event_group_set_calls == 0);
+  assert(g_event_group_clear_calls == 0);
+
+  wifi_reconnect_timer_cb(NULL);
+  assert(g_event_group_clear_calls == 0);
+}
+
+int main(void) {
+  test_event_group_create_failure();
+  printf("All tests passed\n");
+  return 0;
+}

--- a/UltraNodeV5/tests/ws_engine/stubs/esp_err.h
+++ b/UltraNodeV5/tests/ws_engine/stubs/esp_err.h
@@ -3,3 +3,5 @@
 typedef int esp_err_t;
 
 #define ESP_OK 0
+
+const char *esp_err_to_name(esp_err_t err);

--- a/UltraNodeV5/tests/ws_engine/stubs/esp_log.h
+++ b/UltraNodeV5/tests/ws_engine/stubs/esp_log.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdio.h>
+#include <stdlib.h>
 
 #define ESP_LOGE(tag, fmt, ...) fprintf(stderr, "E (%s): " fmt "\n", tag, ##__VA_ARGS__)
 #define ESP_LOGW(tag, fmt, ...) fprintf(stderr, "W (%s): " fmt "\n", tag, ##__VA_ARGS__)

--- a/UltraNodeV5/tests/ws_engine/stubs/freertos/FreeRTOS.h
+++ b/UltraNodeV5/tests/ws_engine/stubs/freertos/FreeRTOS.h
@@ -4,6 +4,7 @@
 typedef uint32_t TickType_t;
 typedef int BaseType_t;
 typedef unsigned int UBaseType_t;
+typedef uint32_t EventBits_t;
 
 typedef void (*TaskFunction_t)(void *);
 
@@ -14,3 +15,11 @@ typedef uint32_t StackType_t;
 #define pdFALSE 0
 #define pdPASS 1
 #define portMAX_DELAY ((TickType_t)-1)
+#define BIT0 (1U << 0)
+#define BIT1 (1U << 1)
+#define tskIDLE_PRIORITY 0
+
+typedef int portMUX_TYPE;
+#define portMUX_INITIALIZER_UNLOCKED 0
+#define portENTER_CRITICAL(mux) (void)(mux)
+#define portEXIT_CRITICAL(mux) (void)(mux)

--- a/UltraNodeV5/tests/ws_engine/stubs/freertos/semphr.h
+++ b/UltraNodeV5/tests/ws_engine/stubs/freertos/semphr.h
@@ -8,6 +8,7 @@ extern "C" {
 typedef void* SemaphoreHandle_t;
 
 SemaphoreHandle_t xSemaphoreCreateBinary(void);
+SemaphoreHandle_t xSemaphoreCreateMutex(void);
 BaseType_t xSemaphoreTake(SemaphoreHandle_t sem, TickType_t ticks);
 BaseType_t xSemaphoreGive(SemaphoreHandle_t sem);
 void vSemaphoreDelete(SemaphoreHandle_t sem);

--- a/UltraNodeV5/tests/ws_engine/stubs/freertos/task.h
+++ b/UltraNodeV5/tests/ws_engine/stubs/freertos/task.h
@@ -9,6 +9,7 @@ typedef void* TaskHandle_t;
 
 TickType_t xTaskGetTickCount(void);
 void vTaskDelayUntil(TickType_t* const pxPreviousWakeTime, TickType_t xTimeIncrement);
+void vTaskDelay(TickType_t ticks);
 void vTaskDelete(TaskHandle_t task);
 
 #ifdef __cplusplus

--- a/UltraNodeV5/tests/ws_engine/stubs/sdkconfig.h
+++ b/UltraNodeV5/tests/ws_engine/stubs/sdkconfig.h
@@ -10,5 +10,10 @@
 #define CONFIG_UL_GAMMA_ENABLE 0
 #define CONFIG_UL_IS_ESP32C3 0
 #define CONFIG_UL_HAS_PSRAM 0
+#define CONFIG_UL_NODE_ID "test-node"
+#define CONFIG_UL_WIFI_SSID "test-ssid"
+#define CONFIG_UL_WIFI_PSK "test-psk"
+#define CONFIG_UL_SNTP_SYNC_INTERVAL_S 60
+#define CONFIG_UL_TIMEZONE "UTC"
 
 #define MALLOC_CAP_8BIT 0


### PR DESCRIPTION
## Summary
- guard ul_core Wi-Fi start, reconnect timer, and helpers against a missing event group and clean up partial state when allocation fails
- add a host-side unit test with ESP-IDF/FreeRTOS stubs that simulates xEventGroupCreate returning NULL and asserts graceful behavior
- extend existing test stubs with the configuration values and macros required by the new coverage

## Testing
- UltraNodeV5/tests/ul_core/test_ul_core_wifi_event_group_failure

------
https://chatgpt.com/codex/tasks/task_e_68d2fc8633248326b9b08767972f0143