### PR TITLE
Handle WS strip initialization failures gracefully

### DIFF
--- a/UltraNodeV5/components/ul_ws_engine/include/ul_ws_engine.h
+++ b/UltraNodeV5/components/ul_ws_engine/include/ul_ws_engine.h
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-void ul_ws_engine_start(void);
+bool ul_ws_engine_start(void);
 void ul_ws_engine_stop(void);
 
 typedef struct cJSON cJSON;

--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -59,7 +59,10 @@ static void service_manager_task(void *ctx) {
         }
         if (!s_services_running) {
           ul_mqtt_start();
-          ul_ws_engine_start();    // 60 FPS LED engine
+          bool ws_started = ul_ws_engine_start();    // 60 FPS LED engine
+          if (!ws_started) {
+            ESP_LOGE(TAG, "WS engine failed to start; running without it");
+          }
           ul_rgb_engine_start();   // RGB PWM engine
           ul_white_engine_start(); // 200 Hz smoothing
 #if CONFIG_UL_PIR_ENABLED


### PR DESCRIPTION
## Summary
- add explicit error handling for SPI strip bring-up and propagate failures out of ul_ws_engine_start
- unwind LED resources and report failures so service manager logs when the WS engine stays offline
- expand the ws_engine allocation test suite to cover led_strip_new_spi_device failures

## Testing
- `gcc -std=c99 -Wall -Werror -I UltraNodeV5/tests/ws_engine/stubs -I UltraNodeV5/components/ul_ws_engine/include -I UltraNodeV5/components/ul_ws_engine -I UltraNodeV5/components/ul_common_effects/include UltraNodeV5/tests/ws_engine/test_ws_engine_allocation.c -o /tmp/test_ws_engine`
- `/tmp/test_ws_engine`


------
https://chatgpt.com/codex/tasks/task_e_68d3077676148326bb68e98558e2f0a8