### PR TITLE
Add SQLModel auth storage and opaque house identifiers

### DIFF
--- a/Server/.env
+++ b/Server/.env
@@ -17,6 +17,14 @@ EMBED_BROKER=0
 FIRMWARE_DIR=/srv/firmware
 API_BEARER=super-long-random-bearer
 
+# Auth database & sessions
+DATA_DIR=/srv/ultralights
+AUTH_DB_URL=sqlite:////srv/ultralights/auth.sqlite3
+SESSION_SECRET=replace-with-long-random-string
+MAX_HOUSE_ID_LENGTH=22
+INITIAL_ADMIN_USERNAME=hub-admin
+INITIAL_ADMIN_PASSWORD=change-me
+
 # HMAC key for signing manifests (hex or raw). Use your actual hex:
 MANIFEST_HMAC_SECRET=5dc0084093b39dda7bee331e8bd3a21d35f7fb4bbfc446b6ade1ffe7ed475f7f
 

--- a/Server/app/auth/__init__.py
+++ b/Server/app/auth/__init__.py
@@ -1,0 +1,6 @@
+"""Authentication helpers and models."""
+
+from .passwords import hash_password, verify_password
+from .service import init_auth_storage
+
+__all__ = ["hash_password", "verify_password", "init_auth_storage"]

--- a/Server/app/auth/passwords.py
+++ b/Server/app/auth/passwords.py
@@ -1,0 +1,35 @@
+"""Password hashing helpers."""
+from passlib.context import CryptContext
+
+
+_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Hash ``password`` using a strong adaptive hash."""
+
+    if not isinstance(password, str):
+        raise TypeError("password must be a string")
+    return _context.hash(password)
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    """Return ``True`` if ``password`` matches ``hashed_password``."""
+
+    if not password or not hashed_password:
+        return False
+    try:
+        return _context.verify(password, hashed_password)
+    except ValueError:
+        return False
+
+
+def needs_rehash(hashed_password: str) -> bool:
+    """Return ``True`` if the hash should be upgraded."""
+
+    if not hashed_password:
+        return True
+    return _context.needs_update(hashed_password)
+
+
+__all__ = ["hash_password", "verify_password", "needs_rehash"]

--- a/Server/app/auth/service.py
+++ b/Server/app/auth/service.py
@@ -1,0 +1,83 @@
+"""Service helpers for authentication storage."""
+from __future__ import annotations
+
+from sqlmodel import SQLModel, Session, select
+
+from .. import registry
+from ..config import settings
+from ..database import SessionLocal, engine
+from .models import House, User
+from .passwords import hash_password
+
+
+def init_auth_storage() -> None:
+    """Ensure tables exist and seed initial data."""
+
+    SQLModel.metadata.create_all(engine)
+
+    with SessionLocal() as session:
+        _seed_initial_admin(session)
+        _sync_registry_houses(session)
+
+
+def _seed_initial_admin(session: Session) -> None:
+    """Create the initial server admin when the table is empty."""
+
+    existing_admin = session.exec(
+        select(User).where(User.server_admin.is_(True))
+    ).first()
+    if existing_admin:
+        return
+
+    username = settings.INITIAL_ADMIN_USERNAME
+    password = settings.INITIAL_ADMIN_PASSWORD
+
+    if not username or not password:
+        return
+
+    hashed = hash_password(password)
+    user = User(username=username, hashed_password=hashed, server_admin=True)
+    session.add(user)
+    session.commit()
+
+
+def _sync_registry_houses(session: Session) -> None:
+    """Ensure ``House`` rows exist for each registry entry."""
+
+    existing = {
+        house.external_id
+        for house in session.exec(select(House.external_id))
+        if isinstance(house.external_id, str)
+    }
+
+    for entry in settings.DEVICE_REGISTRY:
+        external_id = registry.get_house_external_id(entry)
+        if external_id in existing:
+            continue
+        display_name = str(entry.get("name") or entry.get("id") or external_id)
+        session.add(House(display_name=display_name, external_id=external_id))
+
+    session.commit()
+
+
+def create_user(
+    session: Session,
+    username: str,
+    password: str,
+    *,
+    server_admin: bool = False,
+) -> User:
+    """Create a new ``User`` and return it."""
+
+    user = User(
+        username=username,
+        hashed_password=hash_password(password),
+        server_admin=server_admin,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+__all__ = ["create_user", "init_auth_storage"]

--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -4,6 +4,9 @@ from dotenv import load_dotenv
 load_dotenv()  # reads .env in the project root
 
 class Settings:
+    DATA_DIR = Path(os.getenv("DATA_DIR", "./data")).expanduser().resolve()
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
     WEB_HOST = os.getenv("WEB_HOST", "0.0.0.0")
     WEB_PORT = int(os.getenv("WEB_PORT", "443"))
     PUBLIC_BASE = os.getenv("PUBLIC_BASE", "https://lights.evm100.org")
@@ -20,6 +23,14 @@ class Settings:
 
     API_BEARER = os.getenv("API_BEARER", "")
     MANIFEST_HMAC_SECRET = os.getenv("MANIFEST_HMAC_SECRET", "")
+
+    MAX_HOUSE_ID_LENGTH = int(os.getenv("MAX_HOUSE_ID_LENGTH", "22"))
+    AUTH_DB_URL = os.getenv(
+        "AUTH_DB_URL", f"sqlite:///{DATA_DIR / 'auth.sqlite3'}"
+    )
+    SESSION_SECRET = os.getenv("SESSION_SECRET", "dev-session-secret")
+    INITIAL_ADMIN_USERNAME = os.getenv("INITIAL_ADMIN_USERNAME", "")
+    INITIAL_ADMIN_PASSWORD = os.getenv("INITIAL_ADMIN_PASSWORD", "")
 
     # ------------------------------------------------------------------
     # Device registry ---------------------------------------------------
@@ -95,5 +106,11 @@ class Settings:
     else:
         DEVICE_REGISTRY = DEFAULT_REGISTRY
         REGISTRY_FILE.write_text(json.dumps(DEVICE_REGISTRY, indent=2))
+
+    def resolve_data_path(self, path: str | os.PathLike[str]) -> Path:
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self.DATA_DIR / candidate
+        return candidate.expanduser().resolve()
 
 settings = Settings()

--- a/Server/app/database.py
+++ b/Server/app/database.py
@@ -1,0 +1,78 @@
+"""Database helpers for working with the authentication store."""
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+from sqlalchemy.engine import make_url
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import Session, create_engine
+
+from .config import settings
+
+
+def _ensure_sqlite_directory(database_url: str) -> None:
+    """Create the parent directory for SQLite databases when needed."""
+
+    try:
+        url = make_url(database_url)
+    except Exception:
+        return
+
+    if not url.drivername.startswith("sqlite"):
+        return
+
+    database = url.database
+    if not database or database in {":memory:", ""}:
+        return
+
+    path = settings.resolve_data_path(database)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _build_engine(database_url: str):
+    _ensure_sqlite_directory(database_url)
+    connect_args: dict[str, Any] = {}
+    if database_url.startswith("sqlite"):
+        connect_args["check_same_thread"] = False
+    return create_engine(database_url, connect_args=connect_args, future=True)
+
+
+engine = _build_engine(settings.AUTH_DB_URL)
+SessionLocal = sessionmaker(
+    bind=engine,
+    class_=Session,
+    autocommit=False,
+    autoflush=False,
+)
+
+
+def reset_session_factory(database_url: str | None = None) -> None:
+    """Rebuild the engine/sessionmaker.
+
+    Primarily intended for tests to isolate storage in temporary locations.
+    """
+
+    global engine, SessionLocal
+
+    if database_url is not None:
+        settings.AUTH_DB_URL = database_url
+    engine = _build_engine(settings.AUTH_DB_URL)
+    SessionLocal = sessionmaker(
+        bind=engine,
+        class_=Session,
+        autocommit=False,
+        autoflush=False,
+    )
+
+
+def get_session() -> Iterator[Session]:
+    """Yield a database session suitable for FastAPI dependencies."""
+
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+__all__ = ["engine", "SessionLocal", "get_session", "reset_session_factory"]

--- a/Server/app/device_registry.json
+++ b/Server/app/device_registry.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "del-sur",
+    "external_id": "DyBfmDmTxEPGabwR",
     "name": "Del Sur",
     "rooms": [
       {
@@ -62,6 +63,7 @@
   },
   {
     "id": "sdsu",
+    "external_id": "vPvpjnurt8M6nnyE",
     "name": "SDSU",
     "rooms": []
   }

--- a/Server/app/templates/house.html
+++ b/Server/app/templates/house.html
@@ -3,13 +3,13 @@
 <div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
   <h2 class="text-2xl font-semibold">Rooms</h2>
   <div class="flex items-center gap-2">
-    <a href="/admin/house/{{ house.id }}" class="px-4 py-2 pill bg-slate-700 hover:bg-slate-600">Admin Panel</a>
+    <a href="/admin/house/{{ house_public_id }}" class="px-4 py-2 pill bg-slate-700 hover:bg-slate-600">Admin Panel</a>
     <button id="addRoom" class="w-12 h-12 flex items-center justify-center text-2xl rounded-full bg-indigo-600 hover:bg-indigo-500">+</button>
   </div>
 </div>
 <div class="grid md:grid-cols-3 gap-4" data-room-grid>
   {% for r in house.rooms %}
-  <a href="/house/{{ house.id }}/room/{{ r.id }}" data-room-card data-room-id="{{ r.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400 cursor-move">
+  <a href="/house/{{ house_public_id }}/room/{{ r.id }}" data-room-card data-room-id="{{ r.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400 cursor-move">
     <div class="text-xl font-semibold">{{ r.name }}</div>
     <div class="opacity-60 text-xs mt-2">ID: {{ r.id }}</div>
     <div class="text-sm mt-2">{{ r.nodes|length }} nodes</div>
@@ -20,7 +20,7 @@
 document.getElementById('addRoom').onclick = async () => {
   const name = prompt('New room name');
   if(!name) return;
-  const res = await fetch('/api/house/{{ house.id }}/rooms', {
+  const res = await fetch('/api/house/{{ house_public_id }}/rooms', {
     method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name})
   });
   if(res.ok) location.reload(); else alert('Failed to add room');
@@ -41,7 +41,7 @@ if(grid){
       return;
     }
     try {
-      const res = await fetch('/api/house/{{ house.id }}/rooms/reorder', {
+      const res = await fetch('/api/house/{{ house_public_id }}/rooms/reorder', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({order})

--- a/Server/app/templates/index.html
+++ b/Server/app/templates/index.html
@@ -10,9 +10,9 @@
 
 <div class="grid md:grid-cols-3 gap-4 mt-6">
   {% for h in houses %}
-  <a href="/house/{{ h.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400">
+  <a href="/house/{{ h.external_id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400">
     <div class="text-xl font-semibold">{{ h.name }}</div>
-    <div class="opacity-60 text-xs mt-2">ID: {{ h.id }}</div>
+    <div class="opacity-60 text-xs mt-2">Public ID: {{ h.external_id }}</div>
     <div class="text-sm mt-2">{{ h.rooms|length }} rooms</div>
   </a>
   {% endfor %}

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -22,7 +22,7 @@
     </div>
   </div>
   <div id="presetStatus" class="text-sm mb-3 opacity-80" role="status" aria-live="polite"></div>
-  <div id="presetList" class="flex flex-wrap gap-2" data-editing="false" data-house-id="{{ house.id }}" data-room-id="{{ room.id }}" data-api-base="/api/house/{{ house.id }}/room/{{ room.id }}" data-initial-presets='{{ presets|tojson }}'>
+  <div id="presetList" class="flex flex-wrap gap-2" data-editing="false" data-house-id="{{ house_public_id }}" data-room-id="{{ room.id }}" data-api-base="/api/house/{{ house_public_id }}/room/{{ room.id }}" data-initial-presets='{{ presets|tojson }}'>
     {% for p in presets %}
     <div class="preset-item" data-preset-id="{{ p.id }}" data-custom="{{ 'true' if p.source == 'custom' else 'false' }}">
       <button class="preset preset-button glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400" type="button" data-preset-id="{{ p.id }}">{{ p.name or p.id }}</button>
@@ -36,7 +36,7 @@
   </div>
 </div>
 {% if motion_config %}
-<div class="mt-8" id="motionSchedule" data-save-url="/api/house/{{ house.id }}/room/{{ room.id }}/motion-schedule" data-slot-minutes="{{ motion_config.slot_minutes|default(60) }}" data-color-url="/api/house/{{ house.id }}/room/{{ room.id }}/motion-schedule/color">
+<div class="mt-8" id="motionSchedule" data-save-url="/api/house/{{ house_public_id }}/room/{{ room.id }}/motion-schedule" data-slot-minutes="{{ motion_config.slot_minutes|default(60) }}" data-color-url="/api/house/{{ house_public_id }}/room/{{ room.id }}/motion-schedule/color">
   <h2 class="text-2xl font-semibold mb-4">Motion Schedule</h2>
   <div class="glass rounded-xl p-4">
     <div class="motion-schedule-grid" id="motionScheduleGrid"></div>
@@ -86,7 +86,7 @@
     </div>
   </div>
 </div>
-<div class="mt-8" id="motionImmunity" data-fetch-url="/api/house/{{ house.id }}/room/{{ room.id }}/motion-immune" data-save-url="/api/house/{{ house.id }}/room/{{ room.id }}/motion-immune">
+<div class="mt-8" id="motionImmunity" data-fetch-url="/api/house/{{ house_public_id }}/room/{{ room.id }}/motion-immune" data-save-url="/api/house/{{ house_public_id }}/room/{{ room.id }}/motion-immune">
   <h2 class="text-2xl font-semibold mb-4">Motion Immunity</h2>
   <div class="glass rounded-xl p-4">
     <p class="text-sm opacity-80 mb-3">Select nodes to ignore when motion automations run.</p>
@@ -154,7 +154,7 @@ document.getElementById('addNode').onclick = async () => {
   }
   let res;
   try {
-    res = await fetch('/api/house/{{ house.id }}/room/{{ room.id }}/nodes', {
+    res = await fetch('/api/house/{{ house_public_id }}/room/{{ room.id }}/nodes', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({name}),

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]
 jinja2
 paho-mqtt
 python-dotenv
+sqlmodel
+passlib[bcrypt]

--- a/Server/tests/auth/test_auth_models.py
+++ b/Server/tests/auth/test_auth_models.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from sqlmodel import select
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import registry
+from app.auth.passwords import hash_password, verify_password
+from app.auth.service import create_user, init_auth_storage
+from app.auth.models import User
+from app.config import settings
+from app.database import SessionLocal, reset_session_factory
+
+
+def test_hash_and_verify_password() -> None:
+    password = "s3cret-value"
+    hashed = hash_password(password)
+    assert hashed != password
+    assert verify_password(password, hashed)
+    assert not verify_password("wrong", hashed)
+
+
+def test_init_auth_storage_seeds_admin(tmp_path, monkeypatch) -> None:
+    original_url = settings.AUTH_DB_URL
+    db_path = Path(tmp_path) / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+
+    monkeypatch.setattr(settings, "INITIAL_ADMIN_USERNAME", "seed-admin")
+    monkeypatch.setattr(settings, "INITIAL_ADMIN_PASSWORD", "ultra-secret")
+
+    reset_session_factory(db_url)
+    try:
+        init_auth_storage()
+        with SessionLocal() as session:
+            admin = session.exec(select(User).where(User.server_admin.is_(True))).one()
+            assert admin.username == "seed-admin"
+            assert admin.hashed_password != settings.INITIAL_ADMIN_PASSWORD
+            assert verify_password("ultra-secret", admin.hashed_password)
+
+            guest = create_user(session, "guest-user", "guest-pass")
+            assert guest.id is not None
+            assert verify_password("guest-pass", guest.hashed_password)
+    finally:
+        reset_session_factory(original_url)
+
+
+def test_generate_house_external_ids_random_and_unique(monkeypatch) -> None:
+    sample_registry = [
+        {"id": "alpha", "name": "Alpha"},
+        {"id": "beta", "name": "Beta"},
+    ]
+
+    changed = registry.ensure_house_external_ids(sample_registry, persist=False)
+    assert changed is True
+
+    identifiers = [entry.get("external_id") for entry in sample_registry]
+    assert len(identifiers) == len(set(identifiers))
+
+    for entry, external_id in zip(sample_registry, identifiers):
+        assert isinstance(external_id, str) and external_id
+        assert 8 <= len(external_id) <= settings.MAX_HOUSE_ID_LENGTH
+        assert external_id != entry["id"]
+        assert all(ch in registry.EXTERNAL_ID_ALPHABET for ch in external_id)
+
+    unchanged = registry.ensure_house_external_ids(sample_registry, persist=False)
+    assert unchanged is False


### PR DESCRIPTION
## Summary
- add SQLModel database models, password hashing helpers, and startup seeding for the authentication store
- extend configuration, registry utilities, and web UI to use opaque house external identifiers persisted alongside legacy slugs
- document new environment variables and add unit tests covering password hashing, seeding, and external ID generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d314daa844832685af0b4f8ec12695