### PR TITLE
Add session-based authentication and login flow

### DIFF
--- a/Server/app/auth/__init__.py
+++ b/Server/app/auth/__init__.py
@@ -1,6 +1,31 @@
 """Authentication helpers and models."""
 
-from .passwords import hash_password, verify_password
+from .security import (
+    SESSION_COOKIE_NAME,
+    SESSION_TOKEN_TTL,
+    SESSION_TOKEN_TTL_SECONDS,
+    authenticate_user,
+    clear_session_cookie,
+    create_session_token,
+    hash_password,
+    needs_rehash,
+    set_session_cookie,
+    verify_password,
+    verify_session_token,
+)
 from .service import init_auth_storage
 
-__all__ = ["hash_password", "verify_password", "init_auth_storage"]
+__all__ = [
+    "SESSION_COOKIE_NAME",
+    "SESSION_TOKEN_TTL",
+    "SESSION_TOKEN_TTL_SECONDS",
+    "authenticate_user",
+    "clear_session_cookie",
+    "create_session_token",
+    "hash_password",
+    "init_auth_storage",
+    "needs_rehash",
+    "set_session_cookie",
+    "verify_password",
+    "verify_session_token",
+]

--- a/Server/app/auth/dependencies.py
+++ b/Server/app/auth/dependencies.py
@@ -1,0 +1,44 @@
+"""FastAPI dependencies for authentication."""
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request, status
+from sqlmodel import Session, select
+
+from ..database import get_session
+from .models import User
+from .security import SESSION_COOKIE_NAME, SessionTokenData, verify_session_token
+
+
+def get_current_user(
+    request: Request,
+    session: Session = Depends(get_session),
+) -> User:
+    """Return the authenticated ``User`` or raise ``401``."""
+
+    token_value = request.cookies.get(SESSION_COOKIE_NAME)
+    if not token_value:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Not authenticated")
+
+    token_data: SessionTokenData | None = verify_session_token(token_value)
+    if token_data is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Not authenticated")
+
+    user = session.exec(select(User).where(User.id == token_data.user_id)).first()
+    if not user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Not authenticated")
+
+    request.state.user = user
+    request.state.session_token = token_data
+    return user
+
+
+def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    """Ensure the current user has administrator privileges."""
+
+    if not current_user.server_admin:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Forbidden")
+    return current_user
+
+
+__all__ = ["get_current_user", "require_admin"]
+

--- a/Server/app/auth/passwords.py
+++ b/Server/app/auth/passwords.py
@@ -1,35 +1,6 @@
-"""Password hashing helpers."""
-from passlib.context import CryptContext
+"""Backward compatible wrappers around :mod:`app.auth.security`."""
 
-
-_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-
-def hash_password(password: str) -> str:
-    """Hash ``password`` using a strong adaptive hash."""
-
-    if not isinstance(password, str):
-        raise TypeError("password must be a string")
-    return _context.hash(password)
-
-
-def verify_password(password: str, hashed_password: str) -> bool:
-    """Return ``True`` if ``password`` matches ``hashed_password``."""
-
-    if not password or not hashed_password:
-        return False
-    try:
-        return _context.verify(password, hashed_password)
-    except ValueError:
-        return False
-
-
-def needs_rehash(hashed_password: str) -> bool:
-    """Return ``True`` if the hash should be upgraded."""
-
-    if not hashed_password:
-        return True
-    return _context.needs_update(hashed_password)
+from .security import hash_password, needs_rehash, verify_password
 
 
 __all__ = ["hash_password", "verify_password", "needs_rehash"]

--- a/Server/app/auth/security.py
+++ b/Server/app/auth/security.py
@@ -1,0 +1,217 @@
+"""Security helpers for authentication and session management."""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from passlib.context import CryptContext
+from sqlmodel import Session, select
+
+from ..config import settings
+from .models import User
+
+
+_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Cookies ------------------------------------------------------------------
+SESSION_COOKIE_NAME = "ultralights_session"
+SESSION_TOKEN_TTL = timedelta(hours=12)
+SESSION_TOKEN_TTL_SECONDS = int(SESSION_TOKEN_TTL.total_seconds())
+SESSION_COOKIE_PATH = "/"
+SESSION_COOKIE_SAMESITE = "lax"
+
+
+@dataclass
+class SessionTokenData:
+    """Information extracted from a verified session token."""
+
+    user_id: int
+    username: Optional[str]
+    expires_at: datetime
+
+    @property
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) >= self.expires_at
+
+
+def hash_password(password: str) -> str:
+    """Hash ``password`` using bcrypt."""
+
+    if not isinstance(password, str):
+        raise TypeError("password must be a string")
+    return _pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    """Return ``True`` if ``password`` matches ``hashed_password``."""
+
+    if not password or not hashed_password:
+        return False
+    try:
+        return _pwd_context.verify(password, hashed_password)
+    except ValueError:
+        return False
+
+
+def needs_rehash(hashed_password: str) -> bool:
+    """Return ``True`` if ``hashed_password`` should be upgraded."""
+
+    if not hashed_password:
+        return True
+    return _pwd_context.needs_update(hashed_password)
+
+
+def authenticate_user(session: Session, username: str, password: str) -> Optional[User]:
+    """Return the ``User`` that matches ``username``/``password`` or ``None``."""
+
+    if not username or not password:
+        return None
+    statement = select(User).where(User.username == username)
+    user = session.exec(statement).first()
+    if not user:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+def create_session_token(
+    user: User,
+    *,
+    expires_delta: Optional[timedelta] = None,
+) -> str:
+    """Create a signed token identifying ``user`` with an expiry timestamp."""
+
+    if user.id is None:
+        raise ValueError("user must be persisted before creating a session token")
+    lifetime = expires_delta or SESSION_TOKEN_TTL
+    expires_at = datetime.now(timezone.utc) + lifetime
+    payload = {
+        "sub": int(user.id),
+        "usr": user.username,
+        "exp": int(expires_at.timestamp()),
+        "nonce": secrets.token_hex(8),
+    }
+    payload_bytes = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    signature = hmac.new(_secret_key(), payload_bytes, hashlib.sha256).digest()
+    return f"{_b64encode(payload_bytes)}.{_b64encode(signature)}"
+
+
+def verify_session_token(token: str) -> Optional[SessionTokenData]:
+    """Validate ``token`` and return the decoded data when successful."""
+
+    if not token or "." not in token:
+        return None
+    try:
+        payload_b64, signature_b64 = token.split(".", 1)
+        payload_bytes = _b64decode(payload_b64)
+        signature = _b64decode(signature_b64)
+    except (ValueError, binascii.Error):
+        return None
+
+    expected_signature = hmac.new(
+        _secret_key(), payload_bytes, hashlib.sha256
+    ).digest()
+    if not hmac.compare_digest(signature, expected_signature):
+        return None
+
+    try:
+        payload = json.loads(payload_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+    user_id = _coerce_int(payload.get("sub"))
+    expires_ts = _coerce_int(payload.get("exp"))
+    username = payload.get("usr")
+    if user_id is None or expires_ts is None:
+        return None
+
+    expires_at = datetime.fromtimestamp(expires_ts, tz=timezone.utc)
+    if expires_at <= datetime.now(timezone.utc):
+        return None
+
+    clean_username = str(username) if username is not None else None
+    return SessionTokenData(user_id=user_id, username=clean_username, expires_at=expires_at)
+
+
+def set_session_cookie(response, token: str) -> None:
+    """Attach the session ``token`` to ``response`` as a secure cookie."""
+
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        token,
+        max_age=SESSION_TOKEN_TTL_SECONDS,
+        expires=SESSION_TOKEN_TTL_SECONDS,
+        path=SESSION_COOKIE_PATH,
+        httponly=True,
+        secure=_session_cookie_secure(),
+        samesite=SESSION_COOKIE_SAMESITE,
+    )
+
+
+def clear_session_cookie(response) -> None:
+    """Expire the session cookie on ``response``."""
+
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        "",
+        max_age=0,
+        expires=0,
+        path=SESSION_COOKIE_PATH,
+        httponly=True,
+        secure=_session_cookie_secure(),
+        samesite=SESSION_COOKIE_SAMESITE,
+    )
+
+
+def _secret_key() -> bytes:
+    secret = settings.SESSION_SECRET
+    if not secret:
+        raise RuntimeError("SESSION_SECRET must be configured")
+    return secret.encode("utf-8")
+
+
+def _session_cookie_secure() -> bool:
+    return settings.PUBLIC_BASE.startswith("https://")
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _b64decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _coerce_int(value: object) -> Optional[int]:
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "SESSION_COOKIE_NAME",
+    "SESSION_TOKEN_TTL",
+    "SESSION_TOKEN_TTL_SECONDS",
+    "SessionTokenData",
+    "authenticate_user",
+    "clear_session_cookie",
+    "create_session_token",
+    "hash_password",
+    "needs_rehash",
+    "set_session_cookie",
+    "verify_password",
+    "verify_session_token",
+]
+

--- a/Server/app/auth/service.py
+++ b/Server/app/auth/service.py
@@ -5,17 +5,17 @@ from sqlmodel import SQLModel, Session, select
 
 from .. import registry
 from ..config import settings
-from ..database import SessionLocal, engine
+from .. import database
 from .models import House, User
-from .passwords import hash_password
+from .security import hash_password
 
 
 def init_auth_storage() -> None:
     """Ensure tables exist and seed initial data."""
 
-    SQLModel.metadata.create_all(engine)
+    SQLModel.metadata.create_all(database.engine)
 
-    with SessionLocal() as session:
+    with database.SessionLocal() as session:
         _seed_initial_admin(session)
         _sync_registry_houses(session)
 
@@ -45,9 +45,9 @@ def _sync_registry_houses(session: Session) -> None:
     """Ensure ``House`` rows exist for each registry entry."""
 
     existing = {
-        house.external_id
-        for house in session.exec(select(House.external_id))
-        if isinstance(house.external_id, str)
+        external_id
+        for external_id in session.exec(select(House.external_id))
+        if isinstance(external_id, str)
     }
 
     for entry in settings.DEVICE_REGISTRY:

--- a/Server/app/templates/login.html
+++ b/Server/app/templates/login.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="max-w-md mx-auto bg-slate-900/70 glass rounded-3xl p-8 shadow-xl">
+  <h2 class="text-3xl font-semibold text-center mb-6">Welcome back</h2>
+  <p class="text-sm text-slate-300 text-center mb-6">Sign in to manage your UltraLights installation.</p>
+  {% if error %}
+  <div class="mb-4 px-4 py-3 rounded-md bg-red-500/20 border border-red-500/40 text-red-100 text-sm">
+    {{ error }}
+  </div>
+  {% endif %}
+  <form method="post" class="space-y-5">
+    <div>
+      <label for="username" class="block text-sm font-medium mb-1">Username</label>
+      <input id="username" name="username" type="text" autocomplete="username" required class="w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-purple-500" />
+    </div>
+    <div>
+      <label for="password" class="block text-sm font-medium mb-1">Password</label>
+      <input id="password" name="password" type="password" autocomplete="current-password" required class="w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-purple-500" />
+    </div>
+    <button type="submit" class="w-full bg-purple-600 hover:bg-purple-500 transition-colors text-white font-semibold py-3 rounded-lg">Sign in</button>
+  </form>
+</div>
+{% endblock %}

--- a/Server/tests/auth/test_login_flow.py
+++ b/Server/tests/auth/test_login_flow.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import select
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import database as database_module
+from app.auth.models import House, User
+from app.auth.security import SESSION_COOKIE_NAME, verify_session_token
+from app.auth.service import create_user
+from app.config import settings
+
+
+class _NoopBus:
+    def __getattr__(self, name: str):  # pragma: no cover - simple stub
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    original_url = settings.AUTH_DB_URL
+    db_path = tmp_path / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+    database_module.reset_session_factory(db_url)
+    monkeypatch.setattr(settings, "PUBLIC_BASE", "https://testserver")
+
+    import app.mqtt_bus
+
+    monkeypatch.setattr(app.mqtt_bus, "MqttBus", lambda *args, **kwargs: _NoopBus())
+
+    import app.motion
+    import app.status_monitor
+
+    monkeypatch.setattr(app.motion.motion_manager, "start", lambda: None)
+    monkeypatch.setattr(app.motion.motion_manager, "stop", lambda: None)
+    monkeypatch.setattr(app.status_monitor.status_monitor, "start", lambda: None)
+    monkeypatch.setattr(app.status_monitor.status_monitor, "stop", lambda: None)
+
+    from app.main import app as fastapi_app
+
+    try:
+        with TestClient(fastapi_app, base_url="https://testserver") as client:
+            yield client
+    finally:
+        database_module.reset_session_factory(original_url)
+
+
+def _create_user(username: str, password: str, *, admin: bool = False) -> tuple[User, str]:
+    with database_module.SessionLocal() as session:
+        user = create_user(session, username, password, server_admin=admin)
+        house_external_id = session.exec(select(House.external_id).order_by(House.id)).first()
+        assert house_external_id, "house registry should seed at least one entry"
+        return user, str(house_external_id)
+
+
+def test_login_success_sets_cookie_and_allows_access(client: TestClient) -> None:
+    user, house_external_id = _create_user("login-user", "super-secret", admin=True)
+
+    response = client.post(
+        "/login",
+        data={"username": "login-user", "password": "super-secret"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == f"/house/{house_external_id}"
+
+    cookie_header = response.headers.get("set-cookie", "")
+    assert SESSION_COOKIE_NAME in cookie_header
+    assert "HttpOnly" in cookie_header
+    assert "SameSite=lax" in cookie_header
+    assert "Secure" in cookie_header
+
+    token = response.cookies.get(SESSION_COOKIE_NAME)
+    assert token
+    token_data = verify_session_token(token)
+    assert token_data is not None
+    assert token_data.user_id == user.id
+
+    page = client.get(f"/house/{house_external_id}")
+    assert page.status_code == 200
+
+
+def test_login_rejects_invalid_credentials(client: TestClient) -> None:
+    _, house_external_id = _create_user("login-user", "correct-pass")
+
+    bad = client.post(
+        "/login",
+        data={"username": "login-user", "password": "wrong-pass"},
+    )
+
+    assert bad.status_code == 400
+    assert "Invalid username or password" in bad.text
+
+    cookie_header = bad.headers.get("set-cookie", "")
+    assert f"{SESSION_COOKIE_NAME}=" in cookie_header
+    assert "Max-Age=0" in cookie_header
+
+    unauthenticated = client.get(f"/house/{house_external_id}")
+    assert unauthenticated.status_code == 401
+
+
+def test_logout_clears_cookie_and_blocks_access(client: TestClient) -> None:
+    _, house_external_id = _create_user("login-user", "logmeout")
+
+    client.post(
+        "/login",
+        data={"username": "login-user", "password": "logmeout"},
+    )
+
+    logout = client.get("/logout", follow_redirects=False)
+    assert logout.status_code == 303
+    assert logout.headers["location"] == "/login"
+
+    cookie_header = logout.headers.get("set-cookie", "")
+    assert f"{SESSION_COOKIE_NAME}=" in cookie_header
+    assert "Max-Age=0" in cookie_header
+
+    protected = client.get(f"/house/{house_external_id}")
+    assert protected.status_code == 401


### PR DESCRIPTION
## Summary
- add authentication utilities for hashing passwords, validating credentials, and issuing signed session cookies
- enforce authentication through shared FastAPI dependencies and move the UI to a dedicated login/logout flow
- cover the login workflow with an HTML template update and end-to-end tests

## Testing
- pytest Server/tests

------
https://chatgpt.com/codex/tasks/task_e_68d31c43b1ec8326b6329965dc257312