### PR TITLE
Enforce access policy on UI and API routes

### DIFF
--- a/Server/app/auth/access.py
+++ b/Server/app/auth/access.py
@@ -1,0 +1,293 @@
+"""Access control helpers for page and API routes."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+
+from sqlmodel import Session, select
+
+from .. import registry
+from ..config import settings
+from .models import House, HouseMembership, HouseRole, RoomAccess, User
+
+
+@dataclass
+class HouseAccess:
+    """Represents the scope a user has within a house."""
+
+    house: Optional[House]
+    membership_id: Optional[int]
+    role: Optional[HouseRole]
+    allowed_rooms: Optional[Set[str]] = None
+
+    def can_manage(self, user: User) -> bool:
+        """Return ``True`` if ``user`` may administer the house."""
+
+        if user.server_admin:
+            return True
+        return self.role == HouseRole.ADMIN
+
+    def can_view_room(self, room_id: str) -> bool:
+        """Return ``True`` if ``room_id`` is visible under this access."""
+
+        if self.allowed_rooms is None:
+            return True
+        return room_id in self.allowed_rooms
+
+
+@dataclass
+class HouseContext:
+    """Holds registry data for a house filtered by access."""
+
+    original: Dict[str, Any]
+    filtered: Dict[str, Any]
+    slug: str
+    external_id: str
+    access: HouseAccess
+
+
+@dataclass
+class RoomContext:
+    """Holds registry data for a room filtered by access."""
+
+    house: HouseContext
+    room: Dict[str, Any]
+    filtered_room: Dict[str, Any]
+
+
+@dataclass
+class NodeContext:
+    """Holds registry data for a node filtered by access."""
+
+    room: RoomContext
+    node: Dict[str, Any]
+
+
+def _load_memberships(session: Session, user: User) -> Sequence[tuple[HouseMembership, House]]:
+    return session.exec(
+        select(HouseMembership, House)
+        .join(House, House.id == HouseMembership.house_id)
+        .where(HouseMembership.user_id == user.id)
+    ).all()
+
+
+def _load_room_access(session: Session, membership_ids: Iterable[int]) -> Sequence[RoomAccess]:
+    id_list = [mid for mid in membership_ids if mid is not None]
+    if not id_list:
+        return []
+    return session.exec(
+        select(RoomAccess)
+        .where(RoomAccess.membership_id.in_(id_list))
+    ).all()
+
+
+def _registry_houses() -> List[Dict[str, Any]]:
+    registry.ensure_house_external_ids(persist=False)
+    return settings.DEVICE_REGISTRY
+
+
+def build_access_map(session: Session, user: User) -> Dict[str, HouseAccess]:
+    """Return a mapping of ``external_id`` to :class:`HouseAccess`."""
+
+    access: Dict[str, HouseAccess] = {}
+
+    if user.server_admin:
+        for house in session.exec(select(House)).all():
+            if not isinstance(house.external_id, str):
+                continue
+            access[house.external_id] = HouseAccess(
+                house=house,
+                membership_id=None,
+                role=HouseRole.ADMIN,
+                allowed_rooms=None,
+            )
+
+        for entry in _registry_houses():
+            external_id = registry.get_house_external_id(entry)
+            access.setdefault(
+                external_id,
+                HouseAccess(
+                    house=None,
+                    membership_id=None,
+                    role=HouseRole.ADMIN,
+                    allowed_rooms=None,
+                ),
+            )
+        return access
+
+    membership_rows = _load_memberships(session, user)
+    membership_lookup: Dict[int, HouseAccess] = {}
+
+    for membership, house in membership_rows:
+        external_id = house.external_id
+        if not isinstance(external_id, str):
+            continue
+        if membership.role == HouseRole.ADMIN:
+            allowed_rooms: Optional[Set[str]] = None
+        else:
+            allowed_rooms = set()
+        entry = HouseAccess(
+            house=house,
+            membership_id=membership.id,
+            role=membership.role,
+            allowed_rooms=allowed_rooms,
+        )
+        access[external_id] = entry
+        if membership.id is not None and allowed_rooms is not None:
+            membership_lookup[membership.id] = entry
+
+    if membership_lookup:
+        for entry in _load_room_access(session, membership_lookup.keys()):
+            house_entry = membership_lookup.get(entry.membership_id)
+            if not house_entry or house_entry.allowed_rooms is None:
+                continue
+            room_id = str(entry.room_id).strip()
+            if room_id:
+                house_entry.allowed_rooms.add(room_id)
+
+    return access
+
+
+def _filter_rooms(house: Dict[str, Any], allowed_rooms: Optional[Set[str]]) -> List[Dict[str, Any]]:
+    rooms: List[Dict[str, Any]] = []
+    raw_rooms = house.get("rooms")
+    if not isinstance(raw_rooms, list):
+        return rooms
+    for entry in raw_rooms:
+        if not isinstance(entry, dict):
+            continue
+        room_id = str(entry.get("id") or "").strip()
+        if not room_id:
+            continue
+        if allowed_rooms is not None and room_id not in allowed_rooms:
+            continue
+        rooms.append(dict(entry))
+    return rooms
+
+
+class AccessPolicy:
+    """Authorization helper for requests."""
+
+    def __init__(self, user: User, houses: Dict[str, HouseAccess]):
+        self.user = user
+        self._houses = houses
+
+    @classmethod
+    def from_session(cls, session: Session, user: User) -> "AccessPolicy":
+        return cls(user=user, houses=build_access_map(session, user))
+
+    def get_house_access(self, external_id: str) -> Optional[HouseAccess]:
+        entry = self._houses.get(external_id)
+        if entry is None and self.user.server_admin:
+            entry = HouseAccess(
+                house=None,
+                membership_id=None,
+                role=HouseRole.ADMIN,
+                allowed_rooms=None,
+            )
+            self._houses[external_id] = entry
+        return entry
+
+    def houses_for_templates(self) -> List[Dict[str, Any]]:
+        houses: List[Dict[str, Any]] = []
+        for entry in _registry_houses():
+            filtered = self.filter_house(entry)
+            if filtered is not None:
+                houses.append(filtered)
+        return houses
+
+    def manages_any_house(self) -> bool:
+        return any(access.can_manage(self.user) for access in self._houses.values())
+
+    def filter_house(self, house: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        external_id = registry.get_house_external_id(house)
+        access = self.get_house_access(external_id)
+        if access is None:
+            return None
+        filtered = dict(house)
+        filtered["rooms"] = _filter_rooms(house, access.allowed_rooms)
+        return filtered
+
+    def ensure_house(self, house_id: str) -> HouseContext:
+        house = registry.find_house(house_id)
+        if not house:
+            raise LookupError("house not found")
+        external_id = registry.get_house_external_id(house)
+        access = self.get_house_access(external_id)
+        if access is None:
+            raise PermissionError("house forbidden")
+        filtered = self.filter_house(house)
+        if filtered is None:
+            raise PermissionError("house forbidden")
+        slug = registry.get_house_slug(house)
+        return HouseContext(
+            original=house,
+            filtered=filtered,
+            slug=slug,
+            external_id=external_id,
+            access=access,
+        )
+
+    def ensure_room(self, house_id: str, room_id: str) -> RoomContext:
+        house = self.ensure_house(house_id)
+        room = None
+        for entry in house.original.get("rooms", []) or []:
+            if isinstance(entry, dict) and entry.get("id") == room_id:
+                room = entry
+                break
+        if room is None:
+            raise LookupError("room not found")
+        if not house.access.can_view_room(room_id):
+            raise PermissionError("room forbidden")
+        filtered_room = next(
+            (r for r in house.filtered.get("rooms", []) if r.get("id") == room_id),
+            None,
+        )
+        if filtered_room is None:
+            filtered_room = dict(room)
+        return RoomContext(house=house, room=room, filtered_room=dict(filtered_room))
+
+    def ensure_node(self, node_id: str) -> NodeContext:
+        house, room, node = registry.find_node(node_id)
+        if not node or not house or not room:
+            raise LookupError("node not found")
+        external_id = registry.get_house_external_id(house)
+        room_id = str(room.get("id") or "")
+        if not room_id:
+            raise LookupError("node room missing")
+        access = self.get_house_access(external_id)
+        if access is None or not access.can_view_room(room_id):
+            raise PermissionError("node forbidden")
+        filtered_house = self.filter_house(house)
+        if filtered_house is None:
+            raise PermissionError("node forbidden")
+        house_ctx = HouseContext(
+            original=house,
+            filtered=filtered_house,
+            slug=registry.get_house_slug(house),
+            external_id=external_id,
+            access=access,
+        )
+        filtered_room = next(
+            (r for r in filtered_house.get("rooms", []) if r.get("id") == room_id),
+            None,
+        )
+        if filtered_room is None:
+            filtered_room = dict(room)
+        room_ctx = RoomContext(
+            house=house_ctx,
+            room=room,
+            filtered_room=dict(filtered_room),
+        )
+        return NodeContext(room=room_ctx, node=dict(node))
+
+
+__all__ = [
+    "AccessPolicy",
+    "HouseAccess",
+    "HouseContext",
+    "NodeContext",
+    "RoomContext",
+    "build_access_map",
+]
+

--- a/Server/app/templates/base.html
+++ b/Server/app/templates/base.html
@@ -19,7 +19,7 @@
   <header class="py-8 text-center">
     <h1 class="text-4xl md:text-6xl font-extrabold neon">UltraLights</h1>
     <p class="opacity-70 mt-1">{{ subtitle or "" }}</p>
-    <nav class="mt-3 opacity-80"><a class="underline hover:no-underline" href="/">Home</a></nav>
+    <nav class="mt-3 opacity-80"><a class="underline hover:no-underline" href="/dashboard">Home</a></nav>
   </header>
   <main class="max-w-6xl mx-auto px-4 pb-20">
     {% block content %}{% endblock %}

--- a/Server/app/templates/house.html
+++ b/Server/app/templates/house.html
@@ -3,31 +3,42 @@
 <div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
   <h2 class="text-2xl font-semibold">Rooms</h2>
   <div class="flex items-center gap-2">
+    {% if can_manage_house %}
     <a href="/admin/house/{{ house_public_id }}" class="px-4 py-2 pill bg-slate-700 hover:bg-slate-600">Admin Panel</a>
     <button id="addRoom" class="w-12 h-12 flex items-center justify-center text-2xl rounded-full bg-indigo-600 hover:bg-indigo-500">+</button>
+    {% endif %}
   </div>
 </div>
-<div class="grid md:grid-cols-3 gap-4" data-room-grid>
+{% if house.rooms %}
+<div class="grid md:grid-cols-3 gap-4" data-room-grid data-can-manage="{{ 'true' if can_manage_house else 'false' }}">
   {% for r in house.rooms %}
-  <a href="/house/{{ house_public_id }}/room/{{ r.id }}" data-room-card data-room-id="{{ r.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400 cursor-move">
+  <a href="/house/{{ house_public_id }}/room/{{ r.id }}" data-room-card data-room-id="{{ r.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400{% if can_manage_house %} cursor-move{% endif %}">
     <div class="text-xl font-semibold">{{ r.name }}</div>
     <div class="opacity-60 text-xs mt-2">ID: {{ r.id }}</div>
-    <div class="text-sm mt-2">{{ r.nodes|length }} nodes</div>
+    <div class="text-sm mt-2">{{ r.nodes|length }} node{% if r.nodes|length != 1 %}s{% endif %}</div>
   </a>
   {% endfor %}
 </div>
+{% else %}
+<div class="glass rounded-xl p-6 text-center text-sm opacity-70">
+  No rooms available.
+</div>
+{% endif %}
 <script>
-document.getElementById('addRoom').onclick = async () => {
-  const name = prompt('New room name');
-  if(!name) return;
-  const res = await fetch('/api/house/{{ house_public_id }}/rooms', {
-    method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name})
-  });
-  if(res.ok) location.reload(); else alert('Failed to add room');
-};
+const addRoomButton = document.getElementById('addRoom');
+if(addRoomButton){
+  addRoomButton.onclick = async () => {
+    const name = prompt('New room name');
+    if(!name) return;
+    const res = await fetch('/api/house/{{ house_public_id }}/rooms', {
+      method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name})
+    });
+    if(res.ok) location.reload(); else alert('Failed to add room');
+  };
+}
 
 const grid = document.querySelector('[data-room-grid]');
-if(grid){
+if(grid && grid.dataset.canManage === 'true'){
   const cards = grid.querySelectorAll('[data-room-card]');
   let dragging = null;
   let dropOccurred = false;

--- a/Server/app/templates/index.html
+++ b/Server/app/templates/index.html
@@ -1,27 +1,39 @@
 {% extends "base.html" %}
 {% block content %}
 <div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-  <h2 class="text-2xl font-semibold">Locations</h2>
+  <h2 class="text-2xl font-semibold">My Houses</h2>
   <div class="flex items-center gap-2">
+    {% if show_admin %}
     <a href="/admin" class="px-4 py-2 pill bg-slate-700 hover:bg-slate-600">Admin Panel</a>
+    {% endif %}
+    {% if can_all_off %}
     <button id="allOff" class="px-4 py-2 pill bg-rose-600 hover:bg-rose-500">All Off</button>
+    {% endif %}
   </div>
 </div>
 
+{% if houses %}
 <div class="grid md:grid-cols-3 gap-4 mt-6">
   {% for h in houses %}
   <a href="/house/{{ h.external_id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400">
     <div class="text-xl font-semibold">{{ h.name }}</div>
     <div class="opacity-60 text-xs mt-2">Public ID: {{ h.external_id }}</div>
-    <div class="text-sm mt-2">{{ h.rooms|length }} rooms</div>
+    <div class="text-sm mt-2">{{ h.rooms|length }} room{% if h.rooms|length != 1 %}s{% endif %}</div>
   </a>
   {% endfor %}
 </div>
+{% else %}
+<div class="glass rounded-xl p-6 text-center text-sm opacity-70">
+  No houses assigned to your account yet.
+</div>
+{% endif %}
 
+{% if can_all_off %}
 <script>
 document.getElementById('allOff').onclick = async () => {
   const res = await fetch('/api/all-off', {method:'POST'});
   if(!res.ok){ alert('Failed to turn all off'); }
 };
 </script>
+{% endif %}
 {% endblock %}

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -2,7 +2,9 @@
 {% block content %}
 <div class="mb-6 flex justify-between items-center">
   <h2 class="text-2xl font-semibold">Nodes</h2>
+  {% if can_manage_room %}
   <button id="addNode" class="w-12 h-12 flex items-center justify-center text-2xl rounded-full bg-indigo-600 hover:bg-indigo-500">+</button>
+  {% endif %}
 </div>
 <div class="grid md:grid-cols-3 gap-4">
   {% for n in room.nodes %}
@@ -147,37 +149,40 @@
 {% endif %}
 <script type="module" src="/static/presets.js"></script>
 <script>
-document.getElementById('addNode').onclick = async () => {
-  const name = prompt('New node name');
-  if (!name) {
-    return;
-  }
-  let res;
-  try {
-    res = await fetch('/api/house/{{ house_public_id }}/room/{{ room.id }}/nodes', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({name}),
-    });
-  } catch (error) {
-    alert('Failed to add node');
-    return;
-  }
-  if (res.ok) {
-    location.reload();
-    return;
-  }
-  let message = 'Failed to add node';
-  try {
-    const data = await res.json();
-    if (data && typeof data.detail === 'string' && data.detail.trim()) {
-      message = data.detail;
+const addNodeButton = document.getElementById('addNode');
+if(addNodeButton){
+  addNodeButton.onclick = async () => {
+    const name = prompt('New node name');
+    if (!name) {
+      return;
     }
-  } catch (error) {
-    // ignore JSON parse errors
-  }
-  alert(message);
-};
+    let res;
+    try {
+      res = await fetch('/api/house/{{ house_public_id }}/room/{{ room.id }}/nodes', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({name}),
+      });
+    } catch (error) {
+      alert('Failed to add node');
+      return;
+    }
+    if (res.ok) {
+      location.reload();
+      return;
+    }
+    let message = 'Failed to add node';
+    try {
+      const data = await res.json();
+      if (data && typeof data.detail === 'string' && data.detail.trim()) {
+        message = data.detail;
+      }
+    } catch (error) {
+      // ignore JSON parse errors
+    }
+    alert(message);
+  };
+}
 {% if motion_config %}
 (function(){
   const scheduleContainer = document.getElementById('motionSchedule');

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -5,3 +5,5 @@ paho-mqtt
 python-dotenv
 sqlmodel
 passlib[bcrypt]
+itsdangerous
+python-multipart

--- a/Server/tests/auth/test_login_flow.py
+++ b/Server/tests/auth/test_login_flow.py
@@ -106,8 +106,11 @@ def test_login_rejects_invalid_credentials(client: TestClient) -> None:
     assert f"{SESSION_COOKIE_NAME}=" in cookie_header
     assert "Max-Age=0" in cookie_header
 
-    unauthenticated = client.get(f"/house/{house_external_id}")
-    assert unauthenticated.status_code == 401
+    unauthenticated = client.get(
+        f"/house/{house_external_id}", follow_redirects=False
+    )
+    assert unauthenticated.status_code == 303
+    assert unauthenticated.headers["location"] == "/login"
 
 
 def test_logout_clears_cookie_and_blocks_access(client: TestClient) -> None:
@@ -126,5 +129,8 @@ def test_logout_clears_cookie_and_blocks_access(client: TestClient) -> None:
     assert f"{SESSION_COOKIE_NAME}=" in cookie_header
     assert "Max-Age=0" in cookie_header
 
-    protected = client.get(f"/house/{house_external_id}")
-    assert protected.status_code == 401
+    protected = client.get(
+        f"/house/{house_external_id}", follow_redirects=False
+    )
+    assert protected.status_code == 303
+    assert protected.headers["location"] == "/login"


### PR DESCRIPTION
## Summary
- add an `AccessPolicy` helper to derive house and room visibility for each user
- protect all page and API routes with authenticated access, new dashboard redirect, and admin role checks
- hide unauthorized controls in templates and expand the test suite to cover guest/admin authorization flows

## Testing
- pytest Server/tests

------
https://chatgpt.com/codex/tasks/task_e_68d32285afe8832694b61d831ee4b9f6