### PR TITLE
Add house membership management API and UI

### DIFF
--- a/Server/app/main.py
+++ b/Server/app/main.py
@@ -15,6 +15,7 @@ from .database import get_session
 from .motion import motion_manager
 from .ota import router as ota_router
 from .routes_api import router as api_router
+from .routes_house_admin import router as house_admin_router
 from .routes_pages import router as pages_router
 from .status_monitor import status_monitor
 
@@ -86,6 +87,7 @@ app.add_middleware(
 
 app.include_router(pages_router)
 app.include_router(api_router)
+app.include_router(house_admin_router)
 app.include_router(ota_router)
 
 

--- a/Server/app/routes_house_admin.py
+++ b/Server/app/routes_house_admin.py
@@ -1,0 +1,355 @@
+"""FastAPI routes for managing house memberships."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlmodel import Session, delete, select
+
+from . import registry
+from .auth.dependencies import require_admin
+from .auth.models import House, HouseMembership, HouseRole, RoomAccess, User
+from .auth.security import hash_password
+from .auth.service import create_user
+from .database import get_session
+
+
+router = APIRouter(prefix="/api/house-admin", tags=["house-admin"])
+
+
+def _normalize_room_list(value: Any) -> Optional[List[str]]:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple, set)):
+        items = value
+    else:
+        items = [value]
+    cleaned: List[str] = []
+    for item in items:
+        clean = str(item).strip()
+        if clean:
+            cleaned.append(clean)
+    return cleaned
+
+
+class RoomInfo(BaseModel):
+    """Description of a room and its identifier."""
+
+    id: str
+    name: str
+
+
+class HouseMember(BaseModel):
+    """Serialized membership information for the API."""
+
+    membership_id: int = Field(..., alias="membershipId")
+    user_id: int = Field(..., alias="userId")
+    username: str
+    role: HouseRole
+    server_admin: bool = Field(..., alias="serverAdmin")
+    rooms: List[RoomInfo]
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MembershipListResponse(BaseModel):
+    """Response body for listing memberships within a house."""
+
+    members: List[HouseMember]
+    available_rooms: List[RoomInfo] = Field(..., alias="availableRooms")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MembershipCreate(BaseModel):
+    """Payload for creating a new house membership."""
+
+    username: str = Field(..., min_length=1, max_length=64)
+    password: str = Field(..., min_length=1, max_length=255)
+    role: HouseRole
+    rooms: Optional[List[str]] = None
+
+    model_config = ConfigDict()
+
+    @field_validator("username")
+    @classmethod
+    def _clean_username(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("username cannot be empty")
+        return cleaned
+
+    @field_validator("rooms", mode="before")
+    @classmethod
+    def _normalize_rooms(cls, value: Any) -> Optional[List[str]]:
+        return _normalize_room_list(value)
+
+
+class MembershipUpdate(BaseModel):
+    """Payload for updating an existing house membership."""
+
+    role: Optional[HouseRole] = None
+    password: Optional[str] = None
+    rooms: Optional[List[str]] = None
+
+    model_config = ConfigDict()
+
+    @field_validator("password")
+    @classmethod
+    def _clean_password(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if not str(value).strip():
+            raise ValueError("password cannot be empty")
+        return value
+
+    @field_validator("rooms", mode="before")
+    @classmethod
+    def _normalize_rooms(cls, value: Any) -> Optional[List[str]]:
+        return _normalize_room_list(value)
+
+
+def _get_house(session: Session, house_id: str) -> House:
+    house = session.exec(select(House).where(House.external_id == house_id)).first()
+    if not house:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Unknown house")
+    return house
+
+
+def _room_lookup(house_id: str) -> Dict[str, str]:
+    house = registry.find_house(house_id)
+    if not house:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Unknown house")
+    mapping: Dict[str, str] = {}
+    for entry in house.get("rooms", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        room_id = str(entry.get("id") or "").strip()
+        if not room_id:
+            continue
+        name_value = entry.get("name")
+        if isinstance(name_value, str):
+            clean_name = name_value.strip()
+            mapping[room_id] = clean_name or room_id
+        else:
+            mapping[room_id] = room_id
+    return mapping
+
+
+def _room_assignments(session: Session, membership_ids: Iterable[int]) -> Dict[int, List[str]]:
+    mapping: Dict[int, List[str]] = {}
+    id_list = [mid for mid in membership_ids if mid is not None]
+    if not id_list:
+        return mapping
+    for access in session.exec(
+        select(RoomAccess).where(RoomAccess.membership_id.in_(id_list))
+    ):
+        membership_id = access.membership_id
+        room_id = str(access.room_id)
+        if membership_id is None or not room_id:
+            continue
+        mapping.setdefault(membership_id, []).append(room_id)
+    return mapping
+
+
+def _serialize_member(
+    membership: HouseMembership,
+    user: User,
+    room_map: Dict[str, str],
+    assigned_ids: Iterable[str],
+) -> HouseMember:
+    normalized_ids = []
+    seen: set[str] = set()
+    for room_id in assigned_ids:
+        clean_id = str(room_id).strip()
+        if not clean_id or clean_id in seen:
+            continue
+        seen.add(clean_id)
+        normalized_ids.append(clean_id)
+    normalized_ids.sort(key=lambda rid: room_map.get(rid, rid).lower())
+    rooms = [RoomInfo(id=rid, name=room_map.get(rid, rid)) for rid in normalized_ids]
+    return HouseMember(
+        membership_id=membership.id,
+        user_id=membership.user_id,
+        username=user.username,
+        role=membership.role,
+        server_admin=user.server_admin,
+        rooms=rooms,
+    )
+
+
+def _ensure_unique_username(session: Session, username: str) -> None:
+    existing = session.exec(select(User).where(User.username == username)).first()
+    if existing:
+        raise HTTPException(status.HTTP_409_CONFLICT, "Username already exists")
+
+
+def _apply_room_assignments(
+    session: Session,
+    membership: HouseMembership,
+    room_ids: Iterable[str],
+) -> None:
+    clean_ids: List[str] = []
+    seen: set[str] = set()
+    for raw in room_ids:
+        room_id = str(raw).strip()
+        if not room_id or room_id in seen:
+            continue
+        seen.add(room_id)
+        clean_ids.append(room_id)
+
+    existing = session.exec(
+        select(RoomAccess).where(RoomAccess.membership_id == membership.id)
+    ).all()
+    existing_ids = {entry.room_id: entry for entry in existing}
+
+    for entry in existing:
+        if entry.room_id not in seen:
+            session.delete(entry)
+
+    for room_id in clean_ids:
+        if room_id not in existing_ids:
+            session.add(RoomAccess(membership_id=membership.id, room_id=room_id))
+
+
+def _get_membership(
+    session: Session,
+    house_db_id: int,
+    membership_id: int,
+) -> tuple[HouseMembership, User]:
+    row = session.exec(
+        select(HouseMembership, User)
+        .join(User, User.id == HouseMembership.user_id)
+        .where(HouseMembership.id == membership_id)
+        .where(HouseMembership.house_id == house_db_id)
+    ).first()
+    if not row:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Unknown membership")
+    return row
+
+
+@router.get("/{house_id}/members", response_model=MembershipListResponse)
+def list_members(
+    house_id: str,
+    _admin: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> MembershipListResponse:
+    house = _get_house(session, house_id)
+    room_map = _room_lookup(house_id)
+    rows = session.exec(
+        select(HouseMembership, User)
+        .join(User, User.id == HouseMembership.user_id)
+        .where(HouseMembership.house_id == house.id)
+        .order_by(User.username)
+    ).all()
+    membership_ids = [membership.id for membership, _ in rows if membership.id is not None]
+    assignments = _room_assignments(session, membership_ids)
+    members = [
+        _serialize_member(membership, user, room_map, assignments.get(membership.id, []))
+        for membership, user in rows
+    ]
+    available = [
+        RoomInfo(id=room_id, name=name)
+        for room_id, name in sorted(room_map.items(), key=lambda item: item[1].lower())
+    ]
+    return MembershipListResponse(members=members, available_rooms=available)
+
+
+@router.post(
+    "/{house_id}/members",
+    status_code=status.HTTP_201_CREATED,
+    response_model=HouseMember,
+)
+def create_member(
+    house_id: str,
+    payload: MembershipCreate,
+    _admin: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> HouseMember:
+    house = _get_house(session, house_id)
+    room_map = _room_lookup(house_id)
+    username = payload.username.strip()
+    _ensure_unique_username(session, username)
+
+    user = create_user(session, username, payload.password, server_admin=False)
+
+    membership = HouseMembership(user_id=user.id, house_id=house.id, role=payload.role)
+    session.add(membership)
+    session.commit()
+    session.refresh(membership)
+
+    assigned_room_ids: List[str] = []
+    if membership.role == HouseRole.GUEST:
+        requested_rooms = payload.rooms or []
+        normalized_rooms = [rid for rid in requested_rooms if rid]
+        for room_id in normalized_rooms:
+            if room_id not in room_map:
+                raise HTTPException(
+                    status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    f"Room '{room_id}' is not part of this house",
+                )
+        _apply_room_assignments(session, membership, normalized_rooms)
+        assigned_room_ids = normalized_rooms
+    else:
+        _apply_room_assignments(session, membership, [])
+
+    session.commit()
+    if membership.role != HouseRole.ADMIN:
+        assignments = _room_assignments(session, [membership.id])
+        assigned_room_ids = assignments.get(membership.id, assigned_room_ids)
+    return _serialize_member(membership, user, room_map, assigned_room_ids)
+
+
+@router.patch("/{house_id}/members/{membership_id}", response_model=HouseMember)
+def update_member(
+    house_id: str,
+    membership_id: int,
+    payload: MembershipUpdate,
+    _admin: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> HouseMember:
+    house = _get_house(session, house_id)
+    room_map = _room_lookup(house_id)
+    membership, user = _get_membership(session, house.id, membership_id)
+
+    if payload.role is not None:
+        membership.role = payload.role
+
+    target_role = membership.role
+
+    if payload.password:
+        user.hashed_password = hash_password(payload.password)
+
+    if target_role == HouseRole.ADMIN:
+        _apply_room_assignments(session, membership, [])
+    elif payload.rooms is not None:
+        normalized = [rid for rid in payload.rooms if rid]
+        for room_id in normalized:
+            if room_id not in room_map:
+                raise HTTPException(
+                    status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    f"Room '{room_id}' is not part of this house",
+                )
+        _apply_room_assignments(session, membership, normalized)
+
+    session.commit()
+    assignments = _room_assignments(session, [membership.id])
+    assigned_rooms = assignments.get(membership.id, [])
+    return _serialize_member(membership, user, room_map, assigned_rooms)
+
+
+@router.delete("/{house_id}/members/{membership_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_member(
+    house_id: str,
+    membership_id: int,
+    _admin: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> None:
+    house = _get_house(session, house_id)
+    membership, user = _get_membership(session, house.id, membership_id)
+    session.exec(
+        delete(RoomAccess).where(RoomAccess.membership_id == membership.id)
+    )
+    session.delete(membership)
+    session.commit()

--- a/Server/app/templates/admin.html
+++ b/Server/app/templates/admin.html
@@ -108,6 +108,176 @@
 
 <div id="statusError" class="mt-4 text-sm text-rose-400 hidden"></div>
 
+{% if house_memberships is not none %}
+<section
+  class="mt-12"
+  data-house-admin
+  data-house-id="{{ house_admin_external_id }}">
+  <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+    <div>
+      <h3 class="text-2xl font-semibold">House Members</h3>
+      <p class="text-sm opacity-70">Manage user access for this house.</p>
+    </div>
+    {% if house_member_manage_allowed %}
+    <div class="text-xs opacity-60 md:text-right">
+      Accounts created here are limited to this house.
+    </div>
+    {% endif %}
+  </div>
+  <div class="mt-4 grid gap-4">
+    {% if house_memberships %}
+    {% for member in house_memberships %}
+    <div class="glass rounded-xl p-4" data-member-card="{{ member.id }}">
+      <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+        <div>
+          <div class="text-lg font-semibold">{{ member.username }}</div>
+          <div class="text-xs opacity-70">
+            {{ member.role_label }}{% if member.server_admin %} • Server admin{% endif %}
+          </div>
+          {% if member.rooms %}
+          <div class="mt-2 text-xs opacity-70">
+            Rooms: {{ member.rooms | map(attribute='name') | join(', ') }}
+          </div>
+          {% elif member.role == 'guest' %}
+          <div class="mt-2 text-xs opacity-70">No rooms assigned.</div>
+          {% endif %}
+        </div>
+      </div>
+      {% if house_member_manage_allowed %}
+      <form class="mt-4 space-y-4" data-membership-form data-membership-id="{{ member.id }}">
+        <div class="grid gap-3 md:grid-cols-2">
+          <label class="block text-sm font-semibold">
+            <span>Role</span>
+            <select
+              name="role"
+              class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2"
+              data-role-select>
+              {% for role in house_member_roles or [] %}
+              <option value="{{ role.value }}"{% if role.value == member.role %} selected{% endif %}>{{ role.label }}</option>
+              {% endfor %}
+            </select>
+          </label>
+          <label class="block text-sm font-semibold">
+            <span>New password</span>
+            <input
+              type="password"
+              name="password"
+              placeholder="Leave blank to keep current"
+              class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2"
+              autocomplete="new-password">
+          </label>
+        </div>
+        {% if house_member_options %}
+        <div data-room-section>
+          <div class="text-xs opacity-70">Guest accounts can access the selected rooms.</div>
+          <div class="mt-2 grid gap-2 md:grid-cols-2">
+            {% set assigned_ids = member.rooms | map(attribute='id') | list %}
+            {% for room in house_member_options %}
+            <label class="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                value="{{ room.id }}"
+                class="w-4 h-4"
+                data-room-checkbox{% if room.id in assigned_ids %} checked{% endif %}>
+              <span>{{ room.name }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+        <div class="flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            class="px-4 py-2 pill bg-indigo-600 hover:bg-indigo-500 text-sm font-semibold">
+            Save changes
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 pill bg-rose-600 hover:bg-rose-500 text-sm font-semibold"
+            data-membership-delete
+            data-username="{{ member.username }}">
+            Remove access
+          </button>
+        </div>
+      </form>
+      {% endif %}
+    </div>
+    {% endfor %}
+    {% else %}
+    <div class="glass rounded-xl p-6 text-center text-sm opacity-70">No accounts yet.</div>
+    {% endif %}
+  </div>
+  {% if not house_member_manage_allowed %}
+  <div class="mt-4 text-xs opacity-70">Contact a server administrator to modify access.</div>
+  {% endif %}
+  {% if house_member_manage_allowed %}
+  <div class="mt-8 glass rounded-xl p-4">
+    <h4 class="text-lg font-semibold">Invite a new account</h4>
+    <p class="text-xs opacity-70">New users receive access limited to this house.</p>
+    <form class="mt-4 space-y-4" data-membership-create>
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="block text-sm font-semibold">
+          <span>Username</span>
+          <input
+            type="text"
+            name="username"
+            required
+            class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2"
+            autocomplete="off">
+        </label>
+        <label class="block text-sm font-semibold">
+          <span>Password</span>
+          <input
+            type="password"
+            name="password"
+            required
+            class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2"
+            autocomplete="new-password">
+        </label>
+      </div>
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="block text-sm font-semibold">
+          <span>Role</span>
+          <select
+            name="role"
+            class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2"
+            data-role-select>
+            {% for role in house_member_roles or [] %}
+            <option value="{{ role.value }}">{{ role.label }}</option>
+            {% endfor %}
+          </select>
+        </label>
+      </div>
+      {% if house_member_options %}
+      <div data-room-section>
+        <div class="text-xs opacity-70">Select rooms for guest accounts.</div>
+        <div class="mt-2 grid gap-2 md:grid-cols-2">
+          {% for room in house_member_options %}
+          <label class="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              value="{{ room.id }}"
+              class="w-4 h-4"
+              data-room-checkbox>
+            <span>{{ room.name }}</span>
+          </label>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+      <div>
+        <button
+          type="submit"
+          class="px-4 py-2 pill bg-emerald-600 hover:bg-emerald-500 text-sm font-semibold">
+          Create account
+        </button>
+      </div>
+    </form>
+  </div>
+  {% endif %}
+</section>
+{% endif %}
+
 <script>
 const STATUS_TIMEOUT = {{ status_timeout }};
 const STATUS_HOUSE_ID = {{ status_house_id|tojson }};
@@ -358,5 +528,210 @@ document.querySelectorAll('[data-node-remove]').forEach((btn) => {
     }
   });
 });
+
+async function readErrorMessage(response) {
+  try {
+    const data = await response.clone().json();
+    if (data && typeof data.detail === 'string') {
+      return data.detail;
+    }
+    if (data && Array.isArray(data.detail)) {
+      return data.detail
+        .map((item) => (typeof item === 'string' ? item : item.msg || item.detail || ''))
+        .filter((text) => text)
+        .join(', ');
+    }
+  } catch (err) {
+    // ignore parse errors
+  }
+  try {
+    const text = await response.text();
+    if (text) return text;
+  } catch (err) {
+    // ignore parse errors
+  }
+  return `HTTP ${response.status}`;
+}
+
+const houseAdminSection = document.querySelector('[data-house-admin]');
+if (houseAdminSection) {
+  const houseId = houseAdminSection.dataset.houseId;
+
+  const handleRoleVisibility = (select) => {
+    if (!select) return;
+    const form = select.closest('form');
+    if (!form) return;
+    const roomSection = form.querySelector('[data-room-section]');
+    if (!roomSection) return;
+    if (select.value === 'guest') {
+      roomSection.classList.remove('hidden');
+    } else {
+      roomSection.classList.add('hidden');
+      roomSection.querySelectorAll('[data-room-checkbox]').forEach((checkbox) => {
+        checkbox.checked = false;
+      });
+    }
+  };
+
+  houseAdminSection.querySelectorAll('[data-role-select]').forEach((select) => {
+    handleRoleVisibility(select);
+    select.addEventListener('change', () => handleRoleVisibility(select));
+  });
+
+  houseAdminSection.querySelectorAll('[data-membership-form]').forEach((form) => {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!houseId) {
+        alert('Missing house identifier.');
+        return;
+      }
+      const membershipId = form.dataset.membershipId;
+      if (!membershipId) {
+        alert('Missing membership identifier.');
+        return;
+      }
+      const roleField = form.querySelector('[name="role"]');
+      const roleValue = roleField ? roleField.value : 'guest';
+      const passwordField = form.querySelector('input[name="password"]');
+      const payload = { role: roleValue };
+      if (passwordField && passwordField.value.trim()) {
+        payload.password = passwordField.value;
+      }
+      if (roleValue === 'guest') {
+        payload.rooms = Array.from(
+          form.querySelectorAll('[data-room-checkbox]:checked')
+        )
+          .map((checkbox) => checkbox.value)
+          .filter((value) => value);
+      } else if (form.querySelector('[data-room-checkbox]')) {
+        payload.rooms = [];
+      }
+      const submitButton = form.querySelector('button[type="submit"]');
+      const originalText = submitButton ? submitButton.textContent : '';
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'Saving…';
+      }
+      try {
+        const res = await fetch(
+          `/api/house-admin/${encodeURIComponent(houseId)}/members/${encodeURIComponent(membershipId)}`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          },
+        );
+        if (!res.ok) {
+          const message = await readErrorMessage(res);
+          throw new Error(message);
+        }
+        location.reload();
+      } catch (err) {
+        console.error('Failed to update membership', err);
+        alert(`Failed to save changes: ${err.message}`);
+      } finally {
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.textContent = originalText || 'Save changes';
+        }
+      }
+    });
+  });
+
+  houseAdminSection.querySelectorAll('[data-membership-delete]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      if (!houseId) {
+        alert('Missing house identifier.');
+        return;
+      }
+      const form = button.closest('[data-membership-form]');
+      const membershipId = form ? form.dataset.membershipId : null;
+      if (!membershipId) {
+        alert('Missing membership identifier.');
+        return;
+      }
+      const username = button.dataset.username || membershipId;
+      if (!confirm(`Remove access for ${username}?`)) {
+        return;
+      }
+      const originalText = button.textContent;
+      button.disabled = true;
+      button.textContent = 'Removing…';
+      try {
+        const res = await fetch(
+          `/api/house-admin/${encodeURIComponent(houseId)}/members/${encodeURIComponent(membershipId)}`,
+          { method: 'DELETE' },
+        );
+        if (!res.ok) {
+          const message = await readErrorMessage(res);
+          throw new Error(message);
+        }
+        location.reload();
+      } catch (err) {
+        console.error('Failed to remove membership', err);
+        alert(`Failed to remove access: ${err.message}`);
+        button.disabled = false;
+        button.textContent = originalText;
+      }
+    });
+  });
+
+  const createForm = houseAdminSection.querySelector('[data-membership-create]');
+  if (createForm) {
+    createForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!houseId) {
+        alert('Missing house identifier.');
+        return;
+      }
+      const formData = new FormData(createForm);
+      const username = (formData.get('username') || '').toString().trim();
+      const password = (formData.get('password') || '').toString();
+      const role = (formData.get('role') || 'guest').toString();
+      if (!username) {
+        alert('Username is required.');
+        return;
+      }
+      if (!password) {
+        alert('Password is required.');
+        return;
+      }
+      const rooms = role === 'guest'
+        ? Array.from(createForm.querySelectorAll('[data-room-checkbox]:checked'))
+            .map((checkbox) => checkbox.value)
+            .filter((value) => value)
+        : [];
+      const submitButton = createForm.querySelector('button[type="submit"]');
+      const originalText = submitButton ? submitButton.textContent : '';
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'Creating…';
+      }
+      try {
+        const res = await fetch(
+          `/api/house-admin/${encodeURIComponent(houseId)}/members`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password, role, rooms }),
+          },
+        );
+        if (!res.ok) {
+          const message = await readErrorMessage(res);
+          throw new Error(message);
+        }
+        location.reload();
+      } catch (err) {
+        console.error('Failed to create membership', err);
+        alert(`Failed to create account: ${err.message}`);
+      } finally {
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.textContent = originalText || 'Create account';
+        }
+      }
+    });
+  }
+}
 </script>
 {% endblock %}

--- a/Server/tests/auth/test_house_admin.py
+++ b/Server/tests/auth/test_house_admin.py
@@ -1,0 +1,226 @@
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import select
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import database
+from app.auth.models import HouseMembership, RoomAccess, User
+from app.auth.security import SESSION_COOKIE_NAME
+from app.auth.service import create_user, init_auth_storage
+from app.config import settings
+
+
+class _NoopBus:
+    def __getattr__(self, name: str):  # pragma: no cover - simple stub
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+def _build_registry() -> list[dict]:
+    return [
+        {
+            "id": "alpha",
+            "name": "Alpha House",
+            "external_id": "alpha-public",
+            "rooms": [
+                {
+                    "id": "alpha-room",
+                    "name": "Alpha Room",
+                    "nodes": [],
+                },
+                {
+                    "id": "alpha-denied",
+                    "name": "Alpha Hidden",
+                    "nodes": [],
+                },
+            ],
+        },
+        {
+            "id": "beta",
+            "name": "Beta House",
+            "external_id": "beta-public",
+            "rooms": [
+                {
+                    "id": "beta-room",
+                    "name": "Beta Room",
+                    "nodes": [],
+                }
+            ],
+        },
+    ]
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import app.mqtt_bus
+    monkeypatch.setattr(app.mqtt_bus, "MqttBus", lambda *args, **kwargs: _NoopBus())
+
+    import app.motion
+    import app.registry as registry_module
+    import app.status_monitor
+    from app.main import app as fastapi_app
+    monkeypatch.setattr(app.motion.motion_manager, "start", lambda: None)
+    monkeypatch.setattr(app.motion.motion_manager, "stop", lambda: None)
+    monkeypatch.setattr(app.status_monitor.status_monitor, "start", lambda: None)
+    monkeypatch.setattr(app.status_monitor.status_monitor, "stop", lambda: None)
+
+    original_url = settings.AUTH_DB_URL
+    db_path = tmp_path / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+    database.reset_session_factory(db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", db_url)
+
+    registry_data = _build_registry()
+    registry_file = tmp_path / "registry.json"
+    registry_file.write_text(json.dumps(registry_data))
+    monkeypatch.setattr(settings, "REGISTRY_FILE", registry_file)
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", deepcopy(registry_data))
+    monkeypatch.setattr(registry_module.settings, "DEVICE_REGISTRY", deepcopy(registry_data))
+    monkeypatch.setattr(registry_module.settings, "REGISTRY_FILE", registry_file)
+    registry_module.ensure_house_external_ids(persist=False)
+
+    init_auth_storage()
+
+    try:
+        with TestClient(fastapi_app, base_url="https://testserver") as test_client:
+            yield test_client
+    finally:
+        database.reset_session_factory(original_url)
+
+
+def _login(client: TestClient, username: str, password: str) -> None:
+    response = client.post(
+        "/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert SESSION_COOKIE_NAME in response.cookies
+
+
+def _create_server_admin(username: str, password: str) -> None:
+    with database.SessionLocal() as session:
+        create_user(session, username, password, server_admin=True)
+
+
+def _membership_rooms(session, membership_id: int) -> set[str]:
+    rows = session.exec(
+        select(RoomAccess).where(RoomAccess.membership_id == membership_id)
+    ).all()
+    return {row.room_id for row in rows}
+
+
+def test_create_guest_account_and_prevent_duplicates(client: TestClient):
+    _create_server_admin("admin", "admin-pass")
+    _login(client, "admin", "admin-pass")
+
+    create_response = client.post(
+        "/api/house-admin/alpha-public/members",
+        json={
+            "username": "alpha-guest",
+            "password": "guest-pass",
+            "role": "guest",
+            "rooms": ["alpha-room"],
+        },
+    )
+    assert create_response.status_code == 201
+    body = create_response.json()
+    assert body["username"] == "alpha-guest"
+    assert body["role"] == "guest"
+    assert body["serverAdmin"] is False
+    assert body["rooms"] == [{"id": "alpha-room", "name": "Alpha Room"}]
+
+    duplicate = client.post(
+        "/api/house-admin/alpha-public/members",
+        json={
+            "username": "alpha-guest",
+            "password": "another-pass",
+            "role": "guest",
+        },
+    )
+    assert duplicate.status_code == 409
+
+    with database.SessionLocal() as session:
+        membership = session.exec(
+            select(HouseMembership)
+            .join(User, User.id == HouseMembership.user_id)
+            .where(User.username == "alpha-guest")
+        ).one()
+        assert _membership_rooms(session, membership.id) == {"alpha-room"}
+
+
+def test_role_changes_and_room_constraints(client: TestClient):
+    _create_server_admin("admin", "admin-pass")
+    _login(client, "admin", "admin-pass")
+
+    create_response = client.post(
+        "/api/house-admin/alpha-public/members",
+        json={
+            "username": "switch-user",
+            "password": "guest-pass",
+            "role": "guest",
+            "rooms": ["alpha-room"],
+        },
+    )
+    assert create_response.status_code == 201
+    member_data = create_response.json()
+    membership_id = member_data["membershipId"]
+
+    promote = client.patch(
+        f"/api/house-admin/alpha-public/members/{membership_id}",
+        json={"role": "admin"},
+    )
+    assert promote.status_code == 200
+    promote_body = promote.json()
+    assert promote_body["role"] == "admin"
+    assert promote_body["rooms"] == []
+
+    with database.SessionLocal() as session:
+        assert _membership_rooms(session, membership_id) == set()
+
+    downgrade = client.patch(
+        f"/api/house-admin/alpha-public/members/{membership_id}",
+        json={"role": "guest", "rooms": ["alpha-room"]},
+    )
+    assert downgrade.status_code == 200
+    downgrade_body = downgrade.json()
+    assert downgrade_body["role"] == "guest"
+    assert downgrade_body["rooms"] == [{"id": "alpha-room", "name": "Alpha Room"}]
+
+    cross_house = client.patch(
+        f"/api/house-admin/alpha-public/members/{membership_id}",
+        json={"rooms": ["beta-room"]},
+    )
+    assert cross_house.status_code == 422
+
+    wrong_house = client.patch(
+        f"/api/house-admin/beta-public/members/{membership_id}",
+        json={"role": "guest"},
+    )
+    assert wrong_house.status_code == 404
+
+
+def test_invalid_room_rejected_on_create(client: TestClient):
+    _create_server_admin("admin", "admin-pass")
+    _login(client, "admin", "admin-pass")
+
+    response = client.post(
+        "/api/house-admin/alpha-public/members",
+        json={
+            "username": "invalid-room",
+            "password": "guest-pass",
+            "role": "guest",
+            "rooms": ["unknown-room"],
+        },
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add a `/api/house-admin` router that provides CRUD endpoints for house memberships and room assignments guarded by admin checks
- surface membership data and management forms on the per-house admin page with client-side helpers for account creation and edits
- add pytest coverage for membership creation, role transitions, and room-assignment validation scenarios

## Testing
- pytest Server/tests/auth

------
https://chatgpt.com/codex/tasks/task_e_68d32b240d148326a8aa6682949172ea