### PR TITLE
Add server admin dashboard and controls

### DIFF
--- a/Server/app/auth/models.py
+++ b/Server/app/auth/models.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional
 
-from sqlalchemy import Column, DateTime, Enum as SAEnum, String, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Enum as SAEnum,
+    JSON,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.sql import func
 from sqlmodel import Field, SQLModel
 
@@ -98,4 +105,30 @@ class RoomAccess(SQLModel, table=True):
         default_factory=datetime.utcnow, sa_column=_timestamp_column(onupdate=True)
     )
 
-__all__ = ["House", "HouseMembership", "HouseRole", "RoomAccess", "User"]
+class AuditLog(SQLModel, table=True):
+    __tablename__ = "audit_logs"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    actor_id: Optional[int] = Field(default=None, foreign_key="users.id")
+    action: str = Field(sa_column=Column(String(120), nullable=False))
+    summary: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    data: Dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, default=dict),
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow, sa_column=_timestamp_column()
+    )
+
+
+__all__ = [
+    "AuditLog",
+    "House",
+    "HouseMembership",
+    "HouseRole",
+    "RoomAccess",
+    "User",
+]

--- a/Server/app/main.py
+++ b/Server/app/main.py
@@ -17,6 +17,7 @@ from .ota import router as ota_router
 from .routes_api import router as api_router
 from .routes_house_admin import router as house_admin_router
 from .routes_pages import router as pages_router
+from .routes_server_admin import router as server_admin_router
 from .status_monitor import status_monitor
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
@@ -88,6 +89,7 @@ app.add_middleware(
 app.include_router(pages_router)
 app.include_router(api_router)
 app.include_router(house_admin_router)
+app.include_router(server_admin_router)
 app.include_router(ota_router)
 
 

--- a/Server/app/registry.py
+++ b/Server/app/registry.py
@@ -100,6 +100,28 @@ def _generate_unique_external_id(seen: set[str]) -> str:
             return candidate
 
 
+def rotate_house_external_id(house_id: str) -> str:
+    """Assign a new external id to ``house_id`` and persist the change."""
+
+    ensure_house_external_ids(persist=False)
+    house = find_house(house_id)
+    if not house:
+        raise KeyError("house not found")
+
+    seen: set[str] = set()
+    for entry in settings.DEVICE_REGISTRY:
+        if not isinstance(entry, dict) or entry is house:
+            continue
+        raw_id = entry.get("external_id")
+        if isinstance(raw_id, str) and raw_id:
+            seen.add(raw_id)
+
+    new_id = _generate_unique_external_id(seen)
+    house["external_id"] = new_id
+    save_registry()
+    return new_id
+
+
 def iter_nodes(registry: Optional[Registry] = None) -> Iterator[Tuple[House, Room, Node]]:
     """Yield (house, room, node) for every node in the registry."""
     if registry is None:

--- a/Server/app/routes_server_admin.py
+++ b/Server/app/routes_server_admin.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlmodel import Session, select
+
+from . import registry
+from .auth.dependencies import require_admin
+from .auth.models import House, HouseMembership, HouseRole, User
+from .auth.service import create_user, record_audit_event
+from .database import get_session
+
+router = APIRouter(prefix="/api/server-admin", tags=["server-admin"])
+
+
+class RotateHouseIdRequest(BaseModel):
+    """Payload for rotating a house external identifier."""
+
+    confirm: bool = Field(..., description="Confirmation flag to rotate the ID")
+
+
+class RotateHouseIdResponse(BaseModel):
+    """Response payload after rotating a house id."""
+
+    house_id: str = Field(..., alias="houseId")
+    new_id: str = Field(..., alias="newId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class HouseAdminCreateRequest(BaseModel):
+    """Request payload for creating a new house administrator."""
+
+    username: str = Field(..., min_length=1, max_length=64)
+    password: str = Field(..., min_length=1, max_length=255)
+
+    model_config = ConfigDict()
+
+    @field_validator("username")
+    @classmethod
+    def _clean_username(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("username cannot be empty")
+        return cleaned
+
+
+class HouseAdminResponse(BaseModel):
+    """Serialized information about a created house admin."""
+
+    membership_id: int = Field(..., alias="membershipId")
+    user_id: int = Field(..., alias="userId")
+    username: str
+    house_id: str = Field(..., alias="houseId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+def _get_house_row(session: Session, external_id: str, *, display_name: str) -> House:
+    house = session.exec(select(House).where(House.external_id == external_id)).first()
+    if house:
+        if display_name and house.display_name != display_name:
+            house.display_name = display_name
+        return house
+    house = House(display_name=display_name or external_id, external_id=external_id)
+    session.add(house)
+    session.flush()
+    return house
+
+
+def _ensure_unique_username(session: Session, username: str) -> None:
+    existing = session.exec(select(User).where(User.username == username)).first()
+    if existing:
+        raise HTTPException(status.HTTP_409_CONFLICT, "Username already exists")
+
+
+@router.post(
+    "/houses/{house_id}/rotate-id",
+    response_model=RotateHouseIdResponse,
+)
+def rotate_house_id(
+    house_id: str,
+    payload: RotateHouseIdRequest,
+    current_user: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> RotateHouseIdResponse:
+    if not payload.confirm:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Confirmation required")
+
+    house_entry = registry.find_house(house_id)
+    if not house_entry:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Unknown house")
+
+    current_external = registry.get_house_external_id(house_entry)
+    new_external = registry.rotate_house_external_id(house_id)
+
+    display_name = str(
+        house_entry.get("name") or house_entry.get("id") or new_external
+    )
+    house_row = _get_house_row(session, current_external, display_name=display_name)
+    house_row.external_id = new_external
+
+    record_audit_event(
+        session,
+        actor=current_user,
+        action="house_id_rotated",
+        summary=f"Rotated house id for {display_name}",
+        data={"previous": current_external, "new": new_external},
+        commit=True,
+    )
+
+    return RotateHouseIdResponse(house_id=current_external, new_id=new_external)
+
+
+@router.post(
+    "/houses/{house_id}/admins",
+    status_code=status.HTTP_201_CREATED,
+    response_model=HouseAdminResponse,
+)
+def create_house_admin(
+    house_id: str,
+    payload: HouseAdminCreateRequest,
+    current_user: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> HouseAdminResponse:
+    house_entry = registry.find_house(house_id)
+    if not house_entry:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Unknown house")
+
+    external_id = registry.get_house_external_id(house_entry)
+    display_name = str(
+        house_entry.get("name") or house_entry.get("id") or external_id
+    )
+    house_row = _get_house_row(session, external_id, display_name=display_name)
+
+    username = payload.username.strip()
+    _ensure_unique_username(session, username)
+
+    user = create_user(session, username, payload.password, server_admin=False)
+
+    membership = HouseMembership(
+        user_id=user.id,
+        house_id=house_row.id,
+        role=HouseRole.ADMIN,
+    )
+    session.add(membership)
+    session.flush()
+
+    record_audit_event(
+        session,
+        actor=current_user,
+        action="house_admin_created",
+        summary=f"Created house admin {username}",
+        data={"house": external_id, "user": username},
+        commit=True,
+    )
+
+    session.refresh(membership)
+    return HouseAdminResponse(
+        membership_id=membership.id,
+        user_id=user.id,
+        username=user.username,
+        house_id=external_id,
+    )
+
+
+__all__ = ["router"]

--- a/Server/app/templates/index.html
+++ b/Server/app/templates/index.html
@@ -3,6 +3,9 @@
 <div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
   <h2 class="text-2xl font-semibold">My Houses</h2>
   <div class="flex items-center gap-2">
+    {% if show_server_admin %}
+    <a href="/server-admin" class="px-4 py-2 pill bg-amber-600 hover:bg-amber-500">Server Admin</a>
+    {% endif %}
     {% if show_admin %}
     <a href="/admin" class="px-4 py-2 pill bg-slate-700 hover:bg-slate-600">Admin Panel</a>
     {% endif %}

--- a/Server/app/templates/server_admin.html
+++ b/Server/app/templates/server_admin.html
@@ -1,0 +1,261 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="mb-6 flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+  <div>
+    <h2 class="text-3xl font-semibold">Server Administration</h2>
+    <p class="text-sm opacity-70">Global overview of houses, nodes, and user accounts.</p>
+  </div>
+  <div class="glass rounded-xl px-4 py-2 text-sm opacity-80">
+    <div>Total houses: {{ houses|length }}</div>
+    <div>Total nodes: {{ total_nodes }}</div>
+  </div>
+</div>
+
+<section class="space-y-4" aria-labelledby="housesHeading">
+  <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+    <div>
+      <h3 id="housesHeading" class="text-2xl font-semibold">Houses</h3>
+      <p class="text-sm opacity-70">Public identifiers should be rotated if exposed.</p>
+    </div>
+    <div class="text-xs opacity-60 md:text-right">
+      Reveal IDs only when necessary. Treat them as secrets for OTA access.
+    </div>
+  </div>
+  {% if houses %}
+  <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3" data-house-grid>
+    {% for house in houses %}
+    <div class="glass rounded-xl p-4 space-y-3" data-house-card data-current-id="{{ house.external_id }}">
+      <div class="flex flex-col gap-2">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <div class="text-lg font-semibold">{{ house.name }}</div>
+            <div class="text-xs opacity-70">Slug: {{ house.slug or '—' }}</div>
+          </div>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              class="px-3 py-1 pill text-xs font-semibold bg-slate-700 hover:bg-slate-600"
+              data-reveal-id>
+              Reveal ID
+            </button>
+            <button
+              type="button"
+              class="px-3 py-1 pill text-xs font-semibold bg-amber-600 hover:bg-amber-500"
+              data-rotate-id
+              data-house-name="{{ house.name }}">
+              Rotate ID
+            </button>
+          </div>
+        </div>
+        <div class="text-xs opacity-70">Rooms: {{ house.room_count }} • Nodes: {{ house.node_count }}</div>
+      </div>
+      <div class="rounded bg-slate-900/60 border border-amber-500/60 px-3 py-2 text-xs space-y-2 hidden" data-id-panel>
+        <div class="text-amber-400 font-semibold">Warning: Rotating the ID invalidates existing links. Share with trusted admins only.</div>
+        <div class="font-mono break-words" data-id-value>{{ house.external_id }}</div>
+      </div>
+      <div class="space-y-2">
+        <div class="text-xs uppercase opacity-60">Nodes</div>
+        {% if house.nodes %}
+        <ul class="space-y-2 text-sm" data-node-list>
+          {% for node in house.nodes %}
+          <li class="border border-slate-800/60 rounded px-3 py-2" data-node-entry>
+            <div class="font-semibold">{{ node.name }}</div>
+            <div class="text-xs opacity-70">ID: <span class="font-mono">{{ node.id }}</span></div>
+            <div class="text-xs opacity-70">Room: {{ node.room }}{% if node.kind %} • {{ node.kind }}{% endif %}</div>
+          </li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        <div class="text-xs opacity-60">No nodes registered.</div>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="glass rounded-xl p-6 text-center text-sm opacity-70">No houses configured.</div>
+  {% endif %}
+</section>
+
+<section class="mt-12 grid gap-6 md:grid-cols-2" aria-labelledby="accountHeading">
+  <div class="space-y-4">
+    <div>
+      <h3 id="accountHeading" class="text-2xl font-semibold">Accounts</h3>
+      <p class="text-sm opacity-70">Server admins appear with a badge.</p>
+    </div>
+    <div class="space-y-3" data-account-list>
+      {% if accounts %}
+      {% for account in accounts %}
+      <div class="glass rounded-xl p-4">
+        <div class="flex flex-col gap-2">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <div class="text-lg font-semibold">{{ account.username }}</div>
+              {% if account.server_admin %}
+              <div class="text-xs font-semibold text-amber-400">Server admin</div>
+              {% else %}
+              <div class="text-xs opacity-60">House member</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="text-xs opacity-70">
+            {% if account.assignments %}
+            Houses: {{ account.assignments | map(attribute='house_name') | join(', ') }}
+            {% else %}
+            No house assignments.
+            {% endif %}
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+      {% else %}
+      <div class="glass rounded-xl p-4 text-sm opacity-70 text-center">No accounts found.</div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="glass rounded-xl p-4 space-y-4" data-create-admin>
+    <div>
+      <h4 class="text-xl font-semibold">Create house administrator</h4>
+      <p class="text-xs opacity-70">Creates a new account with full access to a selected house.</p>
+    </div>
+    <form class="space-y-4" data-create-admin-form>
+      <label class="block text-sm font-semibold">
+        <span>House</span>
+        <select name="house" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" required>
+          {% for option in house_options %}
+          <option value="{{ option.id }}">{{ option.name }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="block text-sm font-semibold">
+        <span>Username</span>
+        <input type="text" name="username" required class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" autocomplete="off">
+      </label>
+      <label class="block text-sm font-semibold">
+        <span>Password</span>
+        <input type="password" name="password" required class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" autocomplete="new-password">
+      </label>
+      <div class="flex items-center gap-3">
+        <button type="submit" class="px-4 py-2 pill bg-emerald-600 hover:bg-emerald-500 text-sm font-semibold">Create admin</button>
+        <div class="text-xs opacity-70" data-create-admin-status></div>
+      </div>
+    </form>
+  </div>
+</section>
+
+<section class="mt-12 space-y-3" aria-labelledby="auditHeading">
+  <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+    <div>
+      <h3 id="auditHeading" class="text-2xl font-semibold">Recent audit log</h3>
+      <p class="text-sm opacity-70">Latest privileged actions are recorded for accountability.</p>
+    </div>
+    <div class="text-xs opacity-60 md:text-right">Only the last 10 entries are shown.</div>
+  </div>
+  {% if audit_entries %}
+  <div class="grid gap-3">
+    {% for entry in audit_entries %}
+    <div class="glass rounded-xl p-4 text-sm">
+      <div class="flex flex-col gap-1">
+        <div class="font-semibold">{{ entry.summary or entry.action }}</div>
+        <div class="text-xs opacity-70">{{ entry.created_at }}{% if entry.actor %} • {{ entry.actor }}{% endif %}</div>
+        {% if entry.data %}
+        <div class="text-xs font-mono break-words opacity-70">{{ entry.data | tojson }}</div>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="glass rounded-xl p-4 text-sm opacity-70 text-center">No audit entries yet.</div>
+  {% endif %}
+</section>
+
+<script>
+const houseCards = Array.from(document.querySelectorAll('[data-house-card]'));
+houseCards.forEach((card) => {
+  const revealButton = card.querySelector('[data-reveal-id]');
+  const panel = card.querySelector('[data-id-panel]');
+  const rotateButton = card.querySelector('[data-rotate-id]');
+
+  if (revealButton && panel) {
+    revealButton.addEventListener('click', () => {
+      panel.classList.remove('hidden');
+      revealButton.classList.add('hidden');
+    });
+  }
+
+  if (rotateButton) {
+    rotateButton.addEventListener('click', async () => {
+      const houseName = rotateButton.dataset.houseName || 'this house';
+      const currentId = card.getAttribute('data-current-id');
+      if (!currentId) return;
+      const confirmed = window.confirm(`Rotate the public ID for ${houseName}? This will invalidate existing bookmarks.`);
+      if (!confirmed) return;
+      rotateButton.disabled = true;
+      rotateButton.textContent = 'Rotating…';
+      try {
+        const res = await fetch(`/api/server-admin/houses/${encodeURIComponent(currentId)}/rotate-id`, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({confirm: true})
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const data = await res.json();
+        card.setAttribute('data-current-id', data.newId);
+        const idValue = card.querySelector('[data-id-value]');
+        if (idValue) {
+          idValue.textContent = data.newId;
+        }
+        window.alert('House ID rotated. Page will refresh to update references.');
+        window.location.reload();
+      } catch (err) {
+        console.error('Failed to rotate house id', err);
+        window.alert('Unable to rotate house id. Please try again.');
+      } finally {
+        rotateButton.disabled = false;
+        rotateButton.textContent = 'Rotate ID';
+      }
+    });
+  }
+});
+
+const createForm = document.querySelector('[data-create-admin-form]');
+if (createForm) {
+  const statusLabel = createForm.querySelector('[data-create-admin-status]');
+  createForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const formData = new FormData(createForm);
+    const houseId = formData.get('house');
+    const username = formData.get('username');
+    const password = formData.get('password');
+    if (!houseId || !username || !password) {
+      return;
+    }
+    const confirmed = window.confirm(`Create a new administrator '${username}' for this house?`);
+    if (!confirmed) return;
+    statusLabel.textContent = 'Creating…';
+    try {
+      const res = await fetch(`/api/server-admin/houses/${encodeURIComponent(houseId)}/admins`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({username, password})
+      });
+      if (!res.ok) {
+        const message = await res.text();
+        throw new Error(message || `HTTP ${res.status}`);
+      }
+      statusLabel.textContent = 'Admin created';
+      createForm.reset();
+      window.setTimeout(() => {
+        statusLabel.textContent = '';
+      }, 3000);
+    } catch (err) {
+      console.error('Failed to create house admin', err);
+      statusLabel.textContent = 'Failed to create admin';
+    }
+  });
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add an audit log model and helper so privileged actions are recorded
- add a server admin dashboard summarizing houses, nodes, accounts, and audit history with warnings about house IDs
- expose server-admin-only APIs for rotating house IDs and creating house admins, and cover new access rules with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d32f71df7083268abbeb391ff68722