### PR TITLE
Revamp authenticated navigation and tests

### DIFF
--- a/Server/app/static/presets.js
+++ b/Server/app/static/presets.js
@@ -260,8 +260,8 @@ if (container) {
     container.appendChild(fragment);
   };
 
-  const fetchJson = async (url, options) => {
-    const response = await fetch(url, options);
+  const fetchJson = async (url, options = {}) => {
+    const response = await fetch(url, { credentials: 'same-origin', ...options });
     let data = null;
     try {
       data = await response.json();

--- a/Server/app/templates/admin.html
+++ b/Server/app/templates/admin.html
@@ -339,7 +339,7 @@ dots.forEach((dot) => setDot(dot, false));
 
 async function refreshStatuses() {
   try {
-    const res = await fetch(STATUS_URL);
+    const res = await fetch(STATUS_URL, { credentials: 'same-origin' });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     errorEl.classList.add('hidden');
@@ -459,7 +459,10 @@ if (roomMenuContainer) {
         btn.disabled = true;
         btn.textContent = 'Deleting…';
         try {
-          const res = await fetch(`/api/house/${encodeURIComponent(STATUS_HOUSE_ID)}/rooms/${encodeURIComponent(roomId)}`, { method: 'DELETE' });
+          const res = await fetch(`/api/house/${encodeURIComponent(STATUS_HOUSE_ID)}/rooms/${encodeURIComponent(roomId)}`, {
+            method: 'DELETE',
+            credentials: 'same-origin'
+          });
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           location.reload();
         } catch (err) {
@@ -483,7 +486,10 @@ document.querySelectorAll('[data-node-ota]').forEach((btn) => {
     btn.disabled = true;
     btn.textContent = 'Checking…';
     try {
-      const res = await fetch(`/api/node/${encodeURIComponent(nodeId)}/ota/check`, { method: 'POST' });
+      const res = await fetch(`/api/node/${encodeURIComponent(nodeId)}/ota/check`, {
+        method: 'POST',
+        credentials: 'same-origin'
+      });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       btn.textContent = 'Queued!';
       setTimeout(() => { btn.textContent = original; btn.disabled = false; }, 1500);
@@ -510,7 +516,10 @@ document.querySelectorAll('[data-node-remove]').forEach((btn) => {
     btn.textContent = 'Removing…';
     const card = btn.closest('[data-node-card]');
     try {
-      const res = await fetch(`/api/node/${encodeURIComponent(nodeId)}`, { method: 'DELETE' });
+      const res = await fetch(`/api/node/${encodeURIComponent(nodeId)}`, {
+        method: 'DELETE',
+        credentials: 'same-origin'
+      });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       if (card) {
         card.remove();
@@ -618,6 +627,7 @@ if (houseAdminSection) {
           {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
             body: JSON.stringify(payload),
           },
         );
@@ -660,7 +670,7 @@ if (houseAdminSection) {
       try {
         const res = await fetch(
           `/api/house-admin/${encodeURIComponent(houseId)}/members/${encodeURIComponent(membershipId)}`,
-          { method: 'DELETE' },
+          { method: 'DELETE', credentials: 'same-origin' },
         );
         if (!res.ok) {
           const message = await readErrorMessage(res);
@@ -713,6 +723,7 @@ if (houseAdminSection) {
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
             body: JSON.stringify({ username, password, role, rooms }),
           },
         );

--- a/Server/app/templates/base.html
+++ b/Server/app/templates/base.html
@@ -15,15 +15,127 @@
   .pill { border-radius: 9999px; }
 </style>
 </head>
+{% set has_nav = nav is defined and nav %}
 <body class="min-h-screen bg-slate-950 text-slate-100">
-  <header class="py-8 text-center">
-    <h1 class="text-4xl md:text-6xl font-extrabold neon">UltraLights</h1>
-    <p class="opacity-70 mt-1">{{ subtitle or "" }}</p>
-    <nav class="mt-3 opacity-80"><a class="underline hover:no-underline" href="/dashboard">Home</a></nav>
-  </header>
-  <main class="max-w-6xl mx-auto px-4 pb-20">
-    {% block content %}{% endblock %}
-  </main>
-  <footer class="text-center text-xs opacity-60 py-6">Made with ✨ FastAPI • MQTT • HTTPS</footer>
+  <div class="min-h-screen flex flex-col lg:flex-row">
+    {% if has_nav %}
+    <aside class="w-full lg:w-80 xl:w-96 bg-slate-950/70 border-b lg:border-b-0 lg:border-r border-slate-800/60" aria-label="Primary navigation">
+      <div class="h-full flex flex-col gap-6 px-6 py-8">
+        <div>
+          <div class="text-xs uppercase tracking-wide text-slate-500">Signed in</div>
+          <div class="mt-1 text-lg font-semibold" data-nav-username>{{ nav.username }}</div>
+          {% if nav.active_house %}
+          <div class="mt-5">
+            <div class="text-xs uppercase tracking-wide text-slate-500">Active house</div>
+            <a href="{{ nav.active_house.url }}" class="mt-1 block text-2xl font-semibold text-slate-100 hover:text-indigo-100" data-nav-active-house>
+              {{ nav.active_house.name }}
+            </a>
+          </div>
+          {% else %}
+          <p class="mt-5 text-sm text-slate-400">Select a house below to begin.</p>
+          {% endif %}
+        </div>
+        <nav class="flex-1 overflow-y-auto pr-2" data-nav-houses>
+          <div class="text-xs uppercase tracking-wide text-slate-500 mb-3">Houses</div>
+          {% if nav.houses %}
+          <ul class="space-y-4">
+            {% for house in nav.houses %}
+            <li class="space-y-2" data-nav-house="{{ house.id }}">
+              <a href="{{ house.url }}" class="block rounded-2xl border px-4 py-3 transition {{ 'border-indigo-500/70 bg-indigo-600/15 text-indigo-100 shadow-lg shadow-indigo-600/20' if house.is_active else 'border-slate-800/80 bg-slate-900/60 hover:border-indigo-500/50 hover:bg-slate-900/80' }}" data-nav-house-link="{{ house.id }}">
+                <div class="text-sm font-semibold leading-tight">{{ house.name }}</div>
+              </a>
+              {% if house.rooms %}
+              <ul class="ml-3 border-l border-slate-800/60 pl-3 space-y-1" data-nav-room-list="{{ house.id }}">
+                {% for room in house.rooms %}
+                <li data-nav-room-id="{{ room.id }}">
+                  <a href="{{ room.url }}" class="block rounded-xl px-3 py-1 text-sm transition {{ 'bg-indigo-500/20 text-indigo-100' if room.is_active else 'text-slate-300 hover:bg-slate-800/60 hover:text-slate-100' }}" data-nav-room-link="{{ room.id }}">
+                    {{ room.name }}
+                  </a>
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}
+              <div class="ml-3 text-xs text-slate-500" data-nav-empty-rooms>No rooms assigned</div>
+              {% endif %}
+              {% if house.admin_url %}
+              <a href="{{ house.admin_url }}" class="inline-flex items-center gap-2 rounded-xl border border-slate-800/70 bg-slate-900/60 px-3 py-1.5 text-xs font-semibold text-slate-200 hover:border-indigo-400 hover:text-indigo-100" data-nav-house-admin="{{ house.id }}">
+                Manage house
+              </a>
+              {% endif %}
+            </li>
+            {% endfor %}
+          </ul>
+          {% else %}
+          <p class="text-sm text-slate-400">No houses assigned to your account.</p>
+          {% endif %}
+        </nav>
+        <div class="flex flex-col gap-2 pt-2 border-t border-slate-800/60">
+          {% if nav.show_admin %}
+          <a href="/admin" class="w-full text-center rounded-xl border border-slate-800/70 bg-slate-900/70 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-indigo-100" data-nav-admin-link>
+            Admin Panel
+          </a>
+          {% endif %}
+          {% if nav.show_server_admin %}
+          <a href="/server-admin" class="w-full text-center rounded-xl border border-amber-400/60 bg-amber-500/20 px-4 py-2 text-sm font-semibold text-amber-100 transition hover:bg-amber-500/30" data-nav-server-admin-link>
+            Server Admin
+          </a>
+          {% endif %}
+          {% if nav.can_all_off %}
+          <button type="button" class="w-full rounded-xl border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-sm font-semibold text-rose-100 transition hover:bg-rose-500/30" data-nav-all-off>
+            All Off
+          </button>
+          {% endif %}
+          <a href="{{ nav.logout_url }}" class="w-full text-center rounded-xl border border-slate-800/70 bg-slate-950/70 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-indigo-100" data-nav-logout>
+            Sign out
+          </a>
+        </div>
+      </div>
+    </aside>
+    {% endif %}
+    <div class="flex-1 flex flex-col min-h-screen">
+      <header class="px-6 py-8 border-b border-slate-800/60">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 class="text-4xl md:text-5xl font-extrabold neon">UltraLights</h1>
+            {% if subtitle or title %}
+            <p class="opacity-70 mt-1 text-sm md:text-base">{{ subtitle or title }}</p>
+            {% endif %}
+          </div>
+          {% if not has_nav %}
+          <a href="/login" class="self-start rounded-full bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-500">Sign in</a>
+          {% endif %}
+        </div>
+      </header>
+      <main class="flex-1 px-4 py-8 md:px-10">
+        {% block content %}{% endblock %}
+      </main>
+      <footer class="text-center text-xs opacity-60 py-6">Made with ✨ FastAPI • MQTT • HTTPS</footer>
+    </div>
+  </div>
+  {% if has_nav and nav.can_all_off and nav.all_off_url %}
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const allOffButton = document.querySelector('[data-nav-all-off]');
+    if (!allOffButton) return;
+    allOffButton.addEventListener('click', async () => {
+      allOffButton.disabled = true;
+      try {
+        const response = await fetch('{{ nav.all_off_url }}', {
+          method: 'POST',
+          credentials: 'same-origin'
+        });
+        if (!response.ok) {
+          alert('Failed to turn everything off.');
+        }
+      } catch (error) {
+        console.error('Failed to trigger All Off', error);
+        alert('Failed to turn everything off.');
+      } finally {
+        allOffButton.disabled = false;
+      }
+    });
+  });
+  </script>
+  {% endif %}
 </body>
 </html>

--- a/Server/app/templates/house.html
+++ b/Server/app/templates/house.html
@@ -31,7 +31,10 @@ if(addRoomButton){
     const name = prompt('New room name');
     if(!name) return;
     const res = await fetch('/api/house/{{ house_public_id }}/rooms', {
-      method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name})
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      credentials: 'same-origin',
+      body: JSON.stringify({name})
     });
     if(res.ok) location.reload(); else alert('Failed to add room');
   };
@@ -55,6 +58,7 @@ if(grid && grid.dataset.canManage === 'true'){
       const res = await fetch('/api/house/{{ house_public_id }}/rooms/reorder', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
         body: JSON.stringify({order})
       });
       if(!res.ok){

--- a/Server/app/templates/index.html
+++ b/Server/app/templates/index.html
@@ -1,42 +1,47 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-  <h2 class="text-2xl font-semibold">My Houses</h2>
-  <div class="flex items-center gap-2">
-    {% if show_server_admin %}
-    <a href="/server-admin" class="px-4 py-2 pill bg-amber-600 hover:bg-amber-500">Server Admin</a>
-    {% endif %}
-    {% if show_admin %}
-    <a href="/admin" class="px-4 py-2 pill bg-slate-700 hover:bg-slate-600">Admin Panel</a>
-    {% endif %}
-    {% if can_all_off %}
-    <button id="allOff" class="px-4 py-2 pill bg-rose-600 hover:bg-rose-500">All Off</button>
+{% set nav_data = nav if nav is defined else none %}
+<div class="max-w-3xl mx-auto">
+  <div class="glass rounded-3xl p-8 space-y-6">
+    <h2 class="text-3xl font-semibold text-center">Welcome{% if nav_data and nav_data.username %} {{ nav_data.username }}{% endif %}</h2>
+    <p class="text-center text-slate-300 text-sm md:text-base">
+      Use the navigation menu to choose a house or room to control.
+    </p>
+    {% if nav_data and nav_data.houses %}
+    <div class="space-y-4">
+      <h3 class="text-xl font-semibold text-slate-100 text-center md:text-left">Available houses</h3>
+      <ul class="space-y-4">
+        {% for house in nav_data.houses %}
+        <li class="rounded-2xl border border-slate-800/70 bg-slate-900/60 px-5 py-4 space-y-3" data-dashboard-house="{{ house.id }}">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div class="flex items-center gap-2">
+              <span class="text-base font-semibold">{{ house.name }}</span>
+              {% if house.is_active %}
+              <span class="inline-flex items-center gap-1 rounded-full bg-indigo-500/20 px-2 py-0.5 text-xs text-indigo-100" data-dashboard-active>Active</span>
+              {% endif %}
+            </div>
+            <a href="{{ house.url }}" class="text-sm font-semibold text-indigo-300 hover:text-indigo-200" data-dashboard-house-link="{{ house.id }}">Open house</a>
+          </div>
+          {% if house.rooms %}
+          <div class="flex flex-wrap gap-2" data-dashboard-rooms="{{ house.id }}">
+            {% for room in house.rooms %}
+            <a href="{{ room.url }}" class="rounded-full border border-slate-800/70 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-indigo-100 {% if room.is_active %}bg-indigo-500/20 text-indigo-100 border-indigo-400{% endif %}" data-dashboard-room="{{ room.id }}">
+              {{ room.name }}
+            </a>
+            {% endfor %}
+          </div>
+          {% else %}
+          <p class="text-xs text-slate-400">No rooms assigned yet.</p>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% else %}
+    <div class="rounded-2xl border border-slate-800/70 bg-slate-900/60 px-5 py-6 text-center text-sm text-slate-300">
+      Your account is not currently assigned to any houses. Please contact an administrator for access.
+    </div>
     {% endif %}
   </div>
 </div>
-
-{% if houses %}
-<div class="grid md:grid-cols-3 gap-4 mt-6">
-  {% for h in houses %}
-  <a href="/house/{{ h.external_id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400">
-    <div class="text-xl font-semibold">{{ h.name }}</div>
-    <div class="opacity-60 text-xs mt-2">Public ID: {{ h.external_id }}</div>
-    <div class="text-sm mt-2">{{ h.rooms|length }} room{% if h.rooms|length != 1 %}s{% endif %}</div>
-  </a>
-  {% endfor %}
-</div>
-{% else %}
-<div class="glass rounded-xl p-6 text-center text-sm opacity-70">
-  No houses assigned to your account yet.
-</div>
-{% endif %}
-
-{% if can_all_off %}
-<script>
-document.getElementById('allOff').onclick = async () => {
-  const res = await fetch('/api/all-off', {method:'POST'});
-  if(!res.ok){ alert('Failed to turn all off'); }
-};
-</script>
-{% endif %}
 {% endblock %}

--- a/Server/app/templates/modules/motion.html
+++ b/Server/app/templates/modules/motion.html
@@ -12,7 +12,7 @@
 <script>
 const motion=document.getElementById('motion');
 const duration=document.getElementById('motionDuration');
-async function post(path, body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+async function post(path, body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},credentials:'same-origin',body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
 async function send(){await post(`/api/node/{{ node.id }}/motion`,{enabled:motion.checked,duration:parseInt(duration.value)});}
 motion.addEventListener('change',send);
 duration.addEventListener('change',send);

--- a/Server/app/templates/modules/ota.html
+++ b/Server/app/templates/modules/ota.html
@@ -3,6 +3,6 @@
   <button id="btnCheck" class="px-5 py-2 pill bg-amber-500 hover:bg-amber-400 text-white">Check Now</button>
 </section>
 <script>
-async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
+async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},credentials:'same-origin',body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
 document.getElementById('btnCheck').onclick=async()=>{await post(`/api/node/{{ node.id }}/ota/check`,{});};
 </script>

--- a/Server/app/templates/modules/rgb.html
+++ b/Server/app/templates/modules/rgb.html
@@ -143,6 +143,7 @@ class RgbModuleManager {
     return fetch(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
       body: JSON.stringify(body),
     }).then((res) => {
       if (!res.ok) {

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -144,6 +144,7 @@ class WhiteModuleManager {
     return fetch(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
       body: JSON.stringify(body),
     }).then((res) => {
       if (!res.ok) {

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -150,6 +150,7 @@ class WsModuleManager {
     return fetch(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
       body: JSON.stringify(body),
     }).then((res) => {
       if (!res.ok) {

--- a/Server/app/templates/node.html
+++ b/Server/app/templates/node.html
@@ -168,6 +168,7 @@ async function submitNodeName() {
     const res = await fetch(`/api/node/${encodeURIComponent(STATUS_NODE_ID)}/name`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
       body: JSON.stringify({ name: desiredName }),
     });
     if (!res.ok) {
@@ -290,7 +291,7 @@ setDot({{ status_initial_online|tojson }});
 async function refreshStatus() {
   if (!statusDot) return;
   try {
-    const res = await fetch(STATUS_URL, { cache: 'no-store' });
+    const res = await fetch(STATUS_URL, { cache: 'no-store', credentials: 'same-origin' });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     setDot(Boolean(data.online));
@@ -324,7 +325,7 @@ function applyModuleVisibility(modulesList) {
 async function refreshState() {
   setModuleStateMessage('Loading module state…');
   try {
-    const res = await fetch(STATE_URL, { cache: 'no-store' });
+    const res = await fetch(STATE_URL, { cache: 'no-store', credentials: 'same-origin' });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     if (!data || typeof data !== 'object') {

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -161,6 +161,7 @@ if(addNodeButton){
       res = await fetch('/api/house/{{ house_public_id }}/room/{{ room.id }}/nodes', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
         body: JSON.stringify({name}),
       });
     } catch (error) {
@@ -500,6 +501,7 @@ if(addNodeButton){
         const response = await fetch(colorUrl, {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
+          credentials: 'same-origin',
           body: JSON.stringify({preset: presetId, color: selected}),
         });
         let data = null;
@@ -806,6 +808,7 @@ if(addNodeButton){
           const response = await fetch(saveUrl, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
+            credentials: 'same-origin',
             body: JSON.stringify({schedule: scheduleData}),
           });
           let data = null;
@@ -923,7 +926,7 @@ if(addNodeButton){
         setStatus('Loading immunity...', 'info');
       }
       try {
-        const response = await fetch(fetchUrl);
+        const response = await fetch(fetchUrl, { credentials: 'same-origin' });
         let data = null;
         try {
           data = await response.json();
@@ -960,6 +963,7 @@ if(addNodeButton){
           const response = await fetch(saveUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
             body: JSON.stringify({ immune: selected }),
           });
           let data = null;
@@ -1027,6 +1031,7 @@ if(addNodeButton){
         const res = await fetch(`/api/node/${nodeId}/motion`, {
           method:'POST',
           headers:{'Content-Type':'application/json'},
+          credentials: 'same-origin',
           body: JSON.stringify({enabled, duration})
         });
         if(!res.ok) alert('Failed to update timer');

--- a/Server/app/templates/server_admin.html
+++ b/Server/app/templates/server_admin.html
@@ -197,6 +197,7 @@ houseCards.forEach((card) => {
         const res = await fetch(`/api/server-admin/houses/${encodeURIComponent(currentId)}/rotate-id`, {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
+          credentials: 'same-origin',
           body: JSON.stringify({confirm: true})
         });
         if (!res.ok) {
@@ -240,6 +241,7 @@ if (createForm) {
       const res = await fetch(`/api/server-admin/houses/${encodeURIComponent(houseId)}/admins`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
         body: JSON.stringify({username, password})
       });
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- replace the dashboard house grid with a welcome panel and a reusable authenticated navigation sidebar that lists houses, rooms, admin links, and logout actions
- feed navigation context into page responses, adjust templates and scripts to use same-origin fetch calls, and surface filtered data for guests and admins
- expand authorization coverage to assert navigation visibility per role and ensure access-scoped rendering

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d33268fb1883268c959e29754b606c