### PR TITLE
Allow house admins to manage memberships

### DIFF
--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -799,7 +799,7 @@ def admin_house_panel(
             house_memberships=memberships,
             house_member_options=available_room_options,
             house_member_roles=role_options,
-            house_member_manage_allowed=current_user.server_admin,
+            house_member_manage_allowed=house_ctx.access.can_manage(current_user),
             house_admin_external_id=house_ctx.external_id,
         )
         | nav_context,


### PR DESCRIPTION
## Summary
- replace the house admin API dependency with an AccessPolicy backed check that allows house admins to manage memberships
- update the admin house page to rely on the per-house access flag so delegated admins see management controls
- extend the house admin tests to cover delegated admins and ensure guests are rejected

## Testing
- pytest Server/tests/auth/test_house_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68d33abbb6c883268cb06fd03dab9d2c