### PR TITLE
Ensure house admin delete route has no response model

### DIFF
--- a/Server/app/routes_house_admin.py
+++ b/Server/app/routes_house_admin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlmodel import Session, delete, select
 
@@ -357,7 +357,12 @@ def update_member(
     return _serialize_member(membership, user, room_map, assigned_rooms)
 
 
-@router.delete("/{house_id}/members/{membership_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{house_id}/members/{membership_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_model=None,
+    response_class=Response,
+)
 def delete_member(
     house_id: str,
     membership_id: int,

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -5,5 +5,6 @@ paho-mqtt
 python-dotenv
 sqlmodel
 passlib[bcrypt]
-itsdangerous
+itsdangerous>=2.1.2,<3
 python-multipart
+httpx


### PR DESCRIPTION
## Summary
- ensure the house-admin delete membership endpoint disables its response model so FastAPI allows the 204 status

## Testing
- python -m pytest Server/tests/auth/test_house_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68d3125504988326a929b313138473d9