### PR TITLE
Remove node OTA module and expose all-off control

### DIFF
--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -44,7 +44,7 @@ from .brightness_limits import brightness_limits
 router = APIRouter()
 TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
-NODE_MODULE_TEMPLATES = ["ws", "rgb", "white", "ota", "motion"]
+NODE_MODULE_TEMPLATES = ["ws", "rgb", "white", "motion"]
 
 
 def _require_current_user(

--- a/Server/app/templates/base.html
+++ b/Server/app/templates/base.html
@@ -80,6 +80,13 @@
             Server Admin
           </a>
           {% endif %}
+          {% if nav.can_all_off and nav.all_off_url %}
+          <button
+            type="button"
+            class="w-full text-center rounded-xl border border-rose-500/60 bg-rose-500/20 px-4 py-2 text-sm font-semibold text-rose-100 transition hover:bg-rose-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
+            data-nav-all-off
+            data-nav-all-off-url="{{ nav.all_off_url }}">All Off</button>
+          {% endif %}
           <a href="{{ nav.logout_url }}" class="w-full text-center rounded-xl border border-slate-800/70 bg-slate-950/70 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-indigo-100" data-nav-logout>
             Sign out
           </a>
@@ -107,5 +114,43 @@
       <footer class="text-center text-xs opacity-60 py-6">Made with ✨ FastAPI • MQTT • HTTPS</footer>
     </div>
   </div>
+  {% if nav and nav.can_all_off and nav.all_off_url %}
+  <script>
+    (() => {
+      const button = document.querySelector('[data-nav-all-off]');
+      if (!button) return;
+      const url = button.dataset.navAllOffUrl;
+      if (!url) return;
+      let busy = false;
+      const defaultText = button.textContent.trim() || 'All Off';
+      button.addEventListener('click', async () => {
+        if (busy) return;
+        busy = true;
+        button.disabled = true;
+        button.textContent = 'Turning off…';
+        try {
+          const response = await fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+          });
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          button.textContent = 'All off sent';
+          window.setTimeout(() => {
+            button.textContent = defaultText;
+          }, 1600);
+        } catch (error) {
+          console.error('Failed to send all-off command', error);
+          window.alert('Failed to turn everything off. Please try again.');
+          button.textContent = defaultText;
+        } finally {
+          busy = false;
+          button.disabled = false;
+        }
+      });
+    })();
+  </script>
+  {% endif %}
 </body>
 </html>

--- a/Server/app/templates/modules/ota.html
+++ b/Server/app/templates/modules/ota.html
@@ -1,8 +1,0 @@
-<section class="glass rounded-2xl p-6">
-  <h3 class="text-lg font-semibold mb-3">OTA Update</h3>
-  <button id="btnCheck" class="px-5 py-2 pill bg-amber-500 hover:bg-amber-400 text-white">Check Now</button>
-</section>
-<script>
-async function post(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},credentials:'same-origin',body:JSON.stringify(body)});if(!res.ok){alert('Request failed');}}
-document.getElementById('btnCheck').onclick=async()=>{await post(`/api/node/{{ node.id }}/ota/check`,{});};
-</script>


### PR DESCRIPTION
## Summary
- remove the OTA module from the node page module template list so the check button no longer renders
- surface the server-wide "All Off" action in the navigation for server admins with a simple POST helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3679dbe7483269ca01db0135e3cb0