### PR TITLE
Refactor OTA credentials to use opaque node IDs

### DIFF
--- a/Server/app/auth/models.py
+++ b/Server/app/auth/models.py
@@ -124,11 +124,41 @@ class AuditLog(SQLModel, table=True):
     )
 
 
+class NodeCredential(SQLModel, table=True):
+    __tablename__ = "node_credentials"
+    __table_args__ = (
+        UniqueConstraint("download_id", name="uq_node_credentials_download_id"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    node_id: str = Field(
+        sa_column=Column(String(64), unique=True, nullable=False, index=True)
+    )
+    house_slug: str = Field(sa_column=Column(String(64), nullable=False))
+    room_id: str = Field(sa_column=Column(String(120), nullable=False))
+    display_name: str = Field(sa_column=Column(String(120), nullable=False))
+    download_id: str = Field(
+        sa_column=Column(String(64), unique=True, nullable=False, index=True)
+    )
+    token_hash: str = Field(sa_column=Column(String(64), nullable=False))
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow, sa_column=_timestamp_column()
+    )
+    token_issued_at: datetime = Field(
+        default_factory=datetime.utcnow, sa_column=_timestamp_column(onupdate=True)
+    )
+    provisioned_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+
+
 __all__ = [
     "AuditLog",
     "House",
     "HouseMembership",
     "HouseRole",
+    "NodeCredential",
     "RoomAccess",
     "User",
 ]

--- a/Server/app/auth/service.py
+++ b/Server/app/auth/service.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 from sqlmodel import SQLModel, Session, select
 
-from .. import registry
+from .. import node_credentials, registry
 from ..config import settings
 from .. import database
 from .models import AuditLog, House, User
@@ -20,6 +20,7 @@ def init_auth_storage() -> None:
     with database.SessionLocal() as session:
         _seed_initial_admin(session)
         _sync_registry_houses(session)
+        _sync_registry_nodes(session)
 
 
 def _seed_initial_admin(session: Session) -> None:
@@ -60,6 +61,12 @@ def _sync_registry_houses(session: Session) -> None:
         session.add(House(display_name=display_name, external_id=external_id))
 
     session.commit()
+
+
+def _sync_registry_nodes(session: Session) -> None:
+    """Ensure credential rows exist for every registry node."""
+
+    node_credentials.sync_registry_nodes(session)
 
 
 def create_user(

--- a/Server/app/device_registry.json
+++ b/Server/app/device_registry.json
@@ -8,7 +8,7 @@
         "name": "Cocina",
         "nodes": [
           {
-            "id": "del-sur-kitchen",
+            "id": "1j1mmiwwxw2eg9jlbmjric",
             "name": "Kitchen",
             "kind": "ultranode",
             "modules": [
@@ -16,10 +16,11 @@
               "rgb",
               "white",
               "ota"
-            ]
+            ],
+            "download_id": "FH8ME2oulLnj0BtUhS7qQP"
           },
           {
-            "id": "del-sur-sala",
+            "id": "vs6l65mvud2kwmpinv1aj4",
             "name": "Sala",
             "kind": "ultranode",
             "modules": [
@@ -27,7 +28,8 @@
               "rgb",
               "white",
               "ota"
-            ]
+            ],
+            "download_id": "3KIeE6s9eHCFrsTHhjEMvk"
           }
         ]
       },
@@ -36,7 +38,7 @@
         "name": "Master",
         "nodes": [
           {
-            "id": "del-sur-master-tv",
+            "id": "b9na9ask79lvd42vy0102l",
             "name": "Master TV",
             "kind": "ultranode",
             "modules": [
@@ -44,10 +46,11 @@
               "rgb",
               "white",
               "ota"
-            ]
+            ],
+            "download_id": "fr537pB3AvXIDWOWDtSN0o"
           },
           {
-            "id": "del-sur-master-closet",
+            "id": "q5h9cx9anfvbr7gkqxrr2f",
             "name": "Master Closet",
             "kind": "ultranode",
             "modules": [
@@ -55,7 +58,8 @@
               "rgb",
               "white",
               "ota"
-            ]
+            ],
+            "download_id": "afcuWQ8BAQsptL6FVjIKA6"
           }
         ]
       },
@@ -64,7 +68,7 @@
         "name": "Edgar",
         "nodes": [
           {
-            "id": "del-sur-amp-lights",
+            "id": "wl63q4b3dsw4gbh1faq9lx",
             "name": "Amp Lights",
             "kind": "ultranode",
             "modules": [
@@ -72,7 +76,8 @@
               "rgb",
               "white",
               "ota"
-            ]
+            ],
+            "download_id": "YChhrHRqFjBCEFOz6Yyjg4"
           }
         ]
       }

--- a/Server/app/node_credentials.py
+++ b/Server/app/node_credentials.py
@@ -1,0 +1,292 @@
+"""Database-backed node credential helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, List, Optional, Tuple
+
+from sqlmodel import Session, select
+
+from . import registry
+from .auth.models import NodeCredential
+
+
+@dataclass
+class NodeCredentialWithToken:
+    """Return value that optionally includes a freshly issued token."""
+
+    credential: NodeCredential
+    plaintext_token: Optional[str]
+
+
+def _now() -> datetime:
+    return datetime.utcnow()
+
+
+def _first_result(result: Any) -> Any:
+    """Return the first item from a SQLModel result or stub."""
+
+    if hasattr(result, "first"):
+        return result.first()
+    if hasattr(result, "one_or_none"):
+        try:
+            return result.one_or_none()
+        except Exception:  # pragma: no cover - defensive fallback
+            pass
+    if hasattr(result, "all"):
+        rows = result.all()
+        return rows[0] if rows else None
+    try:
+        iterator = iter(result)
+    except TypeError:  # pragma: no cover - defensive
+        return None
+    return next(iterator, None)
+
+
+def _get_by_node_id(session: Session, node_id: str) -> Optional[NodeCredential]:
+    result = session.exec(
+        select(NodeCredential).where(NodeCredential.node_id == node_id)
+    )
+    return _first_result(result)
+
+
+def get_by_node_id(session: Session, node_id: str) -> Optional[NodeCredential]:
+    return _get_by_node_id(session, node_id)
+
+
+def get_by_download_id(session: Session, download_id: str) -> Optional[NodeCredential]:
+    result = session.exec(
+        select(NodeCredential).where(NodeCredential.download_id == download_id)
+    )
+    return _first_result(result)
+
+
+def get_by_token_hash(session: Session, token_hash: str) -> Optional[NodeCredential]:
+    result = session.exec(
+        select(NodeCredential).where(NodeCredential.token_hash == token_hash)
+    )
+    return _first_result(result)
+
+
+def any_tokens(session: Session) -> bool:
+    result = session.exec(select(NodeCredential.id))
+    return _first_result(result) is not None
+
+
+def ensure_for_node(
+    session: Session,
+    *,
+    node_id: str,
+    house_slug: str,
+    room_id: str,
+    display_name: str,
+    download_id: Optional[str] = None,
+    token_hash: Optional[str] = None,
+    rotate_token: bool = False,
+) -> NodeCredentialWithToken:
+    """Ensure a credential row exists for ``node_id`` and return it."""
+
+    credential = _get_by_node_id(session, node_id)
+    plaintext: Optional[str] = None
+
+    if credential:
+        changed = False
+        if credential.house_slug != house_slug:
+            credential.house_slug = house_slug
+            changed = True
+        if credential.room_id != room_id:
+            credential.room_id = room_id
+            changed = True
+        if credential.display_name != display_name:
+            credential.display_name = display_name
+            changed = True
+        if download_id and credential.download_id != download_id:
+            credential.download_id = download_id
+            changed = True
+
+        if rotate_token:
+            plaintext = registry.generate_node_token()
+            credential.token_hash = registry.hash_node_token(plaintext)
+            credential.token_issued_at = _now()
+            changed = True
+        elif token_hash and credential.token_hash != token_hash:
+            credential.token_hash = token_hash
+            credential.token_issued_at = _now()
+            changed = True
+
+        if changed:
+            session.add(credential)
+            session.commit()
+            session.refresh(credential)
+
+        return NodeCredentialWithToken(credential=credential, plaintext_token=plaintext)
+
+    if download_id is None:
+        download_id = registry.generate_download_id()
+
+    if rotate_token:
+        plaintext = registry.generate_node_token()
+        token_hash = registry.hash_node_token(plaintext)
+    elif token_hash is None:
+        plaintext = registry.generate_node_token()
+        token_hash = registry.hash_node_token(plaintext)
+    else:
+        plaintext = None
+
+    credential = NodeCredential(
+        node_id=node_id,
+        house_slug=house_slug,
+        room_id=room_id,
+        display_name=display_name,
+        download_id=download_id,
+        token_hash=token_hash,
+        created_at=_now(),
+        token_issued_at=_now(),
+    )
+    session.add(credential)
+    session.commit()
+    session.refresh(credential)
+
+    return NodeCredentialWithToken(credential=credential, plaintext_token=plaintext)
+
+
+def rotate_token(
+    session: Session, node_id: str, *, token: Optional[str] = None
+) -> Tuple[NodeCredential, str]:
+    credential = _get_by_node_id(session, node_id)
+    if credential is None:
+        raise KeyError("node credentials not found")
+
+    plaintext = token or registry.generate_node_token()
+    credential.token_hash = registry.hash_node_token(plaintext)
+    credential.token_issued_at = _now()
+    session.add(credential)
+    session.commit()
+    session.refresh(credential)
+    return credential, plaintext
+
+
+def update_download_id(
+    session: Session, node_id: str, download_id: Optional[str] = None
+) -> NodeCredential:
+    credential = _get_by_node_id(session, node_id)
+    if credential is None:
+        raise KeyError("node credentials not found")
+
+    new_download = download_id or registry.generate_download_id()
+    credential.download_id = new_download
+    session.add(credential)
+    session.commit()
+    session.refresh(credential)
+    return credential
+
+
+def mark_provisioned(
+    session: Session, node_id: str, *, timestamp: Optional[datetime] = None
+) -> NodeCredential:
+    credential = _get_by_node_id(session, node_id)
+    if credential is None:
+        raise KeyError("node credentials not found")
+
+    credential.provisioned_at = timestamp or _now()
+    session.add(credential)
+    session.commit()
+    session.refresh(credential)
+    return credential
+
+
+def clear_provisioned(session: Session, node_id: str) -> NodeCredential:
+    credential = _get_by_node_id(session, node_id)
+    if credential is None:
+        raise KeyError("node credentials not found")
+
+    credential.provisioned_at = None
+    session.add(credential)
+    session.commit()
+    session.refresh(credential)
+    return credential
+
+
+def delete_credentials(session: Session, node_id: str) -> None:
+    credential = _get_by_node_id(session, node_id)
+    if credential is None:
+        return
+    session.delete(credential)
+    session.commit()
+
+
+def list_unprovisioned(session: Session) -> List[NodeCredential]:
+    return session.exec(
+        select(NodeCredential).where(NodeCredential.provisioned_at.is_(None))
+    ).all()
+
+
+def sync_registry_nodes(session: Session) -> None:
+    """Ensure every registry node has a credential entry and synced download id."""
+
+    registry.ensure_house_external_ids(persist=False)
+
+    changed = False
+    for house, room, node in registry.iter_nodes():
+        node_id = str(node.get("id") or "").strip()
+        if not node_id:
+            continue
+
+        house_slug = registry.get_house_slug(house)
+        room_id = str(room.get("id") or "").strip()
+        display_name = str(node.get("name") or node_id)
+
+        raw_download = node.get(registry.NODE_DOWNLOAD_ID_KEY)
+        download_id = str(raw_download).strip() if isinstance(raw_download, str) else None
+        if download_id and any(
+            ch not in registry.DOWNLOAD_ID_ALPHABET for ch in download_id
+        ):
+            download_id = None
+
+        raw_token_hash = node.get(registry.NODE_TOKEN_HASH_KEY)
+        token_hash = (
+            str(raw_token_hash).strip()
+            if isinstance(raw_token_hash, str) and raw_token_hash
+            else None
+        )
+
+        existing = get_by_node_id(session, node_id)
+        ensured = ensure_for_node(
+            session,
+            node_id=node_id,
+            house_slug=house_slug,
+            room_id=room_id,
+            display_name=display_name,
+            download_id=download_id if existing is None or not existing.download_id else None,
+            token_hash=token_hash if existing is None or not existing.token_hash else None,
+        )
+
+        credential = ensured.credential
+        if credential.download_id != download_id:
+            node[registry.NODE_DOWNLOAD_ID_KEY] = credential.download_id
+            changed = True
+
+        if registry.NODE_TOKEN_HASH_KEY in node:
+            node.pop(registry.NODE_TOKEN_HASH_KEY, None)
+            changed = True
+
+    if changed:
+        registry.save_registry()
+
+
+__all__ = [
+    "NodeCredentialWithToken",
+    "any_tokens",
+    "clear_provisioned",
+    "delete_credentials",
+    "ensure_for_node",
+    "get_by_node_id",
+    "get_by_download_id",
+    "get_by_token_hash",
+    "list_unprovisioned",
+    "mark_provisioned",
+    "rotate_token",
+    "sync_registry_nodes",
+    "update_download_id",
+]

--- a/Server/app/ota.py
+++ b/Server/app/ota.py
@@ -1,9 +1,20 @@
-import hmac, hashlib, mimetypes, os
-from pathlib import Path
+import hashlib
+import hmac
+import json
+import mimetypes
+import os
 from datetime import datetime, timezone
-from typing import Optional
-from fastapi import APIRouter, Request, Header, HTTPException, Response
+from pathlib import Path
+from typing import Optional, Tuple
+
+from fastapi import APIRouter, Header, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
+
+from sqlalchemy.exc import OperationalError
+from sqlmodel import Session, SQLModel
+
+from . import database, node_credentials, registry
+from .auth.service import init_auth_storage
 from .config import settings
 
 router = APIRouter()
@@ -11,15 +22,7 @@ router = APIRouter()
 # If you have a central config module, prefer importing from it:
 # from .config import FIRMWARE_DIR, PUBLIC_BASE, API_BEARER, MANIFEST_HMAC_SECRET, LAN_PUBLIC_BASE
 
-# Otherwise, read from environment with sensible defaults:
-FIRMWARE_DIR = Path(os.getenv("FIRMWARE_DIR", "/srv/firmware"))
-FIRMWARE_DIR.mkdir(parents=True, exist_ok=True)
-
-PUBLIC_BASE = os.getenv("PUBLIC_BASE", "https://lights.evm100.org")
-API_BEARER = os.getenv("API_BEARER", "")
-MANIFEST_HMAC_SECRET = os.getenv("MANIFEST_HMAC_SECRET", "")
-LAN_PUBLIC_BASE = os.getenv("LAN_PUBLIC_BASE", "")  # keep if you use split-horizon override
-
+FIRMWARE_DIR = settings.FIRMWARE_DIR
 LAN_PUBLIC_BASE = os.getenv("LAN_PUBLIC_BASE", "")  # e.g. https://lan.lights.evm100.org
 
 def latest_symlink_for(dev_id: str) -> Path:
@@ -38,12 +41,109 @@ def _resolve_latest(device_id: str) -> Path:
                 return target
     raise HTTPException(status_code=404, detail=f"No firmware for device_id={device_id}")
 
-def _require_bearer(auth_header: Optional[str]):
-    if not settings.API_BEARER: return
-    if not auth_header or not auth_header.startswith("Bearer "):
+def _authenticate_request(
+    auth_header: Optional[str], session: Session
+) -> Tuple[Optional[node_credentials.NodeCredential], str]:
+    """Return the node associated with ``auth_header`` if applicable."""
+
+    require_auth = bool(settings.API_BEARER or node_credentials.any_tokens(session))
+
+    if not auth_header:
+        if require_auth:
+            raise HTTPException(status_code=401, detail="Missing bearer token")
+        return None, "open"
+
+    if not auth_header.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing bearer token")
-    if auth_header.split(" ",1)[1] != settings.API_BEARER:
-        raise HTTPException(status_code=403, detail="Invalid bearer token")
+
+    token = auth_header.split(" ", 1)[1].strip()
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+
+    if settings.API_BEARER and hmac.compare_digest(token, settings.API_BEARER):
+        return None, "global"
+
+    try:
+        token_hash = registry.hash_node_token(token)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Invalid bearer token") from None
+
+    try:
+        credential = node_credentials.get_by_token_hash(session, token_hash)
+    except OperationalError:
+        session.rollback()
+        init_auth_storage()
+        SQLModel.metadata.create_all(session.get_bind())
+        credential = node_credentials.get_by_token_hash(session, token_hash)
+    if credential:
+        return credential, "node"
+
+    raise HTTPException(status_code=403, detail="Invalid bearer token")
+
+
+def _resolve_access_context(
+    *,
+    authorization: Optional[str],
+    device_id: Optional[str],
+    download_id: Optional[str],
+) -> Tuple[str, str, Optional[node_credentials.NodeCredential]]:
+    """Determine which node and filesystem id a request should access."""
+
+    with database.SessionLocal() as session:
+        credential, _ = _authenticate_request(authorization, session)
+
+        resolved_credential: Optional[node_credentials.NodeCredential] = None
+        resolved_device_id: Optional[str] = None
+        resolved_download_id: Optional[str] = download_id
+
+        if credential:
+            resolved_credential = credential
+            node_id = credential.node_id
+            if not node_id:
+                raise HTTPException(status_code=403, detail="Token missing node identifier")
+            node_download_id = credential.download_id
+            if device_id and device_id != node_id:
+                raise HTTPException(status_code=403, detail="Token not authorized for this device")
+            if download_id and download_id not in {node_download_id, node_id}:
+                raise HTTPException(status_code=403, detail="Token not authorized for this download id")
+            resolved_device_id = node_id
+            resolved_download_id = download_id or node_download_id or node_id
+        else:
+            matched_credential: Optional[node_credentials.NodeCredential] = None
+            if download_id:
+                matched_credential = node_credentials.get_by_download_id(session, download_id)
+                if matched_credential:
+                    resolved_credential = matched_credential
+                    resolved_device_id = matched_credential.node_id
+            if device_id and not resolved_device_id:
+                matched_credential = node_credentials.get_by_node_id(session, device_id)
+                if matched_credential:
+                    resolved_credential = matched_credential
+                    resolved_device_id = matched_credential.node_id
+            if not resolved_device_id and download_id:
+                resolved_device_id = download_id
+                if resolved_credential is None:
+                    _, _, legacy_node = registry.find_node(download_id)
+                    if legacy_node:
+                        resolved_device_id = str(legacy_node.get("id") or download_id)
+            if not resolved_device_id:
+                if device_id:
+                    resolved_device_id = device_id
+                else:
+                    raise HTTPException(status_code=400, detail="device_id required")
+            if not resolved_download_id:
+                if resolved_credential:
+                    resolved_download_id = resolved_credential.download_id
+                else:
+                    legacy_dl = None
+                    _, _, legacy_node = registry.find_node(resolved_device_id)
+                    if legacy_node:
+                        legacy_value = legacy_node.get(registry.NODE_DOWNLOAD_ID_KEY)
+                        if isinstance(legacy_value, str) and legacy_value:
+                            legacy_dl = legacy_value
+                    resolved_download_id = legacy_dl or resolved_device_id
+
+    return resolved_device_id, resolved_download_id, resolved_credential
 
 def _http_date(ts: float) -> str:
     return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT")
@@ -57,39 +157,85 @@ def _sha256_hex(path: Path) -> str:
 
 def _manifest_sig(body: dict) -> Optional[str]:
     secret = settings.MANIFEST_HMAC_SECRET
-    if not secret: return None
-    blob = hashlib.sha256()
-    canonical = hashlib.sha256()  # (just to keep name; not used)
-    payload = (hashlib.json.dumps(body, sort_keys=True, separators=(",", ":"))
-               if hasattr(hashlib, "json") else __import__("json").dumps(body, sort_keys=True, separators=(",", ":"))).encode()
-    key = bytes.fromhex(secret) if all(c in "0123456789abcdef" for c in secret.lower()) and len(secret)%2==0 else secret.encode()
+    if not secret:
+        return None
+
+    payload = json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if (
+        all(c in "0123456789abcdef" for c in secret.lower())
+        and len(secret) % 2 == 0
+    ):
+        try:
+            key = bytes.fromhex(secret)
+        except ValueError:
+            key = secret.encode("utf-8")
+    else:
+        key = secret.encode("utf-8")
+
     return hmac.new(key, payload, hashlib.sha256).hexdigest()
 
-@router.get("/api/firmware/v1/manifest")
-def api_manifest(device_id: str, authorization: Optional[str] = Header(None)):
-    _require_bearer(authorization)
+
+def _build_manifest_response(device_id: str, download_id: Optional[str]) -> JSONResponse:
     target = _resolve_latest(device_id)
     size = target.stat().st_size
     sha = _sha256_hex(target)
     name = target.name
     version = "unknown"
     if "_v" in name and name.endswith(".bin"):
-        version = name.split("_v",1)[-1].rsplit(".bin",1)[0]
+        version = name.split("_v", 1)[-1].rsplit(".bin", 1)[0]
+
+    exposed_id = download_id or device_id
     body = {
         "device_id": device_id,
         "version": version,
         "size": size,
         "sha256_hex": sha,
-        "binary_url": f"{settings.PUBLIC_BASE}/firmware/{device_id}/latest.bin"
+        "binary_url": f"{settings.PUBLIC_BASE}/firmware/{exposed_id}/latest.bin",
     }
+
+    if download_id:
+        body["download_id"] = download_id
+        body["manifest_url"] = f"{settings.PUBLIC_BASE}/firmware/{download_id}/manifest"
+
     if LAN_PUBLIC_BASE:
-        body["binary_url_lan"] = f"{LAN_PUBLIC_BASE}/firmware/{device_id}/latest.bin"
+        body["binary_url_lan"] = f"{LAN_PUBLIC_BASE}/firmware/{exposed_id}/latest.bin"
+        if download_id:
+            body["manifest_url_lan"] = f"{LAN_PUBLIC_BASE}/firmware/{download_id}/manifest"
+
     sig = _manifest_sig(body)
     headers = {"Cache-Control": "no-store"}
     if sig:
         headers["X-Manifest-Signature"] = sig
         body["sig"] = sig
+
     return JSONResponse(body, headers=headers)
+
+
+@router.get("/api/firmware/v1/manifest")
+def api_manifest(
+    device_id: Optional[str] = None,
+    download_id: Optional[str] = None,
+    authorization: Optional[str] = Header(None),
+):
+    resolved_device_id, resolved_download_id, _ = _resolve_access_context(
+        authorization=authorization,
+        device_id=device_id,
+        download_id=download_id,
+    )
+    return _build_manifest_response(resolved_device_id, resolved_download_id)
+
+
+@router.get("/firmware/{download_id}/manifest")
+def api_manifest_by_download(
+    download_id: str,
+    authorization: Optional[str] = Header(None),
+):
+    resolved_device_id, resolved_download_id, _ = _resolve_access_context(
+        authorization=authorization,
+        device_id=None,
+        download_id=download_id,
+    )
+    return _build_manifest_response(resolved_device_id, resolved_download_id)
 
 def _serve_file(path: Path, request: Request) -> Response:
     stat = path.stat()
@@ -139,8 +285,16 @@ def _serve_file(path: Path, request: Request) -> Response:
     headers["Content-Length"] = str(end-start+1)
     return StreamingResponse(file_iter(start, end), headers=headers, media_type=mime, status_code=206)
 
-@router.get("/firmware/{device_id}/latest.bin")
-def api_latest_bin(device_id: str, request: Request, authorization: Optional[str] = Header(None)):
-    _require_bearer(authorization)
-    target = _resolve_latest(device_id)
+@router.get("/firmware/{download_id}/latest.bin")
+def api_latest_bin(
+    download_id: str,
+    request: Request,
+    authorization: Optional[str] = Header(None),
+):
+    resolved_device_id, _, _ = _resolve_access_context(
+        authorization=authorization,
+        device_id=None,
+        download_id=download_id,
+    )
+    target = _resolve_latest(resolved_device_id)
     return _serve_file(target, request)

--- a/Server/docs/node-ids.md
+++ b/Server/docs/node-ids.md
@@ -1,46 +1,62 @@
-# House-Prefixed Node Identifiers
+# Opaque Node Identifiers
 
-New nodes added through the admin UI or API automatically inherit a house-based
-prefix.  The registry stores the `house_id` and human-readable name you provide,
-then uses [`registry.slugify`](../app/registry.py) to lower-case and hyphenate
-both values before joining them into a single identifier:
+Nodes created through the admin UI or API now receive a random, opaque identifier
+at creation time. The identifier is a 22-character string composed of lowercase
+letters and digits (for example `1j1mmiwwxw2eg9jlbmjric`). It no longer contains
+the house slug or any user-provided text, so capturing or guessing a node ID does
+not reveal which house owns it.
 
-```
-<house-slug>-<node-slug>
-```
+Alongside the node ID the server issues:
 
-For example, adding the name **Kitchen Node** to the `del-sur` house produces
-`del-sur-kitchen-node`.  The hyphenated string is how firmware identifies itself
-over MQTT (`ul/<node-id>/...`) and how the OTA server locates binaries, so every
-artifact created during provisioning needs to reuse the exact same value.
+* a unique download identifier used to expose OTA binaries via
+  `/firmware/<download_id>/latest.bin`, and
+* a per-node bearer token whose SHA-256 hash is stored in the authentication
+  database (see [`NodeCredential`](../app/auth/models.py)).
 
-## Provisioning checklist
+All three values live in the SQLModel database instead of the JSON registry.
+`device_registry.json` continues to list houses, rooms and node metadata, but it
+no longer contains hashed OTA tokens.
 
-1. **Capture the generated node ID.** After adding the node, copy the slugged ID
-   shown in the admin UI or the new entry in
-   [`Server/app/device_registry.json`](../app/device_registry.json).  The first
-   segment always matches the house ID.
-2. **Mirror the ID in firmware defaults.** Edit
-   [`UltraNodeV5/sdkconfig.defaults`](../../UltraNodeV5/sdkconfig.defaults) (or
-   your checked-in `sdkconfig`) so `CONFIG_UL_NODE_ID` contains the same string.
-   While editing, also replace the `<node-id>` placeholder in
-   `CONFIG_UL_OTA_MANIFEST_URL` with the slug.  Example:
+## Provisioning workflow
+
+1. **Create the node in the UI.** When you add a node the admin API stores the
+   opaque node ID, download ID and hashed bearer token in the credential table.
+   The response includes the download alias so you can verify the record, but the
+   plaintext token is only returned via provisioning tools.
+
+2. **Generate firmware defaults with the provisioning CLI.** Use
+   [`Server/scripts/provision_node_firmware.py`](../scripts/provision_node_firmware.py)
+   to rotate the token, update `sdkconfig`, and manage the firmware symlink in a
+   single command:
+
+   ```bash
+   python Server/scripts/provision_node_firmware.py provisioned-node \
+       --config UltraNodeV5/sdkconfig --rotate-download
    ```
-   CONFIG_UL_NODE_ID="del-sur-kitchen-node"
-   CONFIG_UL_OTA_MANIFEST_URL="https://lights.evm100.org/firmware/UltraLights/del-sur-kitchen-node/latest.bin"
-   ```
-   If you customise settings through `idf.py menuconfig`, make the same edits
-   there before building the firmware image.
-3. **Publish OTA artifacts under the node ID.** The OTA endpoints resolve
-   `latest.bin` using either `/srv/firmware/<node-id>/latest.bin` or the flat
-   symlink `/srv/firmware/<node-id>_latest.bin`.  Create one of those paths with
-   the freshly built binary so `/firmware/<node-id>/latest.bin` and
-   `/api/firmware/v1/manifest?device_id=<node-id>` both succeed.
-4. **Keep the manifest consistent.** When mirroring binaries to a CDN or
-   generating static manifests, ensure any `device_id` fields, directory names or
-   download URLs use the same slug.  Mixing IDs breaks OTA checks and leads to
-   orphaned firmware slots on the server.
 
-Following the checklist ensures the node you registered under a house continues
-using the same identifier everywhere: the server registry, MQTT topics, firmware
-build flags, and OTA distribution.
+   The command:
+
+   * generates a fresh bearer token and persists its hash,
+   * optionally rotates the download alias (use `--rotate-download`),
+   * writes `CONFIG_UL_NODE_ID`, `CONFIG_UL_OTA_MANIFEST_URL` and
+     `CONFIG_UL_OTA_BEARER_TOKEN` into the selected `sdkconfig` files, and
+   * updates the `/srv/firmware/<download_id>` symlink to point at the node’s
+     firmware directory.
+
+   The plaintext token and manifest URL are printed once so you can archive them
+   securely.
+
+3. **Build and publish firmware.** After the CLI patches `sdkconfig`, build the
+   firmware and place the resulting `latest.bin` into
+   `${FIRMWARE_DIR}/<node-id>/latest.bin`. The symlink maintained by the CLI
+   exposes the binary through the opaque download alias.
+
+4. **Audit provisioning status.** To see which nodes have already been
+   provisioned, run the CLI with `--list`; provisioned entries are marked with an
+   asterisk and include the timestamp the firmware was generated.
+
+If you need to regenerate credentials manually, the
+[`manage_node_credentials`](../scripts/manage_node_credentials.py) helper still
+rotates tokens or download aliases and prints the new values, but the provisioning
+CLI is the recommended path because it keeps firmware defaults, symlinks and the
+database in sync.

--- a/Server/scripts/manage_node_credentials.py
+++ b/Server/scripts/manage_node_credentials.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Generate per-node OTA credentials and download aliases."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import node_credentials, registry, database  # noqa: E402
+from app.auth.service import init_auth_storage  # noqa: E402
+from app.config import settings  # noqa: E402
+
+
+def _ensure_symlink(node_id: str, download_id: str) -> Path:
+    firmware_dir = settings.FIRMWARE_DIR
+    target_dir = firmware_dir / node_id
+    link_path = firmware_dir / download_id
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    if link_path.exists() or link_path.is_symlink():
+        try:
+            existing_target = link_path.resolve(strict=True)
+        except FileNotFoundError:
+            existing_target = None
+        if existing_target == target_dir:
+            return link_path
+        if link_path.is_symlink() or link_path.is_file():
+            link_path.unlink()
+        else:
+            raise RuntimeError(
+                f"Refusing to replace existing directory at {link_path}"
+            )
+
+    link_path.symlink_to(target_dir, target_is_directory=True)
+    return link_path
+
+
+def _remove_symlink(download_id: Optional[str]) -> None:
+    if not download_id:
+        return
+    link_path = settings.FIRMWARE_DIR / download_id
+    if link_path.is_symlink():
+        link_path.unlink()
+
+
+def _issue_credentials(args: argparse.Namespace) -> int:
+    registry.ensure_house_external_ids()
+    init_auth_storage()
+
+    with database.SessionLocal() as session:
+        node_credentials.sync_registry_nodes(session)
+        credential = node_credentials.get_by_node_id(session, args.node_id)
+        if credential is None:
+            print(f"Unknown node id: {args.node_id}", file=sys.stderr)
+            return 1
+
+        previous_download = credential.download_id
+
+        if args.download_id:
+            credential = node_credentials.update_download_id(
+                session, args.node_id, args.download_id
+            )
+        elif args.rotate_download:
+            credential = node_credentials.update_download_id(session, args.node_id)
+
+        download_id = credential.download_id
+
+        if not args.no_symlink:
+            if previous_download and previous_download != download_id:
+                _remove_symlink(previous_download)
+            try:
+                link = _ensure_symlink(args.node_id, download_id)
+            except RuntimeError as exc:  # pragma: no cover - defensive
+                print(f"Warning: {exc}", file=sys.stderr)
+            else:
+                print(
+                    f"Symlink: {link} -> {link.resolve() if link.exists() else 'missing'}"
+                )
+
+        if args.token:
+            credential, token = node_credentials.rotate_token(
+                session, args.node_id, token=args.token
+            )
+        else:
+            credential, token = node_credentials.rotate_token(session, args.node_id)
+
+        node_credentials.sync_registry_nodes(session)
+
+    _, _, node = registry.find_node(args.node_id)
+    node_name = node.get("name") if isinstance(node, dict) else None
+
+    manifest_url = f"{settings.PUBLIC_BASE}/firmware/{credential.download_id}/manifest"
+    binary_url = f"{settings.PUBLIC_BASE}/firmware/{credential.download_id}/latest.bin"
+
+    print("--- OTA credentials ---")
+    print(f"Node: {args.node_id}")
+    if isinstance(node_name, str) and node_name:
+        print(f"Name: {node_name}")
+    print(f"Download ID: {credential.download_id}")
+    print(f"Manifest URL: {manifest_url}")
+    print(f"Binary URL:   {binary_url}")
+    print(f"Bearer Token: {token}")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("node_id", help="Registry node identifier (e.g. house-room-node)")
+    parser.add_argument(
+        "--token",
+        help="Use an explicit bearer token instead of generating a random one.",
+    )
+    parser.add_argument(
+        "--download-id",
+        help="Assign a specific download identifier (otherwise generated automatically).",
+    )
+    parser.add_argument(
+        "--rotate-download",
+        action="store_true",
+        help="Force generation of a new download identifier even if one already exists.",
+    )
+    parser.add_argument(
+        "--no-symlink",
+        action="store_true",
+        help="Do not manage firmware symlinks for the download identifier.",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return _issue_credentials(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Server/scripts/provision_node_firmware.py
+++ b/Server/scripts/provision_node_firmware.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Provision firmware defaults for an opaque node identifier."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from sqlmodel import select  # noqa: E402
+
+from app import database, node_credentials, registry  # noqa: E402
+from app.auth.models import NodeCredential  # noqa: E402
+from app.auth.service import init_auth_storage  # noqa: E402
+from app.config import settings  # noqa: E402
+
+
+def _ensure_symlink(node_id: str, download_id: str) -> Path:
+    firmware_dir = settings.FIRMWARE_DIR
+    target_dir = firmware_dir / node_id
+    link_path = firmware_dir / download_id
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    if link_path.exists() or link_path.is_symlink():
+        try:
+            existing_target = link_path.resolve(strict=True)
+        except FileNotFoundError:
+            existing_target = None
+        if existing_target == target_dir:
+            return link_path
+        if link_path.is_symlink() or link_path.is_file():
+            link_path.unlink()
+        else:
+            raise RuntimeError(
+                f"Refusing to replace existing directory at {link_path}"
+            )
+
+    link_path.symlink_to(target_dir, target_is_directory=True)
+    return link_path
+
+
+def _remove_symlink(download_id: Optional[str]) -> None:
+    if not download_id:
+        return
+    link_path = settings.FIRMWARE_DIR / download_id
+    if link_path.is_symlink():
+        link_path.unlink()
+
+
+def _update_sdkconfig(path: Path, values: Dict[str, str]) -> None:
+    path = path.expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"sdkconfig file not found: {path}")
+
+    lines = path.read_text().splitlines()
+    updated: List[str] = []
+    seen: Dict[str, bool] = {key: False for key in values}
+
+    for line in lines:
+        replaced = False
+        stripped = line.strip()
+        for key, value in values.items():
+            if stripped.startswith(f"{key}="):
+                updated.append(f'{key}="{value}"')
+                seen[key] = True
+                replaced = True
+                break
+        if not replaced:
+            updated.append(line)
+
+    for key, present in seen.items():
+        if not present:
+            updated.append(f'{key}="{values[key]}"')
+
+    updated.append("")
+    path.write_text("\n".join(updated))
+
+
+def _format_timestamp(value: Optional[datetime]) -> str:
+    if not value:
+        return "—"
+    return value.isoformat(timespec="seconds")
+
+
+def _list_nodes() -> int:
+    init_auth_storage()
+    with database.SessionLocal() as session:
+        node_credentials.sync_registry_nodes(session)
+        entries = session.exec(select(NodeCredential)).all()
+
+    if not entries:
+        print("No nodes registered.")
+        return 0
+
+    print("Node ID                          Name                         Provisioned")
+    print("-" * 72)
+    for entry in entries:
+        mark = "" if entry.provisioned_at is None else "*"
+        name = entry.display_name or "—"
+        print(
+            f"{entry.node_id:<30} {name:<27} {_format_timestamp(entry.provisioned_at)}{mark}"
+        )
+    print("\n* indicates firmware already provisioned")
+    return 0
+
+
+def _provision(args: argparse.Namespace) -> int:
+    if not args.node_id:
+        print("node_id required unless --list specified", file=sys.stderr)
+        return 1
+
+    config_paths = args.config or [PROJECT_ROOT / "UltraNodeV5/sdkconfig"]
+    normalized_configs: List[Path] = []
+    for raw in config_paths:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = PROJECT_ROOT / path
+        normalized_configs.append(path)
+    normalized_configs = list(dict.fromkeys(normalized_configs))
+
+    init_auth_storage()
+    registry.ensure_house_external_ids()
+
+    with database.SessionLocal() as session:
+        node_credentials.sync_registry_nodes(session)
+        credential = node_credentials.get_by_node_id(session, args.node_id)
+        if credential is None:
+            print(f"Unknown node id: {args.node_id}", file=sys.stderr)
+            return 1
+
+        if (
+            credential.provisioned_at is not None
+            and not args.allow_reprovision
+            and not args.no_mark_provisioned
+        ):
+            print(
+                "Node already marked as provisioned. Use --allow-reprovision to override.",
+                file=sys.stderr,
+            )
+            return 1
+
+        previous_download = credential.download_id
+        if args.rotate_download:
+            credential = node_credentials.update_download_id(session, args.node_id)
+
+        download_id = credential.download_id
+
+        if not args.no_symlink:
+            if previous_download and previous_download != download_id:
+                _remove_symlink(previous_download)
+            try:
+                link = _ensure_symlink(args.node_id, download_id)
+            except RuntimeError as exc:  # pragma: no cover - defensive
+                print(f"Warning: {exc}", file=sys.stderr)
+                link = None
+            else:
+                print(
+                    f"Symlink: {link} -> {link.resolve() if link.exists() else 'missing'}"
+                )
+        else:
+            link = None
+
+        credential, token = node_credentials.rotate_token(session, args.node_id)
+
+        manifest_url = f"{settings.PUBLIC_BASE}/firmware/{download_id}/manifest"
+        values = {
+            "CONFIG_UL_NODE_ID": args.node_id,
+            "CONFIG_UL_OTA_MANIFEST_URL": manifest_url,
+            "CONFIG_UL_OTA_BEARER_TOKEN": token,
+        }
+
+        updated_files: List[Path] = []
+        for cfg in normalized_configs:
+            try:
+                _update_sdkconfig(cfg, values)
+            except FileNotFoundError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 1
+            updated_files.append(cfg)
+
+        if not args.no_mark_provisioned:
+            node_credentials.mark_provisioned(session, args.node_id)
+
+        node_credentials.sync_registry_nodes(session)
+
+    _, _, node = registry.find_node(args.node_id)
+    name = node.get("name") if isinstance(node, dict) else ""
+
+    print("\n--- Firmware provisioning ---")
+    if name:
+        print(f"Node: {args.node_id} ({name})")
+    else:
+        print(f"Node: {args.node_id}")
+    print(f"Download ID: {download_id}")
+    print(f"Manifest URL: {manifest_url}")
+    print(f"Bearer Token: {token}")
+    if updated_files:
+        print("Updated configuration files:")
+        for cfg in updated_files:
+            print(f"  - {cfg}")
+    if link:
+        print(f"Firmware symlink: {link}")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("node_id", nargs="?", help="Opaque node identifier to provision")
+    parser.add_argument(
+        "--config",
+        action="append",
+        metavar="PATH",
+        help="sdkconfig file to update (defaults to UltraNodeV5/sdkconfig)",
+    )
+    parser.add_argument(
+        "--rotate-download",
+        action="store_true",
+        help="Issue a new download identifier before provisioning.",
+    )
+    parser.add_argument(
+        "--no-symlink",
+        action="store_true",
+        help="Skip creating the firmware download symlink.",
+    )
+    parser.add_argument(
+        "--allow-reprovision",
+        action="store_true",
+        help="Allow provisioning even if the node is already marked provisioned.",
+    )
+    parser.add_argument(
+        "--no-mark-provisioned",
+        action="store_true",
+        help="Do not update the provisioned timestamp in the database.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List nodes and their provisioning status instead of updating firmware.",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.list:
+        return _list_nodes()
+    return _provision(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Server/tests/test_ota_credentials.py
+++ b/Server/tests/test_ota_credentials.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import database, node_credentials, ota, registry
+from app.auth.service import init_auth_storage
+from app.config import settings
+from scripts import manage_node_credentials, provision_node_firmware
+
+
+class _NoopBus:
+    def __getattr__(self, name):  # pragma: no cover - defensive
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+@pytest.fixture()
+def ota_environment(tmp_path, monkeypatch):
+    original_registry = deepcopy(settings.DEVICE_REGISTRY)
+    original_firmware = settings.FIRMWARE_DIR
+    original_public_base = settings.PUBLIC_BASE
+    original_api_bearer = settings.API_BEARER
+    original_db_url = settings.AUTH_DB_URL
+
+    test_registry = [
+        {
+            "id": "test-house",
+            "name": "Test House",
+            "rooms": [
+                {
+                    "id": "lab",
+                    "name": "Lab",
+                    "nodes": [
+                        {
+                            "id": "test-node",
+                            "name": "Test Node",
+                            "kind": "ultranode",
+                            "modules": ["ota"],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", deepcopy(test_registry))
+    monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", settings.DEVICE_REGISTRY)
+    monkeypatch.setattr(registry, "save_registry", lambda: None)
+
+    firmware_dir = tmp_path / "firmware"
+    firmware_dir.mkdir()
+    monkeypatch.setattr(settings, "FIRMWARE_DIR", firmware_dir)
+    monkeypatch.setattr(registry.settings, "FIRMWARE_DIR", firmware_dir)
+    monkeypatch.setattr(ota, "FIRMWARE_DIR", firmware_dir)
+
+    monkeypatch.setattr(settings, "PUBLIC_BASE", "https://example.test")
+    monkeypatch.setattr(ota.settings, "PUBLIC_BASE", "https://example.test")
+    monkeypatch.setattr(settings, "API_BEARER", "shared-secret")
+    monkeypatch.setattr(ota.settings, "API_BEARER", "shared-secret")
+
+    db_path = tmp_path / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+    database.reset_session_factory(db_url)
+    monkeypatch.setattr(ota.settings, "AUTH_DB_URL", db_url)
+    init_auth_storage()
+
+    with database.SessionLocal() as session:
+        node_credentials.sync_registry_nodes(session)
+
+    yield {
+        "registry": settings.DEVICE_REGISTRY,
+        "firmware_dir": firmware_dir,
+    }
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(settings, "FIRMWARE_DIR", original_firmware)
+    monkeypatch.setattr(registry.settings, "FIRMWARE_DIR", original_firmware)
+    monkeypatch.setattr(ota, "FIRMWARE_DIR", original_firmware)
+    monkeypatch.setattr(settings, "PUBLIC_BASE", original_public_base)
+    monkeypatch.setattr(ota.settings, "PUBLIC_BASE", original_public_base)
+    monkeypatch.setattr(settings, "API_BEARER", original_api_bearer)
+    monkeypatch.setattr(ota.settings, "API_BEARER", original_api_bearer)
+    database.reset_session_factory(original_db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", original_db_url)
+    monkeypatch.setattr(ota.settings, "AUTH_DB_URL", original_db_url)
+
+
+@pytest.fixture()
+def node_credential_info(ota_environment):
+    token = "node-token-value"
+    download_id = "DLTESTID1234"
+    with database.SessionLocal() as session:
+        node_credentials.ensure_for_node(
+            session,
+            node_id="test-node",
+            house_slug="test-house",
+            room_id="lab",
+            display_name="Test Node",
+            download_id=download_id,
+            token_hash=registry.hash_node_token(token),
+        )
+        node_credentials.sync_registry_nodes(session)
+
+    node_dir = settings.FIRMWARE_DIR / "test-node"
+    node_dir.mkdir(parents=True, exist_ok=True)
+    (node_dir / "latest.bin").write_bytes(b"OTA")
+
+    return {
+        "token": token,
+        "download_id": download_id,
+        "device_id": "test-node",
+    }
+
+
+@pytest.fixture()
+def client(ota_environment, monkeypatch):
+    import app.mqtt_bus
+
+    monkeypatch.setattr(app.mqtt_bus, "MqttBus", lambda *args, **kwargs: _NoopBus())
+
+    sys.modules.pop("app.motion", None)
+    sys.modules.pop("app.status_monitor", None)
+    import app.motion
+    import app.status_monitor
+
+    monkeypatch.setattr(app.motion.MotionManager, "start", lambda self: None)
+    monkeypatch.setattr(app.motion.MotionManager, "stop", lambda self: None)
+    monkeypatch.setattr(app.status_monitor.StatusMonitor, "start", lambda self: None)
+    monkeypatch.setattr(app.status_monitor.StatusMonitor, "stop", lambda self: None)
+
+    sys.modules.pop("app.main", None)
+    from app.main import app as fastapi_app
+
+    test_client = TestClient(fastapi_app)
+    try:
+        init_auth_storage()
+        SQLModel.metadata.create_all(database.engine)
+        with database.SessionLocal() as session:
+            node_credentials.sync_registry_nodes(session)
+        yield test_client
+    finally:
+        test_client.close()
+
+
+def test_manifest_uses_download_id_with_node_token(node_credential_info, client):
+    response = client.get(
+        f"/firmware/{node_credential_info['download_id']}/manifest",
+        headers={"Authorization": f"Bearer {node_credential_info['token']}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["device_id"] == node_credential_info["device_id"]
+    assert data["download_id"] == node_credential_info["download_id"]
+    assert data["binary_url"].endswith(
+        f"/firmware/{node_credential_info['download_id']}/latest.bin"
+    )
+    assert data["manifest_url"].endswith(
+        f"/firmware/{node_credential_info['download_id']}/manifest"
+    )
+
+
+def test_binary_download_requires_matching_token(node_credential_info, client):
+    url = f"/firmware/{node_credential_info['download_id']}/latest.bin"
+    response = client.get(url, headers={"Authorization": "Bearer wrong"})
+    assert response.status_code == 403
+
+    ok = client.get(url, headers={"Authorization": f"Bearer {node_credential_info['token']}"})
+    assert ok.status_code == 200
+    assert ok.content == b"OTA"
+
+
+def test_manifest_rejects_cross_node_access(node_credential_info, client):
+    other = registry.generate_download_id()
+    response = client.get(
+        f"/firmware/{other}/manifest",
+        headers={"Authorization": f"Bearer {node_credential_info['token']}"},
+    )
+    assert response.status_code == 403
+
+
+def test_manifest_allows_global_token(node_credential_info, client):
+    response = client.get(
+        "/api/firmware/v1/manifest",
+        params={"device_id": node_credential_info["device_id"]},
+        headers={"Authorization": "Bearer shared-secret"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["binary_url"].endswith(
+        f"/firmware/{node_credential_info['download_id']}/latest.bin"
+    )
+
+
+def test_manifest_missing_token_is_rejected(node_credential_info, client):
+    response = client.get(
+        f"/firmware/{node_credential_info['download_id']}/manifest",
+    )
+    assert response.status_code == 401
+
+
+def test_manage_node_credentials_cli_creates_token(tmp_path, monkeypatch):
+    original_registry = deepcopy(settings.DEVICE_REGISTRY)
+    original_firmware = settings.FIRMWARE_DIR
+    original_db_url = settings.AUTH_DB_URL
+
+    test_registry = [
+        {
+            "id": "cli-house",
+            "name": "CLI House",
+            "rooms": [
+                {
+                    "id": "room",
+                    "name": "Room",
+                    "nodes": [
+                        {
+                            "id": "cli-node",
+                            "name": "CLI Node",
+                            "kind": "ultranode",
+                            "modules": ["ota"],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", deepcopy(test_registry))
+    monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", settings.DEVICE_REGISTRY)
+    monkeypatch.setattr(registry, "save_registry", lambda: None)
+
+    firmware_dir = tmp_path / "fw"
+    firmware_dir.mkdir()
+    monkeypatch.setattr(settings, "FIRMWARE_DIR", firmware_dir)
+    monkeypatch.setattr(registry.settings, "FIRMWARE_DIR", firmware_dir)
+
+    db_path = tmp_path / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+    database.reset_session_factory(db_url)
+    monkeypatch.setattr(ota.settings, "AUTH_DB_URL", db_url)
+    init_auth_storage()
+
+    result = manage_node_credentials.main(
+        [
+            "cli-node",
+            "--token",
+            "plain-token",
+            "--download-id",
+            "CLISLOT123",
+        ]
+    )
+    assert result == 0
+
+    node = registry.find_node("cli-node")[2]
+    assert node is not None
+    assert node[registry.NODE_DOWNLOAD_ID_KEY] == "CLISLOT123"
+    assert registry.NODE_TOKEN_HASH_KEY not in node
+
+    with database.SessionLocal() as session:
+        record = node_credentials.get_by_node_id(session, "cli-node")
+        assert record is not None
+        assert record.download_id == "CLISLOT123"
+        assert record.token_hash == registry.hash_node_token("plain-token")
+
+    link = firmware_dir / "CLISLOT123"
+    assert link.is_symlink()
+    assert link.resolve() == firmware_dir / "cli-node"
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(settings, "FIRMWARE_DIR", original_firmware)
+    monkeypatch.setattr(registry.settings, "FIRMWARE_DIR", original_firmware)
+    database.reset_session_factory(original_db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", original_db_url)
+    monkeypatch.setattr(ota.settings, "AUTH_DB_URL", original_db_url)
+
+
+def test_provision_node_firmware_updates_sdkconfig(tmp_path, monkeypatch, capsys):
+    original_registry = deepcopy(settings.DEVICE_REGISTRY)
+    original_firmware = settings.FIRMWARE_DIR
+    original_db_url = settings.AUTH_DB_URL
+
+    test_registry = [
+        {
+            "id": "provision-house",
+            "name": "Provision House",
+            "rooms": [
+                {
+                    "id": "room",
+                    "name": "Room",
+                    "nodes": [
+                        {
+                            "id": "provision-node",
+                            "name": "Provision Node",
+                            "kind": "ultranode",
+                            "modules": ["ota"],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", deepcopy(test_registry))
+    monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", settings.DEVICE_REGISTRY)
+    monkeypatch.setattr(registry, "save_registry", lambda: None)
+
+    firmware_dir = tmp_path / "fw"
+    firmware_dir.mkdir()
+    monkeypatch.setattr(settings, "FIRMWARE_DIR", firmware_dir)
+    monkeypatch.setattr(registry.settings, "FIRMWARE_DIR", firmware_dir)
+
+    sdkconfig = tmp_path / "sdkconfig"
+    sdkconfig.write_text(
+        "\n".join(
+            [
+                'CONFIG_UL_NODE_ID="placeholder"',
+                'CONFIG_UL_OTA_MANIFEST_URL="https://example.test/firmware/placeholder/manifest"',
+                'CONFIG_UL_OTA_BEARER_TOKEN="old"',
+                "",
+            ]
+        )
+    )
+
+    db_path = tmp_path / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+    database.reset_session_factory(db_url)
+    monkeypatch.setattr(ota.settings, "AUTH_DB_URL", db_url)
+    init_auth_storage()
+
+    with database.SessionLocal() as session:
+        node_credentials.ensure_for_node(
+            session,
+            node_id="provision-node",
+            house_slug="provision-house",
+            room_id="room",
+            display_name="Provision Node",
+            download_id="DLINITIAL",
+            token_hash=registry.hash_node_token("seed-token"),
+        )
+        node_credentials.sync_registry_nodes(session)
+
+    result = provision_node_firmware.main(
+        [
+            "provision-node",
+            "--config",
+            str(sdkconfig),
+            "--rotate-download",
+        ]
+    )
+    assert result == 0
+    output = capsys.readouterr().out
+
+    config_text = sdkconfig.read_text()
+    assert 'CONFIG_UL_NODE_ID="provision-node"' in config_text
+    manifest_match = re.search(
+        r'CONFIG_UL_OTA_MANIFEST_URL="([^"]+)"', config_text
+    )
+    token_match = re.search(
+        r'CONFIG_UL_OTA_BEARER_TOKEN="([^"]+)"', config_text
+    )
+    assert manifest_match and token_match
+    manifest_url = manifest_match.group(1)
+    token_value = token_match.group(1)
+
+    with database.SessionLocal() as session:
+        record = node_credentials.get_by_node_id(session, "provision-node")
+        assert record is not None
+        assert record.download_id in manifest_url
+        assert record.token_hash == registry.hash_node_token(token_value)
+        assert record.provisioned_at is not None
+
+    link = firmware_dir / record.download_id
+    assert link.is_symlink()
+    assert link.resolve() == firmware_dir / "provision-node"
+
+    assert "Bearer Token" in output
+    assert token_value in output
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(settings, "FIRMWARE_DIR", original_firmware)
+    monkeypatch.setattr(registry.settings, "FIRMWARE_DIR", original_firmware)
+    database.reset_session_factory(original_db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", original_db_url)
+    monkeypatch.setattr(ota.settings, "AUTH_DB_URL", original_db_url)


### PR DESCRIPTION
## Summary
- add a SQLModel-backed NodeCredential table and service for syncing opaque node IDs, download aliases, and token hashes
- update OTA routes and admin APIs to rely on database credentials, opaque IDs, and new provisioning workflows
- ship a provisioning CLI, enhance the credential management script, refresh docs/sample registry, and extend the OTA/admin tests

## Testing
- pytest Server/tests


------
https://chatgpt.com/codex/tasks/task_e_68d3708345f4832684972572ddde8f71