### PR TITLE
Align firmware storage with /srv/firmware/UltraLights

### DIFF
--- a/Server/.env
+++ b/Server/.env
@@ -14,7 +14,7 @@ BROKER_PORT=1883
 EMBED_BROKER=0
 
 # Firmware dir & security
-FIRMWARE_DIR=/srv/firmware
+FIRMWARE_DIR=/srv/firmware/UltraLights
 API_BEARER=super-long-random-bearer
 
 # Auth database & sessions

--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -18,7 +18,9 @@ class Settings:
     BROKER_PORT = int(os.getenv("BROKER_PORT", "1883"))
     EMBED_BROKER = os.getenv("EMBED_BROKER", "0") == "1"
 
-    FIRMWARE_DIR = Path(os.getenv("FIRMWARE_DIR", "./firmware"))
+    FIRMWARE_DIR = Path(
+        os.getenv("FIRMWARE_DIR", "/srv/firmware/UltraLights")
+    )
     FIRMWARE_DIR.mkdir(parents=True, exist_ok=True)
 
     API_BEARER = os.getenv("API_BEARER", "")

--- a/Server/docs/node-ids.md
+++ b/Server/docs/node-ids.md
@@ -40,8 +40,9 @@ no longer contains hashed OTA tokens.
    * optionally rotates the download alias (use `--rotate-download`),
    * writes `CONFIG_UL_NODE_ID`, `CONFIG_UL_OTA_MANIFEST_URL` and
      `CONFIG_UL_OTA_BEARER_TOKEN` into the selected `sdkconfig` files, and
-   * updates the `/srv/firmware/<download_id>` symlink to point at the node’s
-     firmware directory.
+  * updates the `/srv/firmware/<download_id>` symlink (under the default
+    `/srv/firmware/UltraLights` root) to point at the node’s firmware
+    directory.
 
    The plaintext token and manifest URL are printed once so you can archive them
    securely.
@@ -60,8 +61,11 @@ no longer contains hashed OTA tokens.
      verifying that no other device is still using it.
 
    Keeping the download ID handy also lets you inspect the corresponding
-   firmware folder on disk (`/srv/firmware/<download_id>`) during troubleshooting
-   without revealing the node slug.
+   firmware folder on disk (`/srv/firmware/UltraLights/<download_id>`) during
+   troubleshooting without revealing the node slug. The download directory is a
+   symlink that always resolves to the real node folder (for example
+   `/srv/firmware/UltraLights/<node-id>`), so nothing is stored separately inside
+   the download ID itself.
 
 3. **Build and publish firmware.** After the CLI patches `sdkconfig`, build the
    firmware and place the resulting `latest.bin` into


### PR DESCRIPTION
## Summary
- default the server firmware directory to /srv/firmware/UltraLights so it matches the flashing scripts
- update the sample environment file to document the new firmware root
- clarify in the provisioning docs that download identifiers resolve to node folders via symlinks under /srv/firmware/UltraLights

## Testing
- pytest tests/test_ota_credentials.py


------
https://chatgpt.com/codex/tasks/task_e_68d3ae161800832687e5f08d5066dde5