### PR TITLE
Ensure status heartbeat waits for MQTT connection

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/include/ul_mqtt.h
+++ b/UltraNodeV5/components/ul_mqtt/include/ul_mqtt.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "esp_err.h"
+#include "freertos/FreeRTOS.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -18,6 +19,7 @@ void ul_mqtt_publish_motion(const char *sensor, const char *state);
 void ul_mqtt_publish_ota_event(const char *status, const char *detail);
 bool ul_mqtt_is_ready(void);
 bool ul_mqtt_is_connected(void);
+bool ul_mqtt_wait_for_ready(TickType_t timeout_ticks);
 
 // Execute a command locally without publishing over MQTT. The path should match
 // the suffix of a normal command topic (e.g. "ws/set").

--- a/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
+++ b/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
@@ -79,6 +79,8 @@ esp_err_t esp_mqtt_client_destroy(esp_mqtt_client_handle_t client);
 bool ul_core_is_connected(void);
 void ul_health_notify_mqtt(bool connected);
 
+typedef uint32_t TickType_t;
+
 #define pdMS_TO_TICKS(ms) (ms)
 void vTaskDelay(int ticks);
 


### PR DESCRIPTION
## Summary
- add an event group in the MQTT component so other tasks can wait for the first broker connection
- update the status heartbeat to wait for Wi-Fi and MQTT readiness before publishing, reducing spurious warnings
- extend the test stubs to cover the new wait helper

## Testing
- idf.py build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c4c6c6c883268d559fd12c915ff8