### PR TITLE
Expand identifier defaults to new maximum lengths

### DIFF
--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -26,7 +26,7 @@ class Settings:
     API_BEARER = os.getenv("API_BEARER", "")
     MANIFEST_HMAC_SECRET = os.getenv("MANIFEST_HMAC_SECRET", "")
 
-    MAX_HOUSE_ID_LENGTH = int(os.getenv("MAX_HOUSE_ID_LENGTH", "22"))
+    MAX_HOUSE_ID_LENGTH = int(os.getenv("MAX_HOUSE_ID_LENGTH", "64"))
     AUTH_DB_URL = os.getenv(
         "AUTH_DB_URL", f"sqlite:///{DATA_DIR / 'auth.sqlite3'}"
     )

--- a/Server/app/registry.py
+++ b/Server/app/registry.py
@@ -46,8 +46,10 @@ EXTERNAL_ID_ALPHABET = string.ascii_lowercase + string.ascii_uppercase + string.
 DOWNLOAD_ID_ALPHABET = string.ascii_lowercase + string.ascii_uppercase + string.digits
 NODE_ID_ALPHABET = string.ascii_lowercase + string.digits
 
-DEFAULT_DOWNLOAD_ID_LENGTH = 22
-DEFAULT_NODE_ID_LENGTH = 22
+MAX_NODE_ID_LENGTH = 31
+
+DEFAULT_DOWNLOAD_ID_LENGTH = 48
+DEFAULT_NODE_ID_LENGTH = MAX_NODE_ID_LENGTH
 DEFAULT_TOKEN_BYTES = 32
 
 NODE_DOWNLOAD_ID_KEY = "download_id"
@@ -403,9 +405,6 @@ def reorder_rooms(house_id: str, room_order: Iterable[str]) -> list[Room]:
     house["rooms"] = normalized_order
     save_registry()
     return normalized_order
-
-
-MAX_NODE_ID_LENGTH = 31
 
 
 def add_node(

--- a/Server/docs/node-ids.md
+++ b/Server/docs/node-ids.md
@@ -1,8 +1,8 @@
 # Opaque Node Identifiers
 
 Nodes created through the admin UI or API now receive a random, opaque identifier
-at creation time. The identifier is a 22-character string composed of lowercase
-letters and digits (for example `1j1mmiwwxw2eg9jlbmjric`). It no longer contains
+at creation time. The identifier is a 31-character string composed of lowercase
+letters and digits (for example `dbrpr89wiexuejce52u9840juec77ul`). It no longer contains
 the house slug or any user-provided text, so capturing or guessing a node ID does
 not reveal which house owns it.
 
@@ -12,6 +12,10 @@ Alongside the node ID the server issues:
   `/firmware/<download_id>/latest.bin`, and
 * a per-node bearer token whose SHA-256 hash is stored in the authentication
   database (see [`NodeCredential`](../app/auth/models.py)).
+
+Download identifiers now take advantage of the full 48-character default, while
+house external identifiers can stretch to 64 characters. The node ID remains at
+31 characters to match the ESP32 firmware limit.
 
 All three values live in the SQLModel database instead of the JSON registry.
 `device_registry.json` continues to list houses, rooms and node metadata, but it

--- a/Server/tests/test_admin_api.py
+++ b/Server/tests/test_admin_api.py
@@ -1,6 +1,5 @@
 import importlib
 import json
-import re
 import sys
 from copy import deepcopy
 from pathlib import Path
@@ -258,21 +257,25 @@ def test_api_add_node_generates_opaque_id(monkeypatch, tmp_path, admin_user_sess
 
     assert result["ok"] is True
     node_id = result["node"]["id"]
-    assert re.fullmatch(r"[a-z0-9]{22}", node_id)
+    assert len(node_id) == registry.MAX_NODE_ID_LENGTH
+    assert all(ch in registry.NODE_ID_ALPHABET for ch in node_id)
     assert node_id != "del-sur-kitchen-node"
 
     stored_nodes = settings.DEVICE_REGISTRY[0]["rooms"][0]["nodes"]
     assert stored_nodes[0]["id"] == node_id
 
     credentials = result["credentials"]
-    assert credentials["downloadId"]
+    download_id = credentials["downloadId"]
+    assert download_id
+    assert len(download_id) == registry.DEFAULT_DOWNLOAD_ID_LENGTH
+    assert all(ch in registry.DOWNLOAD_ID_ALPHABET for ch in download_id)
     assert credentials["manifestUrl"].endswith(
-        f"/firmware/{credentials['downloadId']}/manifest"
+        f"/firmware/{download_id}/manifest"
     )
     assert credentials["binaryUrl"].endswith(
-        f"/firmware/{credentials['downloadId']}/latest.bin"
+        f"/firmware/{download_id}/latest.bin"
     )
-    assert stored_nodes[0][registry.NODE_DOWNLOAD_ID_KEY] == credentials["downloadId"]
+    assert stored_nodes[0][registry.NODE_DOWNLOAD_ID_KEY] == download_id
 
 
 def test_api_add_node_duplicate_name(monkeypatch, tmp_path, admin_user_session):
@@ -338,7 +341,9 @@ def test_api_add_node_allows_long_display_name(monkeypatch, tmp_path, admin_user
     )
 
     assert result["ok"] is True
-    assert re.fullmatch(r"[a-z0-9]{22}", result["node"]["id"])
+    node_id = result["node"]["id"]
+    assert len(node_id) == registry.MAX_NODE_ID_LENGTH
+    assert all(ch in registry.NODE_ID_ALPHABET for ch in node_id)
 
 
 def test_api_set_node_name(monkeypatch, tmp_path, admin_user_session):


### PR DESCRIPTION
## Summary
- expand the default maximum house external identifier length to 64 characters
- generate node IDs at the ESP32 limit and extend download identifiers to 48 characters
- refresh documentation and tests to reflect the updated identifier sizes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3da16af2c832684e8522b3291725e