### PR TITLE
Store firmware archives outside public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+firmware_artifacts/


### PR DESCRIPTION
## Summary
- add a firmware_artifacts archive directory and ignore it in git
- update updateAllNodes.sh to archive binaries outside /srv/firmware and migrate legacy artifacts

## Testing
- bash -n UltraNodeV5/updateAllNodes.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3dc0d450c8326847eb8985c0245f9