### PR TITLE
Fix firmware storage paths and symlink management

### DIFF
--- a/Server/scripts/provision_node_firmware.py
+++ b/Server/scripts/provision_node_firmware.py
@@ -29,47 +29,61 @@ def _ensure_symlink(node_id: str, download_id: str) -> Path:
     target_dir = storage_root / node_id
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    def _ensure_link(link_path: Path) -> Path:
-        link_path.parent.mkdir(parents=True, exist_ok=True)
+    def _migrate_into_storage(path: Path) -> None:
+        if not path.exists() and not path.is_symlink():
+            return
 
-        if link_path.exists() or link_path.is_symlink():
+        if path.is_symlink():
+            path.unlink()
+            return
+
+        if path.is_file():
+            raise RuntimeError(f"Unexpected firmware file at {path}")
+
+        if not any(target_dir.iterdir()):
             try:
-                existing_target = link_path.resolve(strict=True)
-            except FileNotFoundError:
-                existing_target = None
-            if existing_target == target_dir:
-                return link_path
-            if link_path.is_symlink() or link_path.is_file():
-                link_path.unlink()
-            elif link_path.is_dir():
-                if target_dir.exists():
-                    try:
-                        next(target_dir.iterdir())
-                    except StopIteration:
-                        target_dir.rmdir()
-                        shutil.move(str(link_path), str(target_dir))
-                    else:
-                        for child in link_path.iterdir():
-                            dest = target_dir / child.name
-                            if dest.exists():
-                                continue
-                            if child.is_dir():
-                                shutil.copytree(child, dest)
-                            else:
-                                shutil.copy2(child, dest)
-                        shutil.rmtree(link_path)
-                else:
-                    shutil.move(str(link_path), str(target_dir))
+                path.rename(target_dir)
+                return
+            except OSError:
+                pass
+
+        for child in path.iterdir():
+            dest = target_dir / child.name
+            if dest.exists():
+                continue
+            if child.is_dir():
+                shutil.copytree(child, dest)
             else:
-                raise RuntimeError(
-                    f"Refusing to replace existing directory at {link_path}"
-                )
+                shutil.copy2(child, dest)
+        shutil.rmtree(path)
 
-        link_path.symlink_to(target_dir, target_is_directory=True)
-        return link_path
+    legacy_node_path = link_root / node_id
+    _migrate_into_storage(legacy_node_path)
+    if legacy_node_path.exists() or legacy_node_path.is_symlink():
+        if legacy_node_path.is_dir():
+            shutil.rmtree(legacy_node_path)
+        else:
+            legacy_node_path.unlink()
 
-    _ensure_link(link_root / node_id)
-    return _ensure_link(link_root / download_id)
+    link_path = link_root / download_id
+    _migrate_into_storage(link_path)
+
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if link_path.exists() or link_path.is_symlink():
+        try:
+            existing_target = link_path.resolve(strict=True)
+        except FileNotFoundError:
+            existing_target = None
+        if existing_target == target_dir:
+            return link_path
+        if link_path.is_dir():
+            shutil.rmtree(link_path)
+        else:
+            link_path.unlink()
+
+    link_path.symlink_to(target_dir, target_is_directory=True)
+    return link_path
 
 
 def _remove_symlink(download_id: Optional[str]) -> None:

--- a/UltraNodeV5/updateAllNodes.sh
+++ b/UltraNodeV5/updateAllNodes.sh
@@ -3,13 +3,17 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
 
 # --- CONFIG ---
 CONFIG_ROOT="${CONFIG_ROOT:-../../Configs}"
-FIRMWARE_DIR="${FIRMWARE_DIR:-${PROJECT_ROOT}/firmware}"
-FIRMWARE_ARCHIVE_DIR="${FIRMWARE_ARCHIVE_DIR:-${PROJECT_ROOT}/firmware_artifacts}"
+FIRMWARE_DIR="${PROJECT_ROOT}/firmware"
+FIRMWARE_ARCHIVE_DIR="${PROJECT_ROOT}/firmware_artifacts"
+
+# Ensure firmware is always stored inside the project tree, regardless of
+# previous environment overrides that pointed to the public symlink directory.
+mkdir -p "${FIRMWARE_DIR}"
 
 mkdir -p "${FIRMWARE_ARCHIVE_DIR}"
 


### PR DESCRIPTION
## Summary
- update the provisioning script to migrate any legacy firmware directories into the project firmware store and only expose download-id symlinks under /srv/firmware/UltraLights
- ensure the bulk flashing script always writes firmware artifacts into the repository firmware directories using physical project paths

## Testing
- pytest Server/tests/test_ota_credentials.py

------
https://chatgpt.com/codex/tasks/task_e_68d44e5c3350832685a0d5a2514f107a