### PR TITLE
Handle orphaned registry nodes when removing

### DIFF
--- a/Server/app/registry.py
+++ b/Server/app/registry.py
@@ -486,6 +486,17 @@ def remove_node(node_id: str) -> Node:
                     removed = nodes.pop(idx)
                     save_registry()
                     return removed
+
+        # Some legacy registry entries may contain nodes that are not yet
+        # associated with a room.  Clean those up as well so operators can
+        # remove orphaned nodes.
+        orphan_nodes = house.get("nodes")
+        if isinstance(orphan_nodes, list):
+            for idx, node in enumerate(orphan_nodes):
+                if isinstance(node, dict) and node.get("id") == node_id:
+                    removed = orphan_nodes.pop(idx)
+                    save_registry()
+                    return removed
     raise KeyError("node not found")
 
 

--- a/Server/tests/test_admin_api.py
+++ b/Server/tests/test_admin_api.py
@@ -101,6 +101,29 @@ def test_registry_remove_room(monkeypatch, tmp_path):
         registry.remove_room("house", "missing")
 
 
+def test_registry_remove_orphan_node(monkeypatch, tmp_path):
+    from app import registry
+    from app.config import settings
+
+    test_registry = [
+        {
+            "id": "house",
+            "name": "House",
+            "nodes": [
+                {"id": "orphan-node", "name": "Orphan", "kind": "ultranode"},
+            ],
+            "rooms": [],
+        }
+    ]
+
+    monkeypatch.setattr(settings, "REGISTRY_FILE", tmp_path / "registry.json")
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", deepcopy(test_registry))
+
+    removed = registry.remove_node("orphan-node")
+    assert removed["id"] == "orphan-node"
+    assert settings.DEVICE_REGISTRY[0]["nodes"] == []
+
+
 def test_registry_reorder_rooms(monkeypatch, tmp_path):
     from app import registry
     from app.config import settings


### PR DESCRIPTION
## Summary
- allow `registry.remove_node` to clean up nodes stored directly under a house
- add a regression test covering orphaned nodes without room assignments

## Testing
- pytest Server/tests/test_admin_api.py::test_registry_remove_orphan_node


------
https://chatgpt.com/codex/tasks/task_e_68d43aad3f488326a1204fb1fef72be2