### PR TITLE
Improve initial admin status refresh

### DIFF
--- a/Server/app/templates/admin.html
+++ b/Server/app/templates/admin.html
@@ -384,6 +384,10 @@ async function refreshStatuses() {
 }
 
 refreshStatuses();
+// Nodes may need a moment to respond to the freshly requested snapshots.
+// Trigger an additional refresh shortly after page load so we pick up the
+// responses without waiting for the longer polling interval.
+window.setTimeout(refreshStatuses, 2000);
 setInterval(refreshStatuses, 5000);
 
 const roomMenuContainer = document.querySelector('[data-room-menu]');


### PR DESCRIPTION
## Summary
- trigger an extra status refresh shortly after loading the admin page
- allow node snapshot responses to be picked up before the regular polling interval

## Testing
- pytest Server/tests/test_admin_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d4671b111483269bd5b3044d48c209