### PR TITLE
Store firmware artifacts under download identifiers

### DIFF
--- a/Server/docs/node-ids.md
+++ b/Server/docs/node-ids.md
@@ -30,7 +30,7 @@ no longer contains hashed OTA tokens.
 
 2. **Generate firmware defaults with the provisioning CLI.** Use
    [`Server/scripts/provision_node_firmware.py`](../scripts/provision_node_firmware.py)
-   to rotate the token, update `sdkconfig`, and manage the firmware symlink in a
+  to rotate the token, update `sdkconfig`, and manage the firmware directory in a
    single command:
 
    ```bash
@@ -44,9 +44,9 @@ no longer contains hashed OTA tokens.
    * optionally rotates the download alias (use `--rotate-download`),
    * writes `CONFIG_UL_NODE_ID`, `CONFIG_UL_OTA_MANIFEST_URL` and
      `CONFIG_UL_OTA_BEARER_TOKEN` into the selected `sdkconfig` files, and
-   * updates the `/srv/firmware/<download_id>` symlink (under the default
-     `/srv/firmware/UltraLights` root) to point at the node’s firmware
-     directory.
+  * ensures the `/srv/firmware/<download_id>` directory (under the default
+    `/srv/firmware/UltraLights` root) exists and contains the node’s firmware
+    artifacts.
 
 
    The plaintext token and manifest URL are printed once so you can archive them
@@ -65,18 +65,16 @@ no longer contains hashed OTA tokens.
    * perform incident response—for example revoking the current token and
      verifying that no other device is still using it.
 
-   Keeping the download ID handy also lets you inspect the corresponding
-
-   firmware folder on disk (`/srv/firmware/UltraLights/<download_id>`) during
-   troubleshooting without revealing the node slug. The download directory is a
-   symlink that always resolves to the real node folder (for example
-   `/srv/firmware/UltraLights/<node-id>`), so nothing is stored separately inside
-   the download ID itself.
+  Keeping the download ID handy also lets you inspect the corresponding
+  firmware folder on disk (`/srv/firmware/UltraLights/<download_id>`) during
+  troubleshooting without revealing the node slug. The download directory holds
+  the firmware artifacts directly, so nothing else in `/srv/firmware/UltraLights`
+  exposes the node identifier.
 
 3. **Build and publish firmware.** After the CLI patches `sdkconfig`, build the
-   firmware and place the resulting `latest.bin` into
-   `${FIRMWARE_DIR}/<node-id>/latest.bin`. The symlink maintained by the CLI
-   exposes the binary through the opaque download alias.
+  firmware and place the resulting `latest.bin` into
+  `${FIRMWARE_DIR}/<download-id>/latest.bin`. The directory name now matches the
+  opaque download alias, so the node ID never appears in the firmware store.
 
 4. **Audit provisioning status.** To see which nodes have already been
    provisioned, run the CLI with `--list`; provisioned entries are marked with an
@@ -85,7 +83,7 @@ no longer contains hashed OTA tokens.
 If you need to regenerate credentials manually, the
 [`manage_node_credentials`](../scripts/manage_node_credentials.py) helper still
 rotates tokens or download aliases and prints the new values, but the provisioning
-CLI is the recommended path because it keeps firmware defaults, symlinks and the
+CLI is the recommended path because it keeps firmware defaults, storage
 database in sync.
 
 ## Why keep download identifiers?
@@ -104,8 +102,9 @@ us a few operational conveniences:
   understands opaque node IDs.
 * The alias gives support staff a shareable handle for diagnostics—you can point
   someone at `/firmware/<download_id>/latest.bin` without also disclosing the
-  node ID. Because the alias is only a symlink, you can rotate or delete it once
-  the troubleshooting session is over.
+  node ID. Because the firmware lives under the download alias itself, retiring
+  an old identifier is as simple as deleting that directory once the
+  troubleshooting session is over.
 
 If these use cases eventually stop mattering we can collapse the indirection and
 serve binaries directly from the node ID, but for now the server and tooling are

--- a/Server/scripts/manage_node_credentials.py
+++ b/Server/scripts/manage_node_credentials.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import sys
 from pathlib import Path
 from typing import Optional
@@ -17,37 +18,61 @@ from app.auth.service import init_auth_storage  # noqa: E402
 from app.config import settings  # noqa: E402
 
 
-def _ensure_symlink(node_id: str, download_id: str) -> Path:
-    firmware_dir = settings.FIRMWARE_DIR
-    target_dir = firmware_dir / node_id
-    link_path = firmware_dir / download_id
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-
-    if link_path.exists() or link_path.is_symlink():
-        try:
-            existing_target = link_path.resolve(strict=True)
-        except FileNotFoundError:
-            existing_target = None
-        if existing_target == target_dir:
-            return link_path
-        if link_path.is_symlink() or link_path.is_file():
-            link_path.unlink()
-        else:
-            raise RuntimeError(
-                f"Refusing to replace existing directory at {link_path}"
-            )
-
-    link_path.symlink_to(target_dir, target_is_directory=True)
-    return link_path
-
-
-def _remove_symlink(download_id: Optional[str]) -> None:
+def _remove_download_directory(download_id: Optional[str]) -> None:
     if not download_id:
         return
-    link_path = settings.FIRMWARE_DIR / download_id
-    if link_path.is_symlink():
-        link_path.unlink()
+
+    path = settings.FIRMWARE_DIR / download_id
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _copy_tree(src: Path, dest: Path) -> None:
+    for child in src.iterdir():
+        target = dest / child.name
+        if child.is_dir():
+            shutil.copytree(child, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(child, target)
+
+
+def _ensure_download_directory(node_id: str, download_id: str) -> Path:
+    firmware_dir = settings.FIRMWARE_DIR
+    download_path = firmware_dir / download_id
+    legacy_dir = firmware_dir / node_id
+
+    if download_path.is_symlink():
+        try:
+            target = download_path.resolve(strict=True)
+        except FileNotFoundError:
+            target = None
+        download_path.unlink()
+        if target and target.exists() and target.is_dir():
+            try:
+                target.rename(download_path)
+            except OSError:
+                download_path.mkdir(parents=True, exist_ok=True)
+                _copy_tree(target, download_path)
+                if target == legacy_dir and legacy_dir.exists():
+                    shutil.rmtree(legacy_dir)
+            else:
+                return download_path
+
+    if download_path.exists() and not download_path.is_dir():
+        raise RuntimeError(f"Firmware path is not a directory: {download_path}")
+
+    download_path.mkdir(parents=True, exist_ok=True)
+
+    if legacy_dir.exists() and legacy_dir.is_dir() and legacy_dir != download_path:
+        _copy_tree(legacy_dir, download_path)
+        try:
+            shutil.rmtree(legacy_dir)
+        except OSError:
+            pass
+
+    return download_path
 
 
 def _issue_credentials(args: argparse.Namespace) -> int:
@@ -74,15 +99,13 @@ def _issue_credentials(args: argparse.Namespace) -> int:
 
         if not args.no_symlink:
             if previous_download and previous_download != download_id:
-                _remove_symlink(previous_download)
+                _remove_download_directory(previous_download)
             try:
-                link = _ensure_symlink(args.node_id, download_id)
+                storage_path = _ensure_download_directory(args.node_id, download_id)
             except RuntimeError as exc:  # pragma: no cover - defensive
                 print(f"Warning: {exc}", file=sys.stderr)
             else:
-                print(
-                    f"Symlink: {link} -> {link.resolve() if link.exists() else 'missing'}"
-                )
+                print(f"Firmware directory: {storage_path}")
 
         if args.token:
             credential, token = node_credentials.rotate_token(
@@ -129,7 +152,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--no-symlink",
         action="store_true",
-        help="Do not manage firmware symlinks for the download identifier.",
+        help="Do not manage the firmware download directory on disk.",
     )
     return parser
 

--- a/Server/scripts/provision_node_firmware.py
+++ b/Server/scripts/provision_node_firmware.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -21,37 +22,61 @@ from app.auth.service import init_auth_storage  # noqa: E402
 from app.config import settings  # noqa: E402
 
 
-def _ensure_symlink(node_id: str, download_id: str) -> Path:
-    firmware_dir = settings.FIRMWARE_DIR
-    target_dir = firmware_dir / node_id
-    link_path = firmware_dir / download_id
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-
-    if link_path.exists() or link_path.is_symlink():
-        try:
-            existing_target = link_path.resolve(strict=True)
-        except FileNotFoundError:
-            existing_target = None
-        if existing_target == target_dir:
-            return link_path
-        if link_path.is_symlink() or link_path.is_file():
-            link_path.unlink()
-        else:
-            raise RuntimeError(
-                f"Refusing to replace existing directory at {link_path}"
-            )
-
-    link_path.symlink_to(target_dir, target_is_directory=True)
-    return link_path
-
-
-def _remove_symlink(download_id: Optional[str]) -> None:
+def _remove_download_directory(download_id: Optional[str]) -> None:
     if not download_id:
         return
-    link_path = settings.FIRMWARE_DIR / download_id
-    if link_path.is_symlink():
-        link_path.unlink()
+
+    path = settings.FIRMWARE_DIR / download_id
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _copy_tree(src: Path, dest: Path) -> None:
+    for child in src.iterdir():
+        target = dest / child.name
+        if child.is_dir():
+            shutil.copytree(child, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(child, target)
+
+
+def _ensure_download_directory(node_id: str, download_id: str) -> Path:
+    firmware_dir = settings.FIRMWARE_DIR
+    download_path = firmware_dir / download_id
+    legacy_dir = firmware_dir / node_id
+
+    if download_path.is_symlink():
+        try:
+            target = download_path.resolve(strict=True)
+        except FileNotFoundError:
+            target = None
+        download_path.unlink()
+        if target and target.exists() and target.is_dir():
+            try:
+                target.rename(download_path)
+            except OSError:
+                download_path.mkdir(parents=True, exist_ok=True)
+                _copy_tree(target, download_path)
+                if target == legacy_dir and legacy_dir.exists():
+                    shutil.rmtree(legacy_dir)
+            else:
+                return download_path
+
+    if download_path.exists() and not download_path.is_dir():
+        raise RuntimeError(f"Firmware path is not a directory: {download_path}")
+
+    download_path.mkdir(parents=True, exist_ok=True)
+
+    if legacy_dir.exists() and legacy_dir.is_dir() and legacy_dir != download_path:
+        _copy_tree(legacy_dir, download_path)
+        try:
+            shutil.rmtree(legacy_dir)
+        except OSError:
+            pass
+
+    return download_path
 
 
 def _update_sdkconfig(path: Path, values: Dict[str, str]) -> None:
@@ -230,18 +255,18 @@ def _provision(args: argparse.Namespace) -> int:
 
         if not args.no_symlink:
             if previous_download and previous_download != download_id:
-                _remove_symlink(previous_download)
+                _remove_download_directory(previous_download)
             try:
-                link = _ensure_symlink(args.node_id, download_id)
+                storage_path = _ensure_download_directory(
+                    args.node_id, download_id
+                )
             except RuntimeError as exc:  # pragma: no cover - defensive
                 print(f"Warning: {exc}", file=sys.stderr)
-                link = None
+                storage_path = None
             else:
-                print(
-                    f"Symlink: {link} -> {link.resolve() if link.exists() else 'missing'}"
-                )
+                print(f"Firmware directory: {storage_path}")
         else:
-            link = None
+            storage_path = None
 
         credential, token = node_credentials.rotate_token(session, args.node_id)
 
@@ -281,8 +306,8 @@ def _provision(args: argparse.Namespace) -> int:
         print("Updated configuration files:")
         for cfg in updated_files:
             print(f"  - {cfg}")
-    if link:
-        print(f"Firmware symlink: {link}")
+    if storage_path:
+        print(f"Firmware directory: {storage_path}")
     return 0
 
 
@@ -303,7 +328,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--no-symlink",
         action="store_true",
-        help="Skip creating the firmware download symlink.",
+        help="Skip managing the firmware download directory on disk.",
     )
     parser.add_argument(
         "--allow-reprovision",

--- a/Server/tests/test_ota_credentials.py
+++ b/Server/tests/test_ota_credentials.py
@@ -275,9 +275,9 @@ def test_manage_node_credentials_cli_creates_token(tmp_path, monkeypatch):
         assert record.download_id == "CLISLOT123"
         assert record.token_hash == registry.hash_node_token("plain-token")
 
-    link = firmware_dir / "CLISLOT123"
-    assert link.is_symlink()
-    assert link.resolve() == firmware_dir / "cli-node"
+    download_dir = firmware_dir / "CLISLOT123"
+    assert download_dir.is_dir()
+    assert not download_dir.is_symlink()
 
     monkeypatch.setattr(settings, "DEVICE_REGISTRY", original_registry)
     monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", original_registry)
@@ -383,9 +383,9 @@ def test_provision_node_firmware_updates_sdkconfig(tmp_path, monkeypatch, capsys
         assert record.token_hash == registry.hash_node_token(token_value)
         assert record.provisioned_at is not None
 
-    link = firmware_dir / record.download_id
-    assert link.is_symlink()
-    assert link.resolve() == firmware_dir / "provision-node"
+    download_dir = firmware_dir / record.download_id
+    assert download_dir.is_dir()
+    assert not download_dir.is_symlink()
 
     assert "Bearer Token" in output
     assert token_value in output

--- a/UltraNodeV5/updateAllNodes.sh
+++ b/UltraNodeV5/updateAllNodes.sh
@@ -10,6 +10,7 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CONFIG_ROOT="${CONFIG_ROOT:-../../Configs}"
 FIRMWARE_DIR="${FIRMWARE_DIR:-/srv/firmware/UltraLights}"
 FIRMWARE_ARCHIVE_DIR="${FIRMWARE_ARCHIVE_DIR:-${PROJECT_ROOT}/firmware_artifacts}"
+FIRMWARE_ROOT_NAME="$(basename "$FIRMWARE_DIR")"
 
 mkdir -p "${FIRMWARE_ARCHIVE_DIR}"
 
@@ -90,15 +91,148 @@ remove_file_with_sudo() {
   sudo rm -f "$path"
 }
 
-migrate_legacy_archives() {
-  local nodeid="$1"
-  local node_dir="$FIRMWARE_DIR/$nodeid"
-  local archive_node_dir="$FIRMWARE_ARCHIVE_DIR/$nodeid"
+ensure_directory() {
+  local dir="$1"
+  mkdir -p "$dir" 2>/dev/null || sudo mkdir -p "$dir"
+}
 
-  mkdir -p "$archive_node_dir"
+copy_tree_with_sudo() {
+  local src="$1"
+  local dest="$2"
+
+  if [[ ! -d "$src" ]]; then
+    return
+  fi
+
+  ensure_directory "$dest"
+
+  if ! cp -a "$src/." "$dest/" 2>/dev/null; then
+    sudo cp -a "$src/." "$dest/" 2>/dev/null || true
+  fi
+}
+
+remove_dir_with_sudo() {
+  local dir="$1"
+
+  if [[ ! -d "$dir" ]]; then
+    return
+  fi
+
+  if rm -rf "$dir" 2>/dev/null; then
+    return
+  fi
+
+  sudo rm -rf "$dir" 2>/dev/null || true
+}
+
+prepare_download_directory() {
+  local download_dir="$1"
+  local legacy_dir="$2"
+
+  if [[ -e "$download_dir" && ! -d "$download_dir" && ! -L "$download_dir" ]]; then
+    echo "ERROR: $download_dir exists and is not a directory" >&2
+    exit 1
+  fi
+
+  if [[ -L "$download_dir" ]]; then
+    local target
+    target="$(readlink -f "$download_dir" || true)"
+    echo "Converting legacy symlink $download_dir -> ${target:-missing} to directory"
+    if ! rm -f "$download_dir" 2>/dev/null; then
+      sudo rm -f "$download_dir"
+    fi
+    ensure_directory "$download_dir"
+    if [[ -n "$target" && -d "$target" && "$target" != "$download_dir" ]]; then
+      echo "Copying firmware files from $target into $download_dir"
+      copy_tree_with_sudo "$target" "$download_dir"
+    fi
+  else
+    ensure_directory "$download_dir"
+  fi
+
+  if [[ -d "$legacy_dir" && "$legacy_dir" != "$download_dir" ]]; then
+    echo "Migrating legacy firmware directory $legacy_dir into $download_dir"
+    copy_tree_with_sudo "$legacy_dir" "$download_dir"
+    remove_dir_with_sudo "$legacy_dir"
+  fi
+}
+
+get_sdkconfig_value() {
+  local sdkconfig_path="$1"
+  local key="$2"
+
+  python3 - "$sdkconfig_path" "$key" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+key = sys.argv[2]
+
+try:
+    lines = path.read_text().splitlines()
+except FileNotFoundError:
+    sys.exit(0)
+
+prefix = f"{key}="
+for line in lines:
+    if not line.startswith(prefix):
+        continue
+    value = line[len(prefix):].strip()
+    if value.startswith('"') and value.endswith('"'):
+        value = value[1:-1]
+    print(value)
+    break
+PY
+}
+
+extract_download_id_from_url() {
+  local url="$1"
+  local firmware_root_name="$2"
+
+  python3 - "$url" "$firmware_root_name" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+url = sys.argv[1]
+firmware_root = sys.argv[2]
+
+if not url:
+    sys.exit(0)
+
+path = urlparse(url).path
+parts = [p for p in path.split("/") if p]
+
+try:
+    idx = parts.index("firmware")
+except ValueError:
+    sys.exit(0)
+
+segments = parts[idx + 1 :]
+if not segments:
+    sys.exit(0)
+
+candidate = segments[0]
+
+if len(segments) >= 2 and candidate == firmware_root:
+    candidate = segments[1]
+
+if candidate in {"manifest", "manifest.json", "latest.bin"} and len(segments) >= 2:
+    candidate = segments[-2]
+
+if candidate:
+    print(candidate)
+PY
+}
+
+migrate_legacy_archives() {
+  local storage_dir="$1"
+  local archive_node_dir="$2"
+  local label="$3"
+
+  ensure_directory "$archive_node_dir"
 
   local legacy_file
-  for legacy_file in "$node_dir"/*.bin; do
+  for legacy_file in "$storage_dir"/*.bin; do
     local base
     base="$(basename "$legacy_file")"
 
@@ -106,7 +240,7 @@ migrate_legacy_archives() {
       continue
     fi
 
-    echo "Migrating legacy firmware artifact $base for $nodeid to private archive"
+    echo "Migrating legacy firmware artifact $base for ${label:-node} to private archive"
     copy_file_to_private_archive "$legacy_file" "$archive_node_dir/$base"
     remove_file_with_sudo "$legacy_file"
   done
@@ -114,15 +248,17 @@ migrate_legacy_archives() {
 
 archive_and_update_latest() {
   local nodeid="$1"
-  local node_dir="$FIRMWARE_DIR/$nodeid"
+  local downloadid="$2"
+  local download_dir="$FIRMWARE_DIR/$downloadid"
+  local legacy_dir="$FIRMWARE_DIR/$nodeid"
   local archive_node_dir="$FIRMWARE_ARCHIVE_DIR/$nodeid"
   local new_bin="build/ultralights.bin"
-  local manifest_path="$node_dir/manifest.json"
+  local manifest_path="$download_dir/manifest.json"
 
-  mkdir -p "$node_dir"
-  mkdir -p "$archive_node_dir"
+  prepare_download_directory "$download_dir" "$legacy_dir"
+  ensure_directory "$archive_node_dir"
 
-  migrate_legacy_archives "$nodeid"
+  migrate_legacy_archives "$download_dir" "$archive_node_dir" "$nodeid"
 
   local previous_version=""
   if [[ -f "$manifest_path" ]]; then
@@ -151,7 +287,7 @@ PY
   fi
 
   # Move previous latest.bin into the private archive if it exists
-  if [[ -f "$node_dir/latest.bin" ]]; then
+  if [[ -f "$download_dir/latest.bin" ]]; then
     if [[ -n "$previous_version" ]]; then
       local safe_prev_version
       safe_prev_version="$(sanitize_version "$previous_version")"
@@ -161,7 +297,7 @@ PY
         archived_path="$archive_node_dir/${safe_prev_version}.bin"
 
         echo "Archiving previous latest.bin for $nodeid -> ${safe_prev_version}.bin (version $previous_version) in private storage"
-        copy_file_to_private_archive "$node_dir/latest.bin" "$archived_path"
+        copy_file_to_private_archive "$download_dir/latest.bin" "$archived_path"
       else
         echo "WARNING: Previous manifest version for $nodeid sanitized to empty; skipping archive rename."
       fi
@@ -175,8 +311,8 @@ PY
   # Copy newly built firmware to latest.bin
   if [[ -f "$new_bin" ]]; then
     echo "Updating latest.bin for $nodeid"
-    sudo cp "$new_bin" "$node_dir/latest.bin"
-    sudo chmod 644 "$node_dir/latest.bin" 2>/dev/null || true
+    sudo cp "$new_bin" "$download_dir/latest.bin"
+    sudo chmod 644 "$download_dir/latest.bin" 2>/dev/null || true
 
     local safe_current_version
     safe_current_version="$(sanitize_version "$FIRMWARE_VERSION")"
@@ -272,8 +408,12 @@ PY
 write_manifest() {
   local nodeid="$1"
   local version="$2"
-  local node_dir="$FIRMWARE_DIR/$nodeid"
-  local latest_bin="$node_dir/latest.bin"
+  local downloadid="$3"
+  local download_dir="$FIRMWARE_DIR/$downloadid"
+  local legacy_dir="$FIRMWARE_DIR/$nodeid"
+  local latest_bin="$download_dir/latest.bin"
+
+  prepare_download_directory "$download_dir" "$legacy_dir"
 
   if [[ ! -f "$latest_bin" ]]; then
     echo "WARNING: Cannot create manifest for $nodeid (missing $latest_bin)" >&2
@@ -301,8 +441,8 @@ write_manifest() {
 JSON
   )
 
-  local manifest_path="$node_dir/manifest.json"
-  local manifest_versioned="$node_dir/manifest_${safe_version}.json"
+  local manifest_path="$download_dir/manifest.json"
+  local manifest_versioned="$download_dir/manifest_${safe_version}.json"
   local tmp
   tmp=$(mktemp)
   printf '%s\n' "$manifest_json" > "$tmp"
@@ -343,9 +483,21 @@ for target_dir in "$CONFIG_ROOT"/*/; do
   configs_found=false
   for config_file in "$target_dir"/sdkconfig.*; do
     configs_found=true
-    nodeid="${config_file##*.}"
+    nodeid_guess="${config_file##*.}"
+    sdk_nodeid="$(get_sdkconfig_value "$config_file" "CONFIG_UL_NODE_ID")"
+    if [[ -n "$sdk_nodeid" ]]; then
+      nodeid="$sdk_nodeid"
+    else
+      nodeid="$nodeid_guess"
+    fi
+    manifest_url="$(get_sdkconfig_value "$config_file" "CONFIG_UL_OTA_MANIFEST_URL")"
+    downloadid="$(extract_download_id_from_url "$manifest_url" "$FIRMWARE_ROOT_NAME")"
+    if [[ -z "$downloadid" ]]; then
+      downloadid="$nodeid"
+      echo "WARNING: Falling back to node id for firmware directory of $nodeid" >&2
+    fi
     echo
-    echo "--- Processing node: $nodeid ---"
+    echo "--- Processing node: $nodeid (download $downloadid) ---"
     echo "Using config: $config_file"
 
     # Copy sdkconfig in place for this build/flash
@@ -364,8 +516,8 @@ for target_dir in "$CONFIG_ROOT"/*/; do
     $FLASH_CMD
 
     # Version/rotate artifacts
-    archive_and_update_latest "$nodeid"
-    write_manifest "$nodeid" "$FIRMWARE_VERSION"
+    archive_and_update_latest "$nodeid" "$downloadid"
+    write_manifest "$nodeid" "$FIRMWARE_VERSION" "$downloadid"
     echo "--- Done: $nodeid ---"
   done
 


### PR DESCRIPTION
## Summary
- store firmware artifacts directly under their download identifiers instead of node directories and symlinks
- update OTA serving logic, provisioning/credential CLIs, and the bulk update script to prepare and migrate download directories
- refresh documentation and tests to reflect the new firmware storage layout

## Testing
- pytest Server/tests

------
https://chatgpt.com/codex/tasks/task_e_68d47e4e1a948326889db25ebacb8aed