### PR TITLE
Store firmware artifacts under download directories

### DIFF
--- a/Server/scripts/manage_node_credentials.py
+++ b/Server/scripts/manage_node_credentials.py
@@ -17,37 +17,10 @@ from app.auth.service import init_auth_storage  # noqa: E402
 from app.config import settings  # noqa: E402
 
 
-def _ensure_symlink(node_id: str, download_id: str) -> Path:
-    firmware_dir = settings.FIRMWARE_DIR
-    target_dir = firmware_dir / node_id
-    link_path = firmware_dir / download_id
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-
-    if link_path.exists() or link_path.is_symlink():
-        try:
-            existing_target = link_path.resolve(strict=True)
-        except FileNotFoundError:
-            existing_target = None
-        if existing_target == target_dir:
-            return link_path
-        if link_path.is_symlink() or link_path.is_file():
-            link_path.unlink()
-        else:
-            raise RuntimeError(
-                f"Refusing to replace existing directory at {link_path}"
-            )
-
-    link_path.symlink_to(target_dir, target_is_directory=True)
-    return link_path
-
-
-def _remove_symlink(download_id: Optional[str]) -> None:
-    if not download_id:
-        return
-    link_path = settings.FIRMWARE_DIR / download_id
-    if link_path.is_symlink():
-        link_path.unlink()
+def _ensure_download_dir(download_id: str) -> Path:
+    download_dir = settings.FIRMWARE_DIR / download_id
+    download_dir.mkdir(parents=True, exist_ok=True)
+    return download_dir
 
 
 def _issue_credentials(args: argparse.Namespace) -> int:
@@ -72,17 +45,8 @@ def _issue_credentials(args: argparse.Namespace) -> int:
 
         download_id = credential.download_id
 
-        if not args.no_symlink:
-            if previous_download and previous_download != download_id:
-                _remove_symlink(previous_download)
-            try:
-                link = _ensure_symlink(args.node_id, download_id)
-            except RuntimeError as exc:  # pragma: no cover - defensive
-                print(f"Warning: {exc}", file=sys.stderr)
-            else:
-                print(
-                    f"Symlink: {link} -> {link.resolve() if link.exists() else 'missing'}"
-                )
+        download_dir = _ensure_download_dir(download_id)
+        print(f"Firmware directory: {download_dir}")
 
         if args.token:
             credential, token = node_credentials.rotate_token(
@@ -125,11 +89,6 @@ def _build_parser() -> argparse.ArgumentParser:
         "--rotate-download",
         action="store_true",
         help="Force generation of a new download identifier even if one already exists.",
-    )
-    parser.add_argument(
-        "--no-symlink",
-        action="store_true",
-        help="Do not manage firmware symlinks for the download identifier.",
     )
     return parser
 

--- a/Server/tests/test_ota_credentials.py
+++ b/Server/tests/test_ota_credentials.py
@@ -275,9 +275,10 @@ def test_manage_node_credentials_cli_creates_token(tmp_path, monkeypatch):
         assert record.download_id == "CLISLOT123"
         assert record.token_hash == registry.hash_node_token("plain-token")
 
-    link = firmware_dir / "CLISLOT123"
-    assert link.is_symlink()
-    assert link.resolve() == firmware_dir / "cli-node"
+    download_dir = firmware_dir / "CLISLOT123"
+    assert download_dir.exists()
+    assert download_dir.is_dir()
+    assert not download_dir.is_symlink()
 
     monkeypatch.setattr(settings, "DEVICE_REGISTRY", original_registry)
     monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", original_registry)
@@ -383,9 +384,10 @@ def test_provision_node_firmware_updates_sdkconfig(tmp_path, monkeypatch, capsys
         assert record.token_hash == registry.hash_node_token(token_value)
         assert record.provisioned_at is not None
 
-    link = firmware_dir / record.download_id
-    assert link.is_symlink()
-    assert link.resolve() == firmware_dir / "provision-node"
+    download_dir = firmware_dir / record.download_id
+    assert download_dir.exists()
+    assert download_dir.is_dir()
+    assert not download_dir.is_symlink()
 
     assert "Bearer Token" in output
     assert token_value in output


### PR DESCRIPTION
## Summary
- ensure the provisioning and credential CLI tools create firmware directories named by download IDs instead of node symlinks
- teach the OTA API and bulk update script to read artifacts from download ID directories while preserving legacy fallbacks
- update docs and tests to reflect the new storage layout

## Testing
- pytest Server/tests/test_ota_credentials.py

------
https://chatgpt.com/codex/tasks/task_e_68d48385111c832681058079b397c652