### PR TITLE
Default white channels to off until connected

### DIFF
--- a/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
+++ b/UltraNodeV5/components/ul_white_engine/ul_white_engine.c
@@ -113,7 +113,8 @@ static void ch_init(int idx, bool enabled, int gpio, int ledc_ch, int pwm_hz) {
     s_ch[idx].gpio = gpio;
     s_ch[idx].ledc_ch = ledc_ch;
     s_ch[idx].pwm_hz = pwm_hz;
-    s_ch[idx].brightness = 255;
+    // Default to lights off until an explicit brightness is received.
+    s_ch[idx].brightness = 0;
     int n=0; const white_effect_t* t = ul_white_get_effects(&n);
     s_ch[idx].eff = &t[0];
     s_ch[idx].frame_idx = 0;


### PR DESCRIPTION
## Summary
- ensure white channel initialization defaults brightness to zero so lights stay off until commanded

## Testing
- not run (ESP-IDF tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d569a7c81483269564f3b6e98598d6