### PR TITLE
Consider snapshot events for admin online status

### DIFF
--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -1159,6 +1159,7 @@ def api_admin_status(
             "online": bool(info.get("online")),
             "last_ok": _iso(info.get("last_ok")),
             "last_seen": _iso(info.get("last_seen")),
+            "last_snapshot": _iso(info.get("last_snapshot")),
             "status": info.get("status"),
             "signal_dbi": signal_value,
         }

--- a/Server/app/templates/admin.html
+++ b/Server/app/templates/admin.html
@@ -362,9 +362,13 @@ async function refreshStatuses() {
       if (lastEl) {
         const lastOk = info.last_ok ? Date.parse(info.last_ok) : null;
         const lastSeen = info.last_seen ? Date.parse(info.last_seen) : null;
+        const lastSnapshot = info.last_snapshot ? Date.parse(info.last_snapshot) : null;
         if (lastOk) {
           const seconds = (nowTs - lastOk) / 1000;
           lastEl.textContent = `OK ${formatDelta(seconds)}`;
+        } else if (lastSnapshot) {
+          const seconds = (nowTs - lastSnapshot) / 1000;
+          lastEl.textContent = `Snapshot ${formatDelta(seconds)}`;
         } else if (lastSeen) {
           const seconds = (nowTs - lastSeen) / 1000;
           lastEl.textContent = `Seen ${formatDelta(seconds)}`;

--- a/Server/tests/test_status_monitor.py
+++ b/Server/tests/test_status_monitor.py
@@ -1,0 +1,38 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.status_monitor import StatusMonitor
+
+
+def _make_message(topic: str, payload: dict) -> SimpleNamespace:
+    return SimpleNamespace(topic=topic, payload=json.dumps(payload).encode("utf-8"))
+
+
+def test_snapshot_event_marks_node_online(monkeypatch):
+    monitor = StatusMonitor(timeout=30)
+
+    snapshot_msg = _make_message(
+        "ul/node-1/evt/status",
+        {"event": "snapshot"},
+    )
+    monitor._on_message(monitor.client, None, snapshot_msg)
+
+    info = monitor.snapshot().get("node-1")
+    assert info is not None
+    assert info["online"] is True
+    assert info["last_snapshot"] is not None
+
+    # Age the snapshot beyond the timeout to ensure it no longer counts.
+    node_snapshot_time = info["last_snapshot"]
+    assert node_snapshot_time is not None
+    monitor._last_snapshot["node-1"] = node_snapshot_time - 31
+
+    aged = monitor.snapshot().get("node-1")
+    assert aged is not None
+    assert aged["online"] is False


### PR DESCRIPTION
## Summary
- treat snapshot MQTT events as connection indicators in the status monitor and expose their timestamps via the admin status API
- update the admin dashboard to show when a recent snapshot was received and light nodes green when snapshots arrive
- add a regression test to ensure snapshot events within the timeout mark nodes online

## Testing
- pytest Server/tests/test_status_monitor.py

------
https://chatgpt.com/codex/tasks/task_e_68d5ac8e65988326b480d9070c336928