### PR TITLE
Update MQTT TLS configuration and credentials

### DIFF
--- a/Server/.env
+++ b/Server/.env
@@ -15,8 +15,12 @@ SSL_KEYFILE=/etc/letsencrypt/live/lights.evm100.com/privkey.pem
 # ---------------------------------------------------------------------------
 # MQTT broker
 # ---------------------------------------------------------------------------
-BROKER_HOST=127.0.0.1
-BROKER_PORT=1883
+BROKER_HOST=lights.evm100.org
+BROKER_PORT=8883
+BROKER_USERNAME=uluser
+BROKER_PASSWORD=ulpwd
+BROKER_TLS_ENABLED=1
+BROKER_TLS_INSECURE=0
 EMBED_BROKER=0
 
 # ---------------------------------------------------------------------------

--- a/Server/README.md
+++ b/Server/README.md
@@ -60,13 +60,33 @@ and trust material through the following environment variables:
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `BROKER_HOST` | MQTT broker hostname. | `127.0.0.1` |
+| `BROKER_HOST` | MQTT broker hostname. | `lights.evm100.org` |
 | `BROKER_PORT` | MQTT broker port. | `8883` |
+| `BROKER_USERNAME` | Username used to authenticate with the broker. | empty |
+| `BROKER_PASSWORD` | Password paired with `BROKER_USERNAME`. | empty |
 | `BROKER_TLS_ENABLED` | Enable MQTT over TLS. Set to `0` to disable. | `1` (unless `EMBED_BROKER=1`) |
 | `BROKER_TLS_CA_FILE` | Path to a CA bundle for broker verification. | empty (system defaults) |
 | `BROKER_TLS_CERTFILE` | Client certificate for mutual TLS. | empty |
 | `BROKER_TLS_KEYFILE` | Private key for the client certificate. | empty |
 | `BROKER_TLS_INSECURE` | Accept invalid certificates (development only). | `0` |
+
+When targeting the hosted Mosquitto instance (listener `8883` with TLS enforced)
+the `.env` file should provide the following snippet so the server and helper
+scripts authenticate correctly:
+
+```
+BROKER_HOST=lights.evm100.org
+BROKER_PORT=8883
+BROKER_USERNAME=uluser
+BROKER_PASSWORD=ulpwd
+BROKER_TLS_ENABLED=1
+BROKER_TLS_INSECURE=0
+```
+
+The broker is configured with Let's Encrypt certificates at
+`/etc/mosquitto/certs/fullchain.pem` and `privkey.pem` and only accepts TLS 1.2
+connections. Clients rely on the system CA bundle, so additional certificate
+paths are unnecessary unless a custom trust store is desired.
 
 ## Operational notes
 

--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -16,6 +16,8 @@ class Settings:
 
     BROKER_HOST = os.getenv("BROKER_HOST", "127.0.0.1")
     BROKER_PORT = int(os.getenv("BROKER_PORT", "8883"))
+    BROKER_USERNAME = os.getenv("BROKER_USERNAME", "")
+    BROKER_PASSWORD = os.getenv("BROKER_PASSWORD", "")
     EMBED_BROKER = os.getenv("EMBED_BROKER", "0") == "1"
     _broker_tls_default = "0" if EMBED_BROKER else "1"
     BROKER_TLS_ENABLED = os.getenv("BROKER_TLS_ENABLED", _broker_tls_default) == "1"

--- a/Server/app/mqtt_tls.py
+++ b/Server/app/mqtt_tls.py
@@ -35,4 +35,8 @@ def connect_mqtt_client(client: mqtt.Client, *, keepalive: int = 30) -> None:
     """Configure TLS (if enabled) and connect ``client`` to the broker."""
 
     configure_client_tls(client)
+    if settings.BROKER_USERNAME or settings.BROKER_PASSWORD:
+        set_credentials = getattr(client, "username_pw_set", None)
+        if callable(set_credentials):
+            set_credentials(settings.BROKER_USERNAME, settings.BROKER_PASSWORD)
     client.connect(settings.BROKER_HOST, settings.BROKER_PORT, keepalive=keepalive)

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -69,8 +69,10 @@ menu "MQTT"
         default "mqtts://lights.evm100.org:8883"
     config UL_MQTT_USER
         string "MQTT Username"
+        default "uluser"
     config UL_MQTT_PASS
         string "MQTT Password"
+        default "ulpwd"
     config UL_MQTT_USE_TLS
         bool "Use TLS for MQTT"
         default y


### PR DESCRIPTION
## Summary
- refresh the documented MQTT environment variables to match the TLS-enabled Mosquitto broker
- add broker credentials to the server configuration and client connection helper
- set the firmware defaults to the new MQTT username/password so nodes connect to the secured broker

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5eb60f17c83268f81e0b329df36e0