### PR TITLE
Handle MQTT monitor gracefully in runServer

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -95,3 +95,7 @@ paths are unnecessary unless a custom trust store is desired.
 - The CLI respects the same SQLModel storage location as the API. Update the
   `AUTH_DB_URL` environment variable or pass `--database-url` to direct it at a
   different SQLite file or database server.
+- When launching the app with `runServer.sh`, the script attempts to open a
+  gnome-terminal window running `mosquitto_sub` for live MQTT monitoring. If no
+  terminal emulator is available, it falls back to a background `mosquitto_sub`
+  subscriber so message logging continues without blocking the server startup.

--- a/Server/runServer.sh
+++ b/Server/runServer.sh
@@ -26,6 +26,13 @@ else
   OPTS=(--host "${WEB_HOST:-0.0.0.0}" --port "${WEB_PORT:-8080}" --proxy-headers --forwarded-allow-ips='*' --log-level info)
 fi
 
-gnome-terminal -- bash -c "mosquitto_sub -t \"#\" -v; exec bash" &
+if command -v gnome-terminal >/dev/null 2>&1 && [[ -n "${DISPLAY:-}" ]]; then
+  gnome-terminal -- bash -c "mosquitto_sub -t \"#\" -v; exec bash" &
+elif command -v mosquitto_sub >/dev/null 2>&1; then
+  echo "gnome-terminal unavailable; starting background mosquitto_sub subscriber"
+  mosquitto_sub -t "#" -v &
+else
+  echo "WARNING: MQTT monitor disabled (requires gnome-terminal or mosquitto_sub)" >&2
+fi
 
 exec uvicorn app.main:app "${OPTS[@]}"


### PR DESCRIPTION
## Summary
- guard the gnome-terminal MQTT monitor in runServer.sh by checking for DISPLAY availability and fall back to a background mosquitto_sub subscriber when needed
- document the optional MQTT monitoring behavior in the server operations guide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5ee228bfc83268ac991675321a874