### PR TITLE
Enable MQTTs monitoring in runServer

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -95,3 +95,9 @@ paths are unnecessary unless a custom trust store is desired.
 - The CLI respects the same SQLModel storage location as the API. Update the
   `AUTH_DB_URL` environment variable or pass `--database-url` to direct it at a
   different SQLite file or database server.
+- When launching the app with `runServer.sh`, the script attempts to open a
+  gnome-terminal window running `mosquitto_sub` for live MQTT monitoring. The
+  subscriber inherits the broker credentials and TLS configuration from the
+  environment so it connects over MQTTs when enabled. If no terminal emulator is
+  available, the script falls back to a background `mosquitto_sub` subscriber so
+  message logging continues without blocking the server startup.

--- a/Server/runServer.sh
+++ b/Server/runServer.sh
@@ -26,6 +26,46 @@ else
   OPTS=(--host "${WEB_HOST:-0.0.0.0}" --port "${WEB_PORT:-8080}" --proxy-headers --forwarded-allow-ips='*' --log-level info)
 fi
 
-gnome-terminal -- bash -c "mosquitto_sub -t \"#\" -v; exec bash" &
+if command -v mosquitto_sub >/dev/null 2>&1; then
+  default_mqtt_port="1883"
+  if [[ "${BROKER_TLS_ENABLED:-1}" != "0" ]]; then
+    default_mqtt_port="8883"
+  fi
+
+  MQTT_SUB_OPTS=(-h "${BROKER_HOST:-localhost}" -p "${BROKER_PORT:-$default_mqtt_port}" -t "#" -v)
+
+  if [[ -n "${BROKER_USERNAME:-}" ]]; then
+    MQTT_SUB_OPTS+=(-u "$BROKER_USERNAME")
+  fi
+  if [[ -n "${BROKER_PASSWORD:-}" ]]; then
+    MQTT_SUB_OPTS+=(-P "$BROKER_PASSWORD")
+  fi
+
+  if [[ "${BROKER_TLS_ENABLED:-1}" != "0" ]]; then
+    if [[ -n "${BROKER_TLS_CA_FILE:-}" && -f "${BROKER_TLS_CA_FILE}" ]]; then
+      MQTT_SUB_OPTS+=(--cafile "$BROKER_TLS_CA_FILE")
+    fi
+    if [[ -n "${BROKER_TLS_CERTFILE:-}" && -f "${BROKER_TLS_CERTFILE}" ]]; then
+      MQTT_SUB_OPTS+=(--cert "$BROKER_TLS_CERTFILE")
+    fi
+    if [[ -n "${BROKER_TLS_KEYFILE:-}" && -f "${BROKER_TLS_KEYFILE}" ]]; then
+      MQTT_SUB_OPTS+=(--key "$BROKER_TLS_KEYFILE")
+    fi
+    if [[ "${BROKER_TLS_INSECURE:-0}" != "0" ]]; then
+      MQTT_SUB_OPTS+=(--insecure)
+    fi
+  fi
+
+  if command -v gnome-terminal >/dev/null 2>&1 && [[ -n "${DISPLAY:-}" ]]; then
+    mqtt_cmd=$(printf '%q ' mosquitto_sub "${MQTT_SUB_OPTS[@]}")
+    mqtt_cmd=${mqtt_cmd% }
+    gnome-terminal -- bash -c "${mqtt_cmd}; exec bash" &
+  else
+    echo "gnome-terminal unavailable; starting background mosquitto_sub subscriber"
+    mosquitto_sub "${MQTT_SUB_OPTS[@]}" &
+  fi
+else
+  echo "WARNING: MQTT monitor disabled (requires gnome-terminal or mosquitto_sub)" >&2
+fi
 
 exec uvicorn app.main:app "${OPTS[@]}"


### PR DESCRIPTION
## Summary
- configure the runServer MQTT monitor to reuse broker credentials and TLS settings so the gnome-terminal window connects over MQTTs when enabled
- ensure the headless mosquitto_sub fallback uses the same secure options and document the behavior in the server README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5ee228bfc83268ac991675321a874