### PR TITLE
Adjust Wi-Fi reset GPIO defaults for ESP32-C3

### DIFF
--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -3,6 +3,7 @@ menu "UltraLights Configuration"
 menu "System"
     config UL_IS_ESP32C3
         bool "Target is ESP32-C3"
+        default y if IDF_TARGET_ESP32C3
         default n
 
     config UL_HAS_PSRAM
@@ -42,6 +43,7 @@ menu "Node / Network"
         config UL_WIFI_RESET_BUTTON_GPIO
             int "Wi-Fi reset button GPIO"
             range 0 48
+            default 9 if IDF_TARGET_ESP32C3
             default 0
         config UL_WIFI_RESET_BUTTON_HOLD_MS
             int "Wi-Fi reset hold time (ms)"


### PR DESCRIPTION
## Summary
- set the Wi-Fi reset button default GPIO to 9 when targeting ESP32-C3
- retain GPIO 0 as the default for other targets
- automatically enable the ESP32-C3 flag when the IDF target is ESP32-C3

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60c35450c8326be9b2b90d8834d16