### PR TITLE
Add relay control component

### DIFF
--- a/UltraNodeV5/components/ul_health/include/ul_health.h
+++ b/UltraNodeV5/components/ul_health/include/ul_health.h
@@ -23,6 +23,8 @@ void ul_health_notify_rgb_engine_ok(void);
 void ul_health_notify_rgb_engine_failure(void);
 void ul_health_notify_white_engine_ok(void);
 void ul_health_notify_white_engine_failure(void);
+void ul_health_notify_relay_engine_ok(void);
+void ul_health_notify_relay_engine_failure(void);
 
 #ifdef __cplusplus
 }

--- a/UltraNodeV5/components/ul_health/ul_health.c
+++ b/UltraNodeV5/components/ul_health/ul_health.c
@@ -50,6 +50,9 @@ typedef struct {
   uint32_t white_engine_failures;
   uint64_t white_first_failure_us;
   uint64_t white_last_failure_us;
+  uint32_t relay_engine_failures;
+  uint64_t relay_first_failure_us;
+  uint64_t relay_last_failure_us;
 } ul_health_state_t;
 
 static ul_health_state_t s_state;
@@ -230,6 +233,42 @@ void ul_health_notify_white_engine_failure(void) {
   uint64_t elapsed_us = now_us - first_failure_us;
   ESP_LOGW(TAG,
            "White smoothing task creation failed %u time%s (%llus since first failure)",
+           (unsigned)failures, failures == 1 ? "" : "s",
+           elapsed_us / 1000000ULL);
+}
+
+void ul_health_notify_relay_engine_ok(void) {
+  portENTER_CRITICAL(&s_lock);
+  if (s_state.started) {
+    s_state.relay_engine_failures = 0;
+    s_state.relay_first_failure_us = 0;
+    s_state.relay_last_failure_us = 0;
+  }
+  portEXIT_CRITICAL(&s_lock);
+}
+
+void ul_health_notify_relay_engine_failure(void) {
+  uint64_t now_us = esp_timer_get_time();
+  uint32_t failures = 0;
+  uint64_t first_failure_us = 0;
+  portENTER_CRITICAL(&s_lock);
+  if (s_state.started) {
+    if (s_state.relay_engine_failures == 0)
+      s_state.relay_first_failure_us = now_us;
+    if (s_state.relay_engine_failures < UINT32_MAX)
+      s_state.relay_engine_failures++;
+    failures = s_state.relay_engine_failures;
+    first_failure_us = s_state.relay_first_failure_us;
+    s_state.relay_last_failure_us = now_us;
+  }
+  portEXIT_CRITICAL(&s_lock);
+
+  if (failures == 0)
+    return;
+
+  uint64_t elapsed_us = now_us - first_failure_us;
+  ESP_LOGW(TAG,
+           "Relay engine initialization failed %u time%s (%llus since first failure)",
            (unsigned)failures, failures == 1 ? "" : "s",
            elapsed_us / 1000000ULL);
 }

--- a/UltraNodeV5/components/ul_mqtt/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_mqtt/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "ul_mqtt.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES mqtt json nvs_flash esp_event esp_timer ul_core ul_ws_engine ul_white_engine ul_rgb_engine ul_ota ul_state
+                       REQUIRES mqtt json nvs_flash esp_event esp_timer ul_core ul_ws_engine ul_white_engine ul_rgb_engine ul_relay ul_ota ul_state
                        PRIV_REQUIRES ul_health)

--- a/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
+++ b/UltraNodeV5/components/ul_mqtt/ul_mqtt.c
@@ -19,6 +19,7 @@
 #include "ul_white_engine.h"
 #include "ul_ws_engine.h"
 #include "ul_rgb_engine.h"
+#include "ul_relay.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
@@ -26,6 +27,7 @@
 #endif
 
 #include <ctype.h>
+#include <strings.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -70,6 +72,7 @@ static bool s_retry_pending = false;
 #define UL_WS_MAX_STRIPS 2
 #define UL_RGB_MAX_STRIPS 4
 #define UL_WHITE_MAX_CHANNELS 4
+#define UL_RELAY_MAX_CHANNELS 4
 
 static uint8_t s_ws_saved_bri[UL_WS_MAX_STRIPS];
 static bool s_ws_saved_valid[UL_WS_MAX_STRIPS];
@@ -541,6 +544,25 @@ static void publish_status_snapshot(void) {
   }
   cJSON_AddItemToObject(root, "white", jw);
 
+  // Relay channels
+  cJSON *jrelay = cJSON_CreateArray();
+  for (int i = 0; i < UL_RELAY_MAX_CHANNELS; ++i) {
+    ul_relay_status_t st;
+    if (ul_relay_get_status(i, &st)) {
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddNumberToObject(o, "channel", i);
+      cJSON_AddBoolToObject(o, "enabled", st.enabled);
+      cJSON_AddBoolToObject(o, "state", st.state);
+      cJSON_AddBoolToObject(o, "active_high", st.active_high);
+      cJSON_AddNumberToObject(o, "gpio", st.gpio);
+      cJSON_AddNumberToObject(o, "min_interval_ms", st.min_interval_ms);
+      double last_change_ms = (double)st.last_change_us / 1000.0;
+      cJSON_AddNumberToObject(o, "last_change_ms", last_change_ms);
+      cJSON_AddItemToArray(jrelay, o);
+    }
+  }
+  cJSON_AddItemToObject(root, "relay", jrelay);
+
   // *Debugging only- download_id is secret
   // OTA (static fields from Kconfig)
   //cJSON *jota = cJSON_CreateObject();
@@ -648,6 +670,29 @@ static void publish_white_ack(int channel, const char *effect, cJSON *params,
   } else {
     cJSON_AddStringToObject(root, "status", "error");
     cJSON_AddStringToObject(root, "error", "invalid effect");
+  }
+  char *json = cJSON_PrintUnformatted(root);
+  publish_json(topic, json);
+  cJSON_free(json);
+  cJSON_Delete(root);
+}
+
+static void publish_relay_ack(int channel, bool desired_state, bool actual_state,
+                              bool ok, const char *error) {
+  char topic[128];
+  snprintf(topic, sizeof(topic), "ul/%s/evt/status", ul_core_get_node_id());
+  cJSON *root = cJSON_CreateObject();
+  cJSON_AddStringToObject(root, "event", "ack");
+  cJSON_AddStringToObject(root, "target", "relay");
+  cJSON_AddNumberToObject(root, "channel", channel);
+  cJSON_AddBoolToObject(root, "desired_state", desired_state);
+  cJSON_AddBoolToObject(root, "state", actual_state);
+  if (ok) {
+    cJSON_AddStringToObject(root, "status", "ok");
+  } else {
+    cJSON_AddStringToObject(root, "status", "error");
+    if (error)
+      cJSON_AddStringToObject(root, "error", error);
   }
   char *json = cJSON_PrintUnformatted(root);
   publish_json(topic, json);
@@ -801,6 +846,75 @@ static bool handle_cmd_white_set(cJSON *root, int *out_channel) {
 
   return (!effect || ok);
 }
+
+static bool handle_cmd_relay_set(cJSON *root, int *out_channel, bool *out_desired) {
+  if (!root)
+    return false;
+
+  int channel = 0;
+  cJSON *jch = cJSON_GetObjectItem(root, "channel");
+  if (jch && cJSON_IsNumber(jch))
+    channel = jch->valueint;
+
+  bool desired = false;
+  bool have_state = false;
+
+  cJSON *jstate = cJSON_GetObjectItem(root, "state");
+  if (jstate) {
+    if (cJSON_IsBool(jstate)) {
+      desired = cJSON_IsTrue(jstate);
+      have_state = true;
+    } else if (cJSON_IsString(jstate) && jstate->valuestring) {
+      if (strcasecmp(jstate->valuestring, "on") == 0) {
+        desired = true;
+        have_state = true;
+      } else if (strcasecmp(jstate->valuestring, "off") == 0) {
+        desired = false;
+        have_state = true;
+      }
+    }
+  }
+
+  if (!have_state) {
+    cJSON *jon = cJSON_GetObjectItem(root, "on");
+    if (jon && cJSON_IsBool(jon)) {
+      desired = cJSON_IsTrue(jon);
+      have_state = true;
+    }
+  }
+
+  if (out_channel)
+    *out_channel = channel;
+  if (out_desired)
+    *out_desired = desired;
+
+  ul_relay_status_t st;
+  bool have_status = ul_relay_get_status(channel, &st);
+
+  bool applied = false;
+  if (have_state)
+    applied = ul_relay_set_state(channel, desired);
+
+  if (have_state)
+    have_status = ul_relay_get_status(channel, &st);
+
+  bool ok = have_state && have_status && st.state == desired;
+  const char *error = NULL;
+  bool actual_state = have_status ? st.state : false;
+
+  if (!have_state) {
+    error = "missing state";
+  } else if (!have_status) {
+    error = "invalid channel";
+  } else if (!applied && st.state != desired) {
+    error = "rate limited";
+  } else if (st.state != desired) {
+    error = "state mismatch";
+  }
+
+  publish_relay_ack(channel, desired, actual_state, ok, error);
+  return ok;
+}
 static void on_message(esp_mqtt_event_handle_t event) {
   // topic expected: ul/<node>/cmd/...
   char node[64] = {0};
@@ -875,6 +989,16 @@ static void on_message(esp_mqtt_event_handle_t event) {
       if (applied) {
         if (event->data && event->data_len > 0) {
           ul_state_record_white(channel, event->data, event->data_len);
+        }
+      }
+    } else if (starts_with(sub, "relay/set")) {
+      motion_fade_cancel();
+      override_index_from_path(root, sub, "relay/set", "channel");
+      int channel = 0;
+      bool applied = handle_cmd_relay_set(root, &channel, NULL);
+      if (applied) {
+        if (event->data && event->data_len > 0) {
+          ul_state_record_relay(channel, event->data, event->data_len);
         }
       }
     } else if (starts_with(sub, "motion/off")) {
@@ -1196,6 +1320,15 @@ void ul_mqtt_run_local(const char *path, const char *json) {
     if (applied) {
       if (payload_len > 0) {
         ul_state_record_white(channel, json, payload_len);
+      }
+    }
+  } else if (starts_with(path, "relay/set")) {
+    override_index_from_path(root, path, "relay/set", "channel");
+    int channel = 0;
+    bool applied = handle_cmd_relay_set(root, &channel, NULL);
+    if (applied) {
+      if (payload_len > 0) {
+        ul_state_record_relay(channel, json, payload_len);
       }
     }
   }

--- a/UltraNodeV5/components/ul_relay/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_relay/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "ul_relay.c"
+                       INCLUDE_DIRS "include"
+                       REQUIRES driver esp_timer ul_health)

--- a/UltraNodeV5/components/ul_relay/include/ul_relay.h
+++ b/UltraNodeV5/components/ul_relay/include/ul_relay.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct cJSON cJSON;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool ul_relay_start(void);
+void ul_relay_stop(void);
+
+// Parse and apply a JSON payload for relay/set
+bool ul_relay_apply_json(cJSON *root, int *out_channel, bool *out_desired);
+
+bool ul_relay_set_state(int channel, bool on);
+int ul_relay_get_channel_count(void);
+
+typedef struct {
+  bool enabled;
+  bool state;
+  bool active_high;
+  int gpio;
+  uint32_t min_interval_ms;
+  uint64_t last_change_us;
+} ul_relay_status_t;
+
+bool ul_relay_get_status(int channel, ul_relay_status_t *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/UltraNodeV5/components/ul_relay/ul_relay.c
+++ b/UltraNodeV5/components/ul_relay/ul_relay.c
@@ -1,0 +1,305 @@
+#include "ul_relay.h"
+#include "sdkconfig.h"
+
+#if !(CONFIG_UL_RELAY0_ENABLED || CONFIG_UL_RELAY1_ENABLED ||                    \
+      CONFIG_UL_RELAY2_ENABLED || CONFIG_UL_RELAY3_ENABLED)
+
+#include <string.h>
+
+bool ul_relay_start(void) { return true; }
+void ul_relay_stop(void) {}
+
+bool ul_relay_apply_json(cJSON *root, int *out_channel, bool *out_desired) {
+  (void)root;
+  if (out_channel)
+    *out_channel = 0;
+  if (out_desired)
+    *out_desired = false;
+  return false;
+}
+
+bool ul_relay_set_state(int channel, bool on) {
+  (void)channel;
+  (void)on;
+  return false;
+}
+
+int ul_relay_get_channel_count(void) { return 0; }
+
+bool ul_relay_get_status(int channel, ul_relay_status_t *out) {
+  (void)channel;
+  if (out)
+    memset(out, 0, sizeof(*out));
+  return false;
+}
+
+#else
+
+#include "cJSON.h"
+#include "driver/gpio.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "string.h"
+#include "ul_health.h"
+
+#include <ctype.h>
+
+static const char *TAG = "ul_relay";
+
+typedef struct {
+  bool enabled;
+  int gpio;
+  bool active_high;
+  bool state;
+  uint32_t min_interval_ms;
+  uint64_t last_change_us;
+} relay_channel_t;
+
+static relay_channel_t s_channels[4];
+static int s_channel_count;
+static bool s_started;
+
+static void reset_channels(void) {
+  memset(s_channels, 0, sizeof(s_channels));
+  s_channel_count = 0;
+  s_started = false;
+}
+
+static bool apply_gpio_level(relay_channel_t *ch, bool on) {
+  if (!ch || !ch->enabled)
+    return false;
+  int level = ch->active_high ? (on ? 1 : 0) : (on ? 0 : 1);
+  esp_err_t err = gpio_set_level((gpio_num_t)ch->gpio, level);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set GPIO%d level: %s", ch->gpio, esp_err_to_name(err));
+    return false;
+  }
+  return true;
+}
+
+static bool configure_channel(int index, int gpio, bool active_high,
+                              uint32_t min_interval_ms) {
+  relay_channel_t *ch = &s_channels[index];
+  ch->enabled = false;
+  ch->gpio = gpio;
+  ch->active_high = active_high;
+  ch->state = false;
+  ch->min_interval_ms = min_interval_ms;
+  ch->last_change_us = 0;
+
+  if (gpio < 0)
+    return false;
+
+  gpio_config_t cfg = {
+      .pin_bit_mask = 1ULL << gpio,
+      .mode = GPIO_MODE_OUTPUT,
+      .pull_up_en = GPIO_PULLUP_DISABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE,
+  };
+
+  esp_err_t err = gpio_config(&cfg);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to configure GPIO%d for relay %d: %s", gpio, index,
+             esp_err_to_name(err));
+    return false;
+  }
+
+  ch->enabled = true;
+  if (!apply_gpio_level(ch, false)) {
+    ch->enabled = false;
+    return false;
+  }
+
+  ch->state = false;
+  ch->last_change_us = esp_timer_get_time();
+  s_channel_count++;
+  return true;
+}
+
+static void init_enabled_channels(void) {
+  reset_channels();
+
+#if CONFIG_UL_RELAY0_ENABLED
+  configure_channel(0, CONFIG_UL_RELAY0_GPIO, CONFIG_UL_RELAY0_ACTIVE_HIGH,
+                    CONFIG_UL_RELAY0_MIN_INTERVAL_MS);
+#endif
+#if CONFIG_UL_RELAY1_ENABLED
+  configure_channel(1, CONFIG_UL_RELAY1_GPIO, CONFIG_UL_RELAY1_ACTIVE_HIGH,
+                    CONFIG_UL_RELAY1_MIN_INTERVAL_MS);
+#endif
+#if CONFIG_UL_RELAY2_ENABLED
+  configure_channel(2, CONFIG_UL_RELAY2_GPIO, CONFIG_UL_RELAY2_ACTIVE_HIGH,
+                    CONFIG_UL_RELAY2_MIN_INTERVAL_MS);
+#endif
+#if CONFIG_UL_RELAY3_ENABLED
+  configure_channel(3, CONFIG_UL_RELAY3_GPIO, CONFIG_UL_RELAY3_ACTIVE_HIGH,
+                    CONFIG_UL_RELAY3_MIN_INTERVAL_MS);
+#endif
+}
+
+bool ul_relay_start(void) {
+  if (s_started) {
+    ESP_LOGW(TAG, "Relay engine already started");
+    return true;
+  }
+
+  init_enabled_channels();
+
+  if (s_channel_count == 0) {
+    ESP_LOGI(TAG, "Relay engine started with no configured channels");
+    ul_health_notify_relay_engine_ok();
+    s_started = true;
+    return true;
+  }
+
+  bool any_enabled = false;
+  for (size_t i = 0; i < sizeof(s_channels) / sizeof(s_channels[0]); ++i) {
+    if (s_channels[i].enabled) {
+      any_enabled = true;
+    }
+  }
+
+  if (!any_enabled) {
+    ESP_LOGE(TAG, "Relay engine failed to configure any channels");
+    ul_health_notify_relay_engine_failure();
+    reset_channels();
+    return false;
+  }
+
+  ul_health_notify_relay_engine_ok();
+  s_started = true;
+  ESP_LOGI(TAG, "Relay engine initialized (%d channel%s)", s_channel_count,
+           s_channel_count == 1 ? "" : "s");
+  return true;
+}
+
+void ul_relay_stop(void) {
+  if (!s_started)
+    return;
+
+  for (size_t i = 0; i < sizeof(s_channels) / sizeof(s_channels[0]); ++i) {
+    if (s_channels[i].enabled) {
+      apply_gpio_level(&s_channels[i], false);
+    }
+  }
+  reset_channels();
+}
+
+bool ul_relay_set_state(int channel, bool on) {
+  if (channel < 0 || channel >= (int)(sizeof(s_channels) / sizeof(s_channels[0])))
+    return false;
+  relay_channel_t *ch = &s_channels[channel];
+  if (!ch->enabled)
+    return false;
+
+  if (ch->state == on)
+    return true;
+
+  uint64_t now_us = esp_timer_get_time();
+  uint64_t min_interval_us = (uint64_t)ch->min_interval_ms * 1000ULL;
+  if (min_interval_us > 0 && ch->last_change_us != 0 &&
+      now_us - ch->last_change_us < min_interval_us) {
+    ESP_LOGW(TAG,
+             "Relay %d command ignored (rate limited: %llu ms since last change)",
+             channel, (unsigned long long)((now_us - ch->last_change_us) / 1000ULL));
+    return false;
+  }
+
+  if (!apply_gpio_level(ch, on))
+    return false;
+
+  ch->state = on;
+  ch->last_change_us = now_us;
+  ESP_LOGI(TAG, "Relay %d set %s", channel, on ? "on" : "off");
+  return true;
+}
+
+int ul_relay_get_channel_count(void) { return s_channel_count; }
+
+bool ul_relay_get_status(int channel, ul_relay_status_t *out) {
+  if (out)
+    memset(out, 0, sizeof(*out));
+
+  if (channel < 0 || channel >= (int)(sizeof(s_channels) / sizeof(s_channels[0])))
+    return false;
+
+  relay_channel_t *ch = &s_channels[channel];
+  if (!ch->enabled)
+    return false;
+
+  if (out) {
+    out->enabled = ch->enabled;
+    out->state = ch->state;
+    out->active_high = ch->active_high;
+    out->gpio = ch->gpio;
+    out->min_interval_ms = ch->min_interval_ms;
+    out->last_change_us = ch->last_change_us;
+  }
+  return true;
+}
+
+static bool parse_state_string(const char *str, bool *out_state) {
+  if (!str || !out_state)
+    return false;
+  char buf[8];
+  size_t len = strlen(str);
+  if (len >= sizeof(buf))
+    len = sizeof(buf) - 1;
+  for (size_t i = 0; i < len; ++i) {
+    buf[i] = (char)tolower((unsigned char)str[i]);
+  }
+  buf[len] = '\0';
+  if (strcmp(buf, "on") == 0)
+    *out_state = true;
+  else if (strcmp(buf, "off") == 0)
+    *out_state = false;
+  else
+    return false;
+  return true;
+}
+
+bool ul_relay_apply_json(cJSON *root, int *out_channel, bool *out_desired) {
+  if (!root)
+    return false;
+
+  int channel = 0;
+  cJSON *jch = cJSON_GetObjectItem(root, "channel");
+  if (jch && cJSON_IsNumber(jch))
+    channel = jch->valueint;
+
+  bool desired = false;
+  bool have_state = false;
+
+  cJSON *jstate = cJSON_GetObjectItem(root, "state");
+  if (jstate) {
+    if (cJSON_IsBool(jstate)) {
+      desired = cJSON_IsTrue(jstate);
+      have_state = true;
+    } else if (cJSON_IsString(jstate)) {
+      have_state = parse_state_string(jstate->valuestring, &desired);
+    }
+  }
+
+  if (!have_state) {
+    cJSON *jon = cJSON_GetObjectItem(root, "on");
+    if (jon && cJSON_IsBool(jon)) {
+      desired = cJSON_IsTrue(jon);
+      have_state = true;
+    }
+  }
+
+  if (out_channel)
+    *out_channel = channel;
+  if (out_desired)
+    *out_desired = desired;
+
+  if (!have_state)
+    return false;
+
+  return ul_relay_set_state(channel, desired);
+}
+
+#endif
+

--- a/UltraNodeV5/components/ul_state/include/ul_state.h
+++ b/UltraNodeV5/components/ul_state/include/ul_state.h
@@ -24,6 +24,7 @@ esp_err_t ul_state_init(void);
 void ul_state_record_ws(int strip, const char *payload, size_t len);
 void ul_state_record_rgb(int strip, const char *payload, size_t len);
 void ul_state_record_white(int channel, const char *payload, size_t len);
+void ul_state_record_relay(int channel, const char *payload, size_t len);
 
 // Copies the most recent persisted JSON payload for the requested target into
 // the caller-provided buffer. The copy includes the terminating null byte. The
@@ -32,6 +33,7 @@ void ul_state_record_white(int channel, const char *payload, size_t len);
 bool ul_state_copy_ws(int strip, char *buffer, size_t buffer_len);
 bool ul_state_copy_rgb(int strip, char *buffer, size_t buffer_len);
 bool ul_state_copy_white(int channel, char *buffer, size_t buffer_len);
+bool ul_state_copy_relay(int channel, char *buffer, size_t buffer_len);
 
 #ifdef __cplusplus
 }

--- a/UltraNodeV5/main/CMakeLists.txt
+++ b/UltraNodeV5/main/CMakeLists.txt
@@ -1,2 +1,2 @@
 idf_component_register(SRCS "app_main.c"
-                       REQUIRES ul_core ul_mqtt ul_ota ul_ws_engine ul_white_engine ul_rgb_engine ul_common_effects ul_pir ul_state ul_provisioning ul_wifi)
+                       REQUIRES ul_core ul_mqtt ul_ota ul_ws_engine ul_white_engine ul_rgb_engine ul_relay ul_common_effects ul_pir ul_state ul_provisioning ul_wifi)

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -401,4 +401,71 @@ menu "White Strips (LEDC)"
     endmenu
 endmenu
 
+menu "Relay Outputs"
+    menu "Relay 0"
+        config UL_RELAY0_ENABLED
+            bool "Enabled"
+            default n
+        config UL_RELAY0_GPIO
+            int "GPIO"
+            range 0 48
+            default 26
+        config UL_RELAY0_ACTIVE_HIGH
+            bool "Active high"
+            default y
+        config UL_RELAY0_MIN_INTERVAL_MS
+            int "Minimum command interval (ms)"
+            range 0 600000
+            default 200
+    endmenu
+    menu "Relay 1"
+        config UL_RELAY1_ENABLED
+            bool "Enabled"
+            default n
+        config UL_RELAY1_GPIO
+            int "GPIO"
+            range 0 48
+            default 27
+        config UL_RELAY1_ACTIVE_HIGH
+            bool "Active high"
+            default y
+        config UL_RELAY1_MIN_INTERVAL_MS
+            int "Minimum command interval (ms)"
+            range 0 600000
+            default 200
+    endmenu
+    menu "Relay 2"
+        config UL_RELAY2_ENABLED
+            bool "Enabled"
+            default n
+        config UL_RELAY2_GPIO
+            int "GPIO"
+            range 0 48
+            default 32
+        config UL_RELAY2_ACTIVE_HIGH
+            bool "Active high"
+            default y
+        config UL_RELAY2_MIN_INTERVAL_MS
+            int "Minimum command interval (ms)"
+            range 0 600000
+            default 200
+    endmenu
+    menu "Relay 3"
+        config UL_RELAY3_ENABLED
+            bool "Enabled"
+            default n
+        config UL_RELAY3_GPIO
+            int "GPIO"
+            range 0 48
+            default 33
+        config UL_RELAY3_ACTIVE_HIGH
+            bool "Active high"
+            default y
+        config UL_RELAY3_MIN_INTERVAL_MS
+            int "Minimum command interval (ms)"
+            range 0 600000
+            default 200
+    endmenu
+endmenu
+
 endmenu

--- a/UltraNodeV5/main/app_main.c
+++ b/UltraNodeV5/main/app_main.c
@@ -24,6 +24,7 @@
 #include "ul_white_engine.h"
 #include "ul_ws_engine.h"
 #include "ul_rgb_engine.h"
+#include "ul_relay.h"
 #include "ul_wifi_credentials.h"
 #if CONFIG_UL_PIR_ENABLED
 #include "ul_pir.h"
@@ -142,6 +143,10 @@ static void service_manager_task(void *ctx) {
           if (!white_started) {
             ESP_LOGE(TAG, "White engine failed to start; running without it");
           }
+          bool relay_started = ul_relay_start();
+          if (!relay_started) {
+            ESP_LOGE(TAG, "Relay engine failed to start; running without it");
+          }
 #if CONFIG_UL_PIR_ENABLED
           ul_pir_start();
 #endif
@@ -157,6 +162,7 @@ static void service_manager_task(void *ctx) {
           ul_ws_engine_stop();
           ul_rgb_engine_stop();
           ul_white_engine_stop();
+          ul_relay_stop();
 #if CONFIG_UL_PIR_ENABLED
           ul_pir_stop();
 #endif


### PR DESCRIPTION
## Summary
- add a dedicated `ul_relay` component with GPIO setup, rate limiting, and JSON parsing for up to four relays
- wire relay support into MQTT acknowledgements, status snapshots, persistence, and service lifecycle/health monitoring
- expose relay configuration options through new Kconfig entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5f74ed180832698c6d5e2bc70fe7e