### PR TITLE
Restart MQTT component after repeated start failures

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
+++ b/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
@@ -126,4 +126,6 @@ void mqtt_event_handler(void *handler_args, esp_event_base_t base,
 
 esp_mqtt_client_handle_t ul_mqtt_test_get_client_handle(void);
 bool ul_mqtt_test_retry_pending(void);
+uint32_t ul_mqtt_test_consecutive_failures(void);
+bool ul_mqtt_test_restart_pending(void);
 


### PR DESCRIPTION
## Summary
- track consecutive MQTT start failures and schedule a component restart when attempts exceed the new threshold
- reset failure tracking when the client connects or stops and expose the counters for unit tests
- expand the retry unit test suite and stubs to cover the restart behaviour

## Testing
- python3 components/ul_mqtt/test/test_ul_mqtt_retry.py

------
https://chatgpt.com/codex/tasks/task_e_68d624b7b3e083268d9df0011a8b715d