### PR TITLE
Ensure swell effects cover full brightness range

### DIFF
--- a/UltraNodeV5/components/ul_rgb_engine/effects_rgb/color_swell.c
+++ b/UltraNodeV5/components/ul_rgb_engine/effects_rgb/color_swell.c
@@ -10,6 +10,7 @@
 #define RGB_STRIP_MAX 4
 
 #define COLOR_SWELL_DURATION_MS 3000
+#define COLOR_SWELL_MIN_FRAMES 256
 
 static uint8_t s_color[RGB_STRIP_MAX][3];
 static bool s_initialized;
@@ -40,8 +41,8 @@ void rgb_color_swell_init(void) {
 
 static int compute_total_frames(void) {
     int frames = (COLOR_SWELL_DURATION_MS * CONFIG_UL_RGB_SMOOTH_HZ) / 1000;
-    if (frames < 1) {
-        frames = 1;
+    if (frames < COLOR_SWELL_MIN_FRAMES) {
+        frames = COLOR_SWELL_MIN_FRAMES;
     }
     return frames;
 }
@@ -69,8 +70,8 @@ void rgb_color_swell_render(int strip, uint8_t out_rgb[3], int frame_idx) {
     int value = 255;
     if (frame_idx <= 0) {
         value = 0;
-    } else if (frame_idx < frames) {
-        int64_t scaled = ((int64_t)frame_idx * 255 + frames / 2) / frames;
+    } else if (frame_idx < frames - 1) {
+        int64_t scaled = ((int64_t)frame_idx * 255) / (frames - 1);
         if (scaled < 0) {
             scaled = 0;
         }

--- a/UltraNodeV5/components/ul_white_engine/effects_white/swell.c
+++ b/UltraNodeV5/components/ul_white_engine/effects_white/swell.c
@@ -6,11 +6,14 @@
 #include <stdint.h>
 
 #define WHITE_SWELL_DURATION_MS 3000
+// Ensure the swell walks every possible brightness value (0-255). With fewer
+// frames than this we would be forced to skip steps, which looks abrupt.
+#define WHITE_SWELL_MIN_FRAMES 256
 
 static int compute_total_frames(void) {
     int frames = (WHITE_SWELL_DURATION_MS * CONFIG_UL_WHITE_SMOOTH_HZ) / 1000;
-    if (frames < 1) {
-        frames = 1;
+    if (frames < WHITE_SWELL_MIN_FRAMES) {
+        frames = WHITE_SWELL_MIN_FRAMES;
     }
     return frames;
 }
@@ -24,11 +27,11 @@ uint8_t white_swell_render(int frame_idx) {
     if (frame_idx <= 0) {
         return 0;
     }
-    if (frame_idx >= frames) {
+    if (frame_idx >= frames - 1) {
         return 255;
     }
 
-    int value = (int)((((int64_t)frame_idx) * 255 + frames / 2) / frames);
+    int value = (int)((((int64_t)frame_idx) * 255) / (frames - 1));
     if (value < 0) {
         value = 0;
     }

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/color_swell.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/color_swell.c
@@ -11,6 +11,7 @@ static uint8_t s_color[2][3];
 static bool s_initialized;
 
 #define COLOR_SWELL_DURATION_MS 3000
+#define COLOR_SWELL_MIN_FRAMES 256
 
 static inline bool valid_strip(int strip) {
     return strip >= 0 && strip < 2;
@@ -38,8 +39,8 @@ void color_swell_init(void) {
 
 static int compute_total_frames(void) {
     int frames = (COLOR_SWELL_DURATION_MS * CONFIG_UL_WS2812_FPS) / 1000;
-    if (frames < 1) {
-        frames = 1;
+    if (frames < COLOR_SWELL_MIN_FRAMES) {
+        frames = COLOR_SWELL_MIN_FRAMES;
     }
     return frames;
 }
@@ -68,8 +69,8 @@ void color_swell_render(uint8_t* frame_rgb, int pixels, int frame_idx) {
     int value = 255;
     if (frame_idx <= 0) {
         value = 0;
-    } else if (frame_idx < frames) {
-        int64_t scaled = ((int64_t)frame_idx * 255 + frames / 2) / frames;
+    } else if (frame_idx < frames - 1) {
+        int64_t scaled = ((int64_t)frame_idx * 255) / (frames - 1);
         if (scaled < 0) {
             scaled = 0;
         }


### PR DESCRIPTION
## Summary
- ensure the white swell effect uses enough frames to cover every brightness step from 0-255
- apply the same minimum-frame logic to the WS2812 and RGB color swell effects so they hit every brightness value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a7243df88326839e6cc6824f23a7