### PR TITLE
Modularize node pre-registration and provisioning workflow

### DIFF
--- a/Server/app/auth/models.py
+++ b/Server/app/auth/models.py
@@ -128,6 +128,64 @@ class AuditLog(SQLModel, table=True):
     created_at: datetime = Field(default_factory=_utcnow, sa_column=_timestamp_column())
 
 
+class NodeRegistration(SQLModel, table=True):
+    """Opaque node identifiers that may be claimed and provisioned later."""
+
+    __tablename__ = "node_registrations"
+    __table_args__ = (
+        UniqueConstraint("download_id", name="uq_node_registrations_download_id"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    node_id: str = Field(
+        sa_column=Column(String(64), unique=True, nullable=False, index=True)
+    )
+    download_id: str = Field(
+        sa_column=Column(String(64), unique=True, nullable=False, index=True)
+    )
+    token_hash: str = Field(sa_column=Column(String(64), nullable=False))
+    provisioning_token: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    created_at: datetime = Field(default_factory=_utcnow, sa_column=_timestamp_column())
+    token_issued_at: datetime = Field(
+        default_factory=_utcnow, sa_column=_timestamp_column(onupdate=True)
+    )
+    provisioned_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    assigned_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    assigned_user_id: Optional[int] = Field(
+        default=None,
+        foreign_key="users.id",
+    )
+    assigned_house_id: Optional[int] = Field(
+        default=None,
+        foreign_key="houses.id",
+    )
+    house_slug: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(64), nullable=True, index=True),
+    )
+    room_id: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(120), nullable=True, index=True),
+    )
+    display_name: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(120), nullable=True),
+    )
+    hardware_metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, default=dict),
+    )
+
+
 class NodeCredential(SQLModel, table=True):
     __tablename__ = "node_credentials"
     __table_args__ = (
@@ -153,13 +211,6 @@ class NodeCredential(SQLModel, table=True):
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),
     )
-    token_issued_at: datetime = Field(
-        default_factory=datetime.utcnow, sa_column=_timestamp_column(onupdate=True)
-    )
-    provisioned_at: Optional[datetime] = Field(
-        default=None,
-        sa_column=Column(DateTime(timezone=True), nullable=True),
-    )
 
 
 __all__ = [
@@ -168,6 +219,7 @@ __all__ = [
     "HouseMembership",
     "HouseRole",
     "NodeCredential",
+    "NodeRegistration",
     "RoomAccess",
     "User",
 ]

--- a/Server/app/node_credentials.py
+++ b/Server/app/node_credentials.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from sqlmodel import Session, select
 
 from . import registry
-from .auth.models import NodeCredential
+from .auth.models import NodeCredential, NodeRegistration
 
 
 @dataclass
@@ -18,6 +18,14 @@ class NodeCredentialWithToken:
 
     credential: NodeCredential
     plaintext_token: Optional[str]
+
+
+@dataclass
+class NodeRegistrationWithToken:
+    """Batch generation return type including the plaintext token."""
+
+    registration: NodeRegistration
+    plaintext_token: str
 
 
 def _now() -> datetime:
@@ -53,6 +61,15 @@ def _get_by_node_id(session: Session, node_id: str) -> Optional[NodeCredential]:
     return _first_result(result)
 
 
+def _get_registration_by_node_id(
+    session: Session, node_id: str
+) -> Optional[NodeRegistration]:
+    result = session.exec(
+        select(NodeRegistration).where(NodeRegistration.node_id == node_id)
+    )
+    return _first_result(result)
+
+
 def get_by_node_id(session: Session, node_id: str) -> Optional[NodeCredential]:
     return _get_by_node_id(session, node_id)
 
@@ -71,9 +88,211 @@ def get_by_token_hash(session: Session, token_hash: str) -> Optional[NodeCredent
     return _first_result(result)
 
 
+def get_registration_by_node_id(
+    session: Session, node_id: str
+) -> Optional[NodeRegistration]:
+    return _get_registration_by_node_id(session, node_id)
+
+
+def get_registration_by_download_id(
+    session: Session, download_id: str
+) -> Optional[NodeRegistration]:
+    result = session.exec(
+        select(NodeRegistration).where(NodeRegistration.download_id == download_id)
+    )
+    return _first_result(result)
+
+
 def any_tokens(session: Session) -> bool:
-    result = session.exec(select(NodeCredential.id))
-    return _first_result(result) is not None
+    """Return True if any node credentials or registrations exist."""
+
+    if _first_result(session.exec(select(NodeCredential.id))):
+        return True
+    return _first_result(session.exec(select(NodeRegistration.id))) is not None
+
+
+def create_batch(
+    session: Session,
+    count: int,
+    *,
+    metadata: Optional[Iterable[Dict[str, Any]]] = None,
+) -> List[NodeRegistrationWithToken]:
+    """Generate ``count`` opaque registrations and persist them."""
+
+    if count <= 0:
+        raise ValueError("count must be positive")
+
+    registrations: List[NodeRegistrationWithToken] = []
+
+    def _collect_strings(statement) -> set[str]:
+        values: set[str] = set()
+        for row in session.exec(statement).all():
+            candidate = row[0] if isinstance(row, tuple) else row
+            if isinstance(candidate, str):
+                values.add(candidate)
+        return values
+
+    existing_node_ids = _collect_strings(select(NodeRegistration.node_id))
+    existing_node_ids.update(_collect_strings(select(NodeCredential.node_id)))
+    existing_download_ids = _collect_strings(select(NodeRegistration.download_id))
+    existing_download_ids.update(_collect_strings(select(NodeCredential.download_id)))
+
+    metadata_list: List[Dict[str, Any]] = []
+    if metadata is not None:
+        for entry in metadata:
+            metadata_list.append(dict(entry))
+
+    for index in range(count):
+        node_id = registry.generate_node_id()
+        while node_id in existing_node_ids:
+            node_id = registry.generate_node_id()
+        existing_node_ids.add(node_id)
+
+        download_id = registry.generate_download_id()
+        while download_id in existing_download_ids:
+            download_id = registry.generate_download_id()
+        existing_download_ids.add(download_id)
+
+        plaintext_token = registry.generate_node_token()
+        token_hash = registry.hash_node_token(plaintext_token)
+
+        metadata_entry: Dict[str, Any] = (
+            dict(metadata_list[index]) if index < len(metadata_list) else {}
+        )
+
+        registration = NodeRegistration(
+            node_id=node_id,
+            download_id=download_id,
+            token_hash=token_hash,
+            provisioning_token=plaintext_token,
+            hardware_metadata=metadata_entry,
+        )
+        session.add(registration)
+        registrations.append(
+            NodeRegistrationWithToken(
+                registration=registration, plaintext_token=plaintext_token
+            )
+        )
+
+    session.commit()
+    for entry in registrations:
+        session.refresh(entry.registration)
+
+    return registrations
+
+
+def list_available_registrations(session: Session) -> List[NodeRegistration]:
+    """Return registrations that have not been assigned to a house/user."""
+
+    result = session.exec(
+        select(NodeRegistration).where(NodeRegistration.assigned_at.is_(None))
+    )
+    return result.all()
+
+
+def list_assigned_registrations(session: Session) -> List[NodeRegistration]:
+    """Return registrations that have been associated with a house or user."""
+
+    result = session.exec(
+        select(NodeRegistration).where(NodeRegistration.assigned_at.is_not(None))
+    )
+    return result.all()
+
+
+def claim_registration(
+    session: Session,
+    node_id: str,
+    *,
+    house_slug: Optional[str] = None,
+    room_id: Optional[str] = None,
+    display_name: Optional[str] = None,
+    assigned_user_id: Optional[int] = None,
+    assigned_house_id: Optional[int] = None,
+    hardware_metadata: Optional[Dict[str, Any]] = None,
+) -> NodeRegistration:
+    """Mark a pre-generated registration as claimed for later assignment."""
+
+    registration = _get_registration_by_node_id(session, node_id)
+    if registration is None:
+        raise KeyError("node registration not found")
+
+    changed = False
+    now = _now()
+
+    if registration.assigned_at is None:
+        registration.assigned_at = now
+        changed = True
+
+    if house_slug is not None and registration.house_slug != house_slug:
+        registration.house_slug = house_slug
+        changed = True
+    if room_id is not None and registration.room_id != room_id:
+        registration.room_id = room_id
+        changed = True
+    if display_name is not None and registration.display_name != display_name:
+        registration.display_name = display_name
+        changed = True
+    if assigned_user_id is not None and registration.assigned_user_id != assigned_user_id:
+        registration.assigned_user_id = assigned_user_id
+        changed = True
+    if assigned_house_id is not None and registration.assigned_house_id != assigned_house_id:
+        registration.assigned_house_id = assigned_house_id
+        changed = True
+    if hardware_metadata:
+        merged = dict(registration.hardware_metadata)
+        merged.update(hardware_metadata)
+        if merged != registration.hardware_metadata:
+            registration.hardware_metadata = merged
+            changed = True
+
+    if changed:
+        session.add(registration)
+        session.commit()
+        session.refresh(registration)
+
+    return registration
+
+
+def _sync_registration_assignment(
+    registration: NodeRegistration,
+    *,
+    house_slug: str,
+    room_id: str,
+    display_name: str,
+    assigned_house_id: Optional[int],
+    assigned_user_id: Optional[int],
+    hardware_metadata: Optional[Dict[str, Any]],
+) -> Tuple[NodeRegistration, bool]:
+    changed = False
+    now = _now()
+
+    if registration.assigned_at is None:
+        registration.assigned_at = now
+        changed = True
+
+    if registration.house_slug != house_slug:
+        registration.house_slug = house_slug
+        changed = True
+    if registration.room_id != room_id:
+        registration.room_id = room_id
+        changed = True
+    if registration.display_name != display_name:
+        registration.display_name = display_name
+        changed = True
+    if assigned_house_id is not None and registration.assigned_house_id != assigned_house_id:
+        registration.assigned_house_id = assigned_house_id
+        changed = True
+    if assigned_user_id is not None and registration.assigned_user_id != assigned_user_id:
+        registration.assigned_user_id = assigned_user_id
+        changed = True
+    if hardware_metadata:
+        merged = dict(registration.hardware_metadata)
+        merged.update(hardware_metadata)
+        if merged != registration.hardware_metadata:
+            registration.hardware_metadata = merged
+            changed = True
+
+    return registration, changed
 
 
 def ensure_for_node(
@@ -86,69 +305,127 @@ def ensure_for_node(
     download_id: Optional[str] = None,
     token_hash: Optional[str] = None,
     rotate_token: bool = False,
+    assigned_house_id: Optional[int] = None,
+    assigned_user_id: Optional[int] = None,
+    hardware_metadata: Optional[Dict[str, Any]] = None,
 ) -> NodeCredentialWithToken:
     """Ensure a credential row exists for ``node_id`` and return it."""
 
-    credential = _get_by_node_id(session, node_id)
     plaintext: Optional[str] = None
+    registration = _get_registration_by_node_id(session, node_id)
+    registration_changed = False
 
-    if credential:
-        changed = False
-        if credential.house_slug != house_slug:
-            credential.house_slug = house_slug
-            changed = True
-        if credential.room_id != room_id:
-            credential.room_id = room_id
-            changed = True
-        if credential.display_name != display_name:
-            credential.display_name = display_name
-            changed = True
-        if download_id and credential.download_id != download_id:
-            credential.download_id = download_id
-            changed = True
+    if registration is None:
+        if download_id is None:
+            download_id = registry.generate_download_id()
+        if rotate_token or token_hash is None:
+            plaintext = registry.generate_node_token()
+            token_hash = registry.hash_node_token(plaintext)
+        else:
+            plaintext = None
+        registration = NodeRegistration(
+            node_id=node_id,
+            download_id=download_id,
+            token_hash=token_hash,
+            provisioning_token=plaintext,
+            assigned_at=_now(),
+            house_slug=house_slug,
+            room_id=room_id,
+            display_name=display_name,
+            assigned_house_id=assigned_house_id,
+            assigned_user_id=assigned_user_id,
+            hardware_metadata=hardware_metadata or {},
+        )
+        registration_changed = True
+    else:
+        registration, updated = _sync_registration_assignment(
+            registration,
+            house_slug=house_slug,
+            room_id=room_id,
+            display_name=display_name,
+            assigned_house_id=assigned_house_id,
+            assigned_user_id=assigned_user_id,
+            hardware_metadata=hardware_metadata,
+        )
+        registration_changed |= updated
+
+        if download_id and registration.download_id != download_id:
+            registration.download_id = download_id
+            registration_changed = True
 
         if rotate_token:
             plaintext = registry.generate_node_token()
-            credential.token_hash = registry.hash_node_token(plaintext)
-            credential.token_issued_at = _now()
-            changed = True
-        elif token_hash and credential.token_hash != token_hash:
-            credential.token_hash = token_hash
-            credential.token_issued_at = _now()
-            changed = True
+            registration.token_hash = registry.hash_node_token(plaintext)
+            registration.token_issued_at = _now()
+            registration.provisioning_token = plaintext
+            registration_changed = True
+        elif token_hash and registration.token_hash != token_hash:
+            registration.token_hash = token_hash
+            registration.token_issued_at = _now()
+            registration_changed = True
 
-        if changed:
-            session.add(credential)
-            session.commit()
-            session.refresh(credential)
+    credential = _get_by_node_id(session, node_id)
+    credential_changed = False
 
-        return NodeCredentialWithToken(credential=credential, plaintext_token=plaintext)
+    if credential:
+        if credential.house_slug != house_slug:
+            credential.house_slug = house_slug
+            credential_changed = True
+        if credential.room_id != room_id:
+            credential.room_id = room_id
+            credential_changed = True
+        if credential.display_name != display_name:
+            credential.display_name = display_name
+            credential_changed = True
+        if credential.download_id != registration.download_id:
+            credential.download_id = registration.download_id
+            credential_changed = True
 
-    if download_id is None:
-        download_id = registry.generate_download_id()
-
-    if rotate_token:
-        plaintext = registry.generate_node_token()
-        token_hash = registry.hash_node_token(plaintext)
-    elif token_hash is None:
-        plaintext = registry.generate_node_token()
-        token_hash = registry.hash_node_token(plaintext)
+        if rotate_token:
+            plaintext = plaintext or registry.generate_node_token()
+            registration.token_hash = registry.hash_node_token(plaintext)
+            registration.token_issued_at = _now()
+            registration.provisioning_token = plaintext
+            credential.token_hash = registration.token_hash
+            credential.token_issued_at = registration.token_issued_at
+            credential_changed = True
+            registration_changed = True
+        elif credential.token_hash != registration.token_hash:
+            credential.token_hash = registration.token_hash
+            credential.token_issued_at = registration.token_issued_at
+            credential_changed = True
     else:
-        plaintext = None
+        if plaintext:
+            token_hash = registry.hash_node_token(plaintext)
+            if registration.token_hash != token_hash:
+                registration.token_hash = token_hash
+                registration.token_issued_at = _now()
+                registration_changed = True
+            if registration.provisioning_token != plaintext:
+                registration.provisioning_token = plaintext
+                registration_changed = True
+        credential = NodeCredential(
+            node_id=node_id,
+            house_slug=house_slug,
+            room_id=room_id,
+            display_name=display_name,
+            download_id=registration.download_id,
+            token_hash=registration.token_hash,
+            created_at=_now(),
+            token_issued_at=registration.token_issued_at,
+        )
+        credential_changed = True
 
-    credential = NodeCredential(
-        node_id=node_id,
-        house_slug=house_slug,
-        room_id=room_id,
-        display_name=display_name,
-        download_id=download_id,
-        token_hash=token_hash,
-        created_at=_now(),
-        token_issued_at=_now(),
-    )
-    session.add(credential)
-    session.commit()
-    session.refresh(credential)
+    if registration_changed:
+        session.add(registration)
+    if credential_changed:
+        session.add(credential)
+    if registration_changed or credential_changed:
+        session.commit()
+        if registration_changed:
+            session.refresh(registration)
+        if credential_changed:
+            session.refresh(credential)
 
     return NodeCredentialWithToken(credential=credential, plaintext_token=plaintext)
 
@@ -157,70 +434,184 @@ def rotate_token(
     session: Session, node_id: str, *, token: Optional[str] = None
 ) -> Tuple[NodeCredential, str]:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+    if credential is None and registration is None:
         raise KeyError("node credentials not found")
 
     plaintext = token or registry.generate_node_token()
-    credential.token_hash = registry.hash_node_token(plaintext)
-    credential.token_issued_at = _now()
-    session.add(credential)
+    token_hash = registry.hash_node_token(plaintext)
+    issued_at = _now()
+
+    if credential is not None:
+        credential.token_hash = token_hash
+        credential.token_issued_at = issued_at
+        session.add(credential)
+
+    if registration is not None:
+        registration.token_hash = token_hash
+        registration.token_issued_at = issued_at
+        registration.provisioning_token = plaintext
+        session.add(registration)
+
     session.commit()
-    session.refresh(credential)
-    return credential, plaintext
+
+    if credential is not None:
+        session.refresh(credential)
+        return credential, plaintext
+
+    session.refresh(registration)
+    # Legacy callers expect a credential, so fabricate a placeholder when
+    # only a registration exists.
+    legacy = NodeCredential(
+        node_id=registration.node_id,
+        house_slug=registration.house_slug or "",
+        room_id=registration.room_id or "",
+        display_name=registration.display_name or registration.node_id,
+        download_id=registration.download_id,
+        token_hash=registration.token_hash,
+        created_at=registration.created_at,
+        token_issued_at=registration.token_issued_at,
+    )
+    return legacy, plaintext
 
 
 def update_download_id(
     session: Session, node_id: str, download_id: Optional[str] = None
 ) -> NodeCredential:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+    if credential is None and registration is None:
         raise KeyError("node credentials not found")
 
     new_download = download_id or registry.generate_download_id()
-    credential.download_id = new_download
-    session.add(credential)
+
+    if credential is not None:
+        credential.download_id = new_download
+        session.add(credential)
+
+    if registration is not None:
+        registration.download_id = new_download
+        session.add(registration)
+
     session.commit()
-    session.refresh(credential)
-    return credential
+
+    if credential is not None:
+        session.refresh(credential)
+        if registration is not None:
+            session.refresh(registration)
+        return credential
+
+    session.refresh(registration)
+    legacy = NodeCredential(
+        node_id=registration.node_id,
+        house_slug=registration.house_slug or "",
+        room_id=registration.room_id or "",
+        display_name=registration.display_name or registration.node_id,
+        download_id=registration.download_id,
+        token_hash=registration.token_hash,
+        created_at=registration.created_at,
+        token_issued_at=registration.token_issued_at,
+    )
+    return legacy
 
 
 def mark_provisioned(
     session: Session, node_id: str, *, timestamp: Optional[datetime] = None
 ) -> NodeCredential:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+    if credential is None and registration is None:
         raise KeyError("node credentials not found")
 
-    credential.provisioned_at = timestamp or _now()
-    session.add(credential)
+    stamp = timestamp or _now()
+
+    if credential is not None:
+        credential.provisioned_at = stamp
+        session.add(credential)
+    if registration is not None:
+        registration.provisioned_at = stamp
+        session.add(registration)
+
     session.commit()
-    session.refresh(credential)
-    return credential
+
+    if credential is not None:
+        session.refresh(credential)
+        if registration is not None:
+            session.refresh(registration)
+        return credential
+
+    session.refresh(registration)
+    legacy = NodeCredential(
+        node_id=registration.node_id,
+        house_slug=registration.house_slug or "",
+        room_id=registration.room_id or "",
+        display_name=registration.display_name or registration.node_id,
+        download_id=registration.download_id,
+        token_hash=registration.token_hash,
+        created_at=registration.created_at,
+        token_issued_at=registration.token_issued_at,
+        provisioned_at=registration.provisioned_at,
+    )
+    return legacy
 
 
 def clear_provisioned(session: Session, node_id: str) -> NodeCredential:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+    if credential is None and registration is None:
         raise KeyError("node credentials not found")
 
-    credential.provisioned_at = None
-    session.add(credential)
+    if credential is not None:
+        credential.provisioned_at = None
+        session.add(credential)
+    if registration is not None:
+        registration.provisioned_at = None
+        session.add(registration)
+
     session.commit()
-    session.refresh(credential)
-    return credential
+
+    if credential is not None:
+        session.refresh(credential)
+        return credential
+
+    session.refresh(registration)
+    legacy = NodeCredential(
+        node_id=registration.node_id,
+        house_slug=registration.house_slug or "",
+        room_id=registration.room_id or "",
+        display_name=registration.display_name or registration.node_id,
+        download_id=registration.download_id,
+        token_hash=registration.token_hash,
+        created_at=registration.created_at,
+        token_issued_at=registration.token_issued_at,
+    )
+    return legacy
 
 
 def delete_credentials(session: Session, node_id: str) -> None:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+
+    if credential is None and registration is None:
         return
-    session.delete(credential)
+
+    if credential is not None:
+        session.delete(credential)
+    if registration is not None:
+        session.delete(registration)
+
     session.commit()
 
 
 def list_unprovisioned(session: Session) -> List[NodeCredential]:
     return session.exec(
         select(NodeCredential).where(NodeCredential.provisioned_at.is_(None))
+    ).all()
+
+
+def list_unprovisioned_registrations(session: Session) -> List[NodeRegistration]:
+    return session.exec(
+        select(NodeRegistration).where(NodeRegistration.provisioned_at.is_(None))
     ).all()
 
 
@@ -253,15 +644,25 @@ def sync_registry_nodes(session: Session) -> None:
             else None
         )
 
-        existing = get_by_node_id(session, node_id)
+        existing_registration = _get_registration_by_node_id(session, node_id)
+        existing_credential = _get_by_node_id(session, node_id)
+        existing_download = None
+        existing_token = None
+        if existing_registration is not None:
+            existing_download = existing_registration.download_id
+            existing_token = existing_registration.token_hash
+        elif existing_credential is not None:
+            existing_download = existing_credential.download_id
+            existing_token = existing_credential.token_hash
+
         ensured = ensure_for_node(
             session,
             node_id=node_id,
             house_slug=house_slug,
             room_id=room_id,
             display_name=display_name,
-            download_id=download_id if existing is None or not existing.download_id else None,
-            token_hash=token_hash if existing is None or not existing.token_hash else None,
+            download_id=download_id if not existing_download else None,
+            token_hash=token_hash if not existing_token else None,
         )
 
         credential = ensured.credential
@@ -279,14 +680,22 @@ def sync_registry_nodes(session: Session) -> None:
 
 __all__ = [
     "NodeCredentialWithToken",
+    "NodeRegistrationWithToken",
     "any_tokens",
+    "claim_registration",
     "clear_provisioned",
+    "create_batch",
     "delete_credentials",
     "ensure_for_node",
     "get_by_node_id",
     "get_by_download_id",
     "get_by_token_hash",
+    "get_registration_by_download_id",
+    "get_registration_by_node_id",
+    "list_assigned_registrations",
+    "list_available_registrations",
     "list_unprovisioned",
+    "list_unprovisioned_registrations",
     "mark_provisioned",
     "rotate_token",
     "sync_registry_nodes",

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -150,39 +150,12 @@
 <script type="module" src="/static/presets.js"></script>
 <script>
 const addNodeButton = document.getElementById('addNode');
-if(addNodeButton){
-  addNodeButton.onclick = async () => {
-    const name = prompt('New node name');
-    if (!name) {
-      return;
-    }
-    let res;
-    try {
-      res = await fetch('/api/house/{{ house_public_id }}/room/{{ room.id }}/nodes', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        credentials: 'same-origin',
-        body: JSON.stringify({name}),
-      });
-    } catch (error) {
-      alert('Failed to add node');
-      return;
-    }
-    if (res.ok) {
-      location.reload();
-      return;
-    }
-    let message = 'Failed to add node';
-    try {
-      const data = await res.json();
-      if (data && typeof data.detail === 'string' && data.detail.trim()) {
-        message = data.detail;
-      }
-    } catch (error) {
-      // ignore JSON parse errors
-    }
-    alert(message);
-  };
+if (addNodeButton) {
+  addNodeButton.classList.add('opacity-50', 'cursor-not-allowed');
+  addNodeButton.disabled = true;
+  addNodeButton.addEventListener('click', () => {
+    alert('Nodes are now provisioned in batches. Please use the offline provisioning workflow.');
+  });
 }
 {% if motion_config %}
 (function(){

--- a/Server/docs/node-ids.md
+++ b/Server/docs/node-ids.md
@@ -1,110 +1,110 @@
 # Opaque Node Identifiers
 
-Nodes created through the admin UI or API now receive a random, opaque identifier
-at creation time. The identifier is a 31-character string composed of lowercase
-letters and digits (for example `dbrpr89wiexuejce52u9840juec77ul`). It no longer contains
-the house slug or any user-provided text, so capturing or guessing a node ID does
-not reveal which house owns it.
+Node identities are now generated ahead of time and stored in the
+`node_registrations` table. Each record reserves an opaque node ID, a firmware
+Download ID, a provisioning bearer token (both the plaintext value and its
+SHA-256 hash), and a JSON payload for hardware-specific metadata. Registrations
+can optionally track which authenticated user or house eventually claims the
+identifier, but they can remain unassigned indefinitely so manufacturing teams
+can mint identifiers in bulk before any customer data exists.
 
-Alongside the node ID the server issues:
+## Batch pre-registration
 
-* a unique download identifier used to expose OTA binaries via
-  `/firmware/<download_id>/latest.bin`, and
-* a per-node bearer token whose SHA-256 hash is stored in the authentication
-  database (see [`NodeCredential`](../app/auth/models.py)).
+Operators create registrations with the
+[`Server/scripts/generate_node_ids.py`](../scripts/generate_node_ids.py) helper.
+The CLI accepts a count and an optional JSON metadata file:
 
-Download identifiers now take advantage of the full 48-character default, while
-house external identifiers can stretch to 64 characters. The node ID remains at
-31 characters to match the ESP32 firmware limit.
+```bash
+python Server/scripts/generate_node_ids.py 25 \
+    --metadata-file tooling/batch-metadata.json > new_nodes.json
+```
 
-All three values live in the SQLModel database instead of the JSON registry.
-`device_registry.json` continues to list houses, rooms and node metadata, but it
-no longer contains hashed OTA tokens.
+The command initialises the auth database (creating tables if necessary),
+persists the requested number of registrations, and writes a machine-readable
+summary to stdout (JSON by default, or CSV when `--format csv` is supplied).
+Each entry includes the node ID, download ID, plaintext bearer token, hash, and
+creation timestamp. The metadata file may contain either a single JSON object
+(applied to every generated node) or a list of objects (applied positionally).
+Those metadata blobs are stored verbatim in the `hardware_metadata` column so
+future tooling—such as a firmware image generator—can inject per-device GPIO or
+feature flags.
 
-## Provisioning workflow
+Because the plaintext token is stored alongside the hash in
+`node_registrations.provisioning_token`, the provisioning workflow can retrieve
+it later without rotating credentials. Treat the exported JSON/CSV like any
+other secret material and store it in your password manager or build system
+vault.
 
-1. **Create the node in the UI.** When you add a node the admin API stores the
-   opaque node ID, download ID and hashed bearer token in the credential table.
-   The response includes the download alias so you can verify the record, but the
-   plaintext token is only returned via provisioning tools.
+To inspect reserved identifiers and their current assignment state, run the
+existing provisioning helper in list mode:
 
-2. **Generate firmware defaults with the provisioning CLI.** Use
-   [`Server/scripts/provision_node_firmware.py`](../scripts/provision_node_firmware.py)
-   to rotate the token, update `sdkconfig`, and manage the firmware directory in a
-   single command:
+```bash
+python Server/scripts/provision_node_firmware.py --list
+```
 
-   ```bash
-   python Server/scripts/provision_node_firmware.py provisioned-node \
-       --config UltraNodeV5/sdkconfig --rotate-download
-   ```
+The table now shows whether each node is still available, has been claimed for a
+house/room, or was already provisioned.
 
-   The command:
+## Provisioning firmware
 
-   * generates a fresh bearer token and persists its hash,
-   * optionally rotates the download alias (use `--rotate-download`),
-   * writes `CONFIG_UL_NODE_ID`, `CONFIG_UL_OTA_MANIFEST_URL` and
-     `CONFIG_UL_OTA_BEARER_TOKEN` into the selected `sdkconfig` files, and
-   * ensures the `/srv/firmware/<download_id>` directory (under the default
-     `/srv/firmware/UltraLights` root) exists and stores the node’s firmware
-     artifacts directly.
+When it is time to flash a device, call
+[`Server/scripts/provision_node_firmware.py`](../scripts/provision_node_firmware.py)
+with the pre-generated node ID:
 
+```bash
+python Server/scripts/provision_node_firmware.py abcd1234efgh5678 \
+    --config UltraNodeV5/sdkconfig
+```
 
-   The plaintext token and manifest URL are printed once so you can archive them
-   securely.
+The command refuses unknown node IDs and no longer generates new identifiers on
+the fly. Instead it reads the download ID, manifest URL, provisioning token, and
+metadata from the registration record. The CLI then:
 
-   > **Where to store the outputs.** Save the manifest URL, download ID and
-   > bearer token in the same vault you use for long-lived service credentials
-   > (for example 1Password, Bitwarden, or your infrastructure secrets manager).
-   > The API only keeps the SHA-256 hash of the token, so you cannot recover the
-   > plaintext later if it is misplaced.
+* patches the requested `sdkconfig` files with
+  `CONFIG_UL_NODE_ID`, `CONFIG_UL_OTA_MANIFEST_URL`,
+  `CONFIG_UL_OTA_BEARER_TOKEN`, and (when metadata is present)
+  `CONFIG_UL_NODE_METADATA` containing a compact JSON string,
+* ensures the firmware download directory
+  `${FIRMWARE_DIR}/<download_id>` exists, and
+* updates the database to mark the node as provisioned unless
+  `--no-mark-provisioned` is supplied.
 
-   You will need the manifest URL and bearer token whenever you:
+`--rotate-download` remains available when you need to retire a compromised
+manifest URL, and the command will fall back to `rotate_token` if the stored
+plaintext token is missing. The summary printed at the end of the run now
+highlights the node's status (available, assigned, or provisioned), current
+assignment target, metadata payload, and download directory.
 
-   * patch another `sdkconfig` (or rebuild the firmware) for this node,
-   * re-flash hardware after a board replacement, or
-   * perform incident response—for example revoking the current token and
-     verifying that no other device is still using it.
+## Assigning registrations
 
-   Keeping the download ID handy also lets you inspect the corresponding
-
-   firmware folder on disk (`/srv/firmware/UltraLights/<download_id>`) during
-   troubleshooting without revealing the node slug. Firmware artifacts now live
-   directly inside the download directory, so the filesystem no longer exposes
-   node identifiers.
-
-3. **Build and publish firmware.** After the CLI patches `sdkconfig`, build the
-   firmware and place the resulting `latest.bin` into
-   `${FIRMWARE_DIR}/<download_id>/latest.bin`. The provisioning tooling keeps
-   the download directory populated with the current binary.
-
-4. **Audit provisioning status.** To see which nodes have already been
-   provisioned, run the CLI with `--list`; provisioned entries are marked with an
-   asterisk and include the timestamp the firmware was generated.
-
-If you need to regenerate credentials manually, the
-[`manage_node_credentials`](../scripts/manage_node_credentials.py) helper still
-rotates tokens or download aliases and prints the new values, but the provisioning
-CLI is the recommended path because it keeps firmware defaults, download directories and the
-database in sync.
+The UI no longer creates nodes directly. The "Add node" button is disabled and
+points administrators to the offline provisioning workflow, while the legacy
+`/api/house/{house_id}/room/{room_id}/nodes` endpoint returns
+`501 Not Implemented`. Future work will introduce an assignment flow that claims
+an existing registration for a specific house, user, and room. Until then,
+operators can use internal tooling (or direct database access) to populate the
+`house_slug`, `room_id`, `assigned_house_id`, and `assigned_user_id` fields once
+a device is tied to a customer.
 
 ## Why keep download identifiers?
 
 Opaque node IDs removed the original privacy concern—we no longer leak a house
-slug through the device identifier—but the dedicated download alias still buys
-us a few operational conveniences:
+slug through the device identifier—but the dedicated download alias still buys a
+few operational conveniences:
 
 * The provisioning CLI can rotate the externally visible firmware URL by issuing
-  a fresh download ID (`--rotate-download`) while leaving `CONFIG_UL_NODE_ID`
-  untouched. That lets us retire a leaked manifest URL or move a node’s firmware
-  folder without changing the identifier the device uses for MQTT and telemetry.
-* Older builds and scripts that were created before the SQLModel migration still
-  expect the download alias that lives in the registry. Maintaining the alias
-  keeps those installations functional while we roll forward to firmware that
-  understands opaque node IDs.
+  a fresh download ID (`--rotate-download`) while leaving
+  `CONFIG_UL_NODE_ID` untouched. That lets us retire a leaked manifest URL or
+  move a node’s firmware folder without changing the identifier the device uses
+  for MQTT and telemetry.
+* Older builds and scripts created before the SQLModel migration still expect the
+  download alias that lives in the registry. Maintaining the alias keeps those
+  installations functional while we roll forward to firmware that understands
+  opaque node IDs.
 * The alias gives support staff a shareable handle for diagnostics—you can point
   someone at `/firmware/<download_id>/latest.bin` without also disclosing the
-  node ID. Because the alias maps directly to an on-disk directory, you can rotate or delete it once
-  the troubleshooting session is over.
+  node ID. Because the alias maps directly to an on-disk directory, you can
+  rotate or delete it once the troubleshooting session is over.
 
 If these use cases eventually stop mattering we can collapse the indirection and
 serve binaries directly from the node ID, but for now the server and tooling are

--- a/Server/scripts/generate_node_ids.py
+++ b/Server/scripts/generate_node_ids.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Batch-generate opaque node registrations for manufacturing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import database, node_credentials  # noqa: E402
+from app.auth.service import init_auth_storage  # noqa: E402
+
+
+def _load_metadata_entries(path: Optional[str]) -> Optional[List[Dict[str, Any]]]:
+    if not path:
+        return None
+
+    metadata_path = Path(path).expanduser()
+    if not metadata_path.exists():
+        raise FileNotFoundError(f"metadata file not found: {metadata_path}")
+
+    payload = json.loads(metadata_path.read_text())
+    if isinstance(payload, list):
+        entries: List[Dict[str, Any]] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                raise ValueError("metadata list entries must be objects")
+            entries.append(dict(item))
+        return entries
+    if isinstance(payload, dict):
+        return [dict(payload)]
+
+    raise ValueError("metadata file must contain a JSON object or list of objects")
+
+
+def _emit_json(records: Iterable[Dict[str, Any]]) -> None:
+    print(json.dumps(list(records), indent=2))
+
+
+def _emit_csv(records: Iterable[Dict[str, Any]]) -> None:
+    import csv
+
+    fieldnames = [
+        "node_id",
+        "download_id",
+        "ota_token",
+        "token_hash",
+        "created_at",
+        "hardware_metadata",
+    ]
+    writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+    writer.writeheader()
+    for record in records:
+        row = dict(record)
+        metadata = row.get("hardware_metadata")
+        row["hardware_metadata"] = json.dumps(metadata or {})
+        writer.writerow(row)
+
+
+def _format_record(entry: node_credentials.NodeRegistrationWithToken) -> Dict[str, Any]:
+    registration = entry.registration
+    return {
+        "node_id": registration.node_id,
+        "download_id": registration.download_id,
+        "ota_token": entry.plaintext_token,
+        "token_hash": registration.token_hash,
+        "created_at": registration.created_at.isoformat()
+        if isinstance(registration.created_at, datetime)
+        else str(registration.created_at),
+        "hardware_metadata": registration.hardware_metadata,
+    }
+
+
+def generate_nodes(
+    *,
+    count: int,
+    metadata_entries: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    init_auth_storage()
+
+    metadata_iter: Optional[Iterable[Dict[str, Any]]] = None
+    if metadata_entries:
+        metadata_iter = metadata_entries
+
+    with database.SessionLocal() as session:
+        entries = node_credentials.create_batch(
+            session,
+            count,
+            metadata=metadata_iter,
+        )
+
+    return [_format_record(entry) for entry in entries]
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "count",
+        type=int,
+        help="Number of node identifiers to generate",
+    )
+    parser.add_argument(
+        "--metadata-file",
+        type=str,
+        default=None,
+        help="Optional JSON file containing hardware metadata objects",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "csv"),
+        default="json",
+        help="Output format (default: json)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+
+    metadata_entries = _load_metadata_entries(args.metadata_file)
+    records = generate_nodes(
+        count=args.count,
+        metadata_entries=metadata_entries,
+    )
+
+    if args.format == "csv":
+        _emit_csv(records)
+    else:
+        _emit_json(records)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/Server/scripts/provision_node_firmware.py
+++ b/Server/scripts/provision_node_firmware.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -16,7 +17,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from sqlmodel import Session, select  # noqa: E402
 
 from app import database, node_credentials, registry  # noqa: E402
-from app.auth.models import AuditLog, NodeCredential, User  # noqa: E402
+from app.auth.models import AuditLog, NodeCredential, NodeRegistration, User  # noqa: E402
 from app.auth.service import init_auth_storage  # noqa: E402
 from app.config import settings  # noqa: E402
 
@@ -138,25 +139,46 @@ def _list_nodes() -> int:
     init_auth_storage()
     with database.SessionLocal() as session:
         node_credentials.sync_registry_nodes(session)
-        entries = session.exec(select(NodeCredential)).all()
+        registrations = session.exec(select(NodeRegistration)).all()
+        credential_rows = session.exec(select(NodeCredential)).all()
         creators = _load_node_creators(session)
 
-    if not entries:
+    if not registrations:
         print("No nodes registered.")
         return 0
 
+    credential_map = {entry.node_id: entry for entry in credential_rows}
     print(
-        "Node ID                          Name                         Created By                  Provisioned"
+        f"{'Node ID':<30} {'Status':<12} {'Display Name':<24} {'Assignment':<24} {'Provisioned':<20} Creator"
     )
-    print("-" * 100)
-    for entry in entries:
-        mark = "" if entry.provisioned_at is None else "*"
-        name = entry.display_name or "—"
-        created_by = creators.get(entry.node_id, "—")
-        print(
-            f"{entry.node_id:<30} {name:<27} {created_by:<27} {_format_timestamp(entry.provisioned_at)}{mark}"
+    print("-" * 125)
+
+    def _status_for(reg: NodeRegistration, cred: Optional[NodeCredential]) -> str:
+        if reg.provisioned_at or (cred and cred.provisioned_at):
+            return "provisioned"
+        if reg.assigned_at or cred:
+            return "assigned"
+        return "available"
+
+    for registration in sorted(registrations, key=lambda r: r.node_id):
+        credential = credential_map.get(registration.node_id)
+        status = _status_for(registration, credential)
+        display_name = registration.display_name or (
+            credential.display_name if credential else "—"
         )
-    print("\n* indicates firmware already provisioned")
+        house = registration.house_slug or (credential.house_slug if credential else None)
+        room = registration.room_id or (credential.room_id if credential else None)
+        if house or room:
+            assignment = f"{house or '—'} / {room or '—'}"
+        else:
+            assignment = "—"
+        provisioned = registration.provisioned_at or (
+            credential.provisioned_at if credential else None
+        )
+        creator = creators.get(registration.node_id, "—")
+        print(
+            f"{registration.node_id:<30} {status:<12} {display_name:<24} {assignment:<24} {_format_timestamp(provisioned):<20} {creator}"
+        )
     return 0
 
 
@@ -177,15 +199,31 @@ def _provision(args: argparse.Namespace) -> int:
     init_auth_storage()
     registry.ensure_house_external_ids()
 
+    token: Optional[str] = None
+    download_id: Optional[str] = None
+    metadata_payload: Dict[str, Any] = {}
+    previous_download: Optional[str] = None
+    final_registration: Optional[NodeRegistration] = None
+    final_credential: Optional[NodeCredential] = None
+    manifest_url: Optional[str] = None
+    download_dir: Optional[Path] = None
+
     with database.SessionLocal() as session:
         node_credentials.sync_registry_nodes(session)
-        credential = node_credentials.get_by_node_id(session, args.node_id)
-        if credential is None:
+        registration = node_credentials.get_registration_by_node_id(
+            session, args.node_id
+        )
+        if registration is None:
             print(f"Unknown node id: {args.node_id}", file=sys.stderr)
             return 1
 
+        credential = node_credentials.get_by_node_id(session, args.node_id)
+
+        provisioned_at = registration.provisioned_at or (
+            credential.provisioned_at if credential else None
+        )
         if (
-            credential.provisioned_at is not None
+            provisioned_at is not None
             and not args.allow_reprovision
             and not args.no_mark_provisioned
         ):
@@ -195,22 +233,39 @@ def _provision(args: argparse.Namespace) -> int:
             )
             return 1
 
-        previous_download = credential.download_id
+        previous_download = registration.download_id
         if args.rotate_download:
-            credential = node_credentials.update_download_id(session, args.node_id)
+            node_credentials.update_download_id(session, args.node_id)
+            registration = node_credentials.get_registration_by_node_id(
+                session, args.node_id
+            )
+            credential = node_credentials.get_by_node_id(session, args.node_id)
 
-        download_id = credential.download_id
+        download_id = registration.download_id
 
         download_dir = _ensure_download_dir(download_id)
 
-        credential, token = node_credentials.rotate_token(session, args.node_id)
+        token = registration.provisioning_token
+        if not token:
+            _, token = node_credentials.rotate_token(session, args.node_id)
+            registration = node_credentials.get_registration_by_node_id(
+                session, args.node_id
+            )
+            credential = node_credentials.get_by_node_id(session, args.node_id)
+            token = registration.provisioning_token or token
 
-        manifest_url = f"{settings.PUBLIC_BASE}/firmware/UltraLights/{download_id}/manifest.json"
+        manifest_url = f"{settings.PUBLIC_BASE}/firmware/{download_id}/manifest.json"
         values = {
             "CONFIG_UL_NODE_ID": args.node_id,
             "CONFIG_UL_OTA_MANIFEST_URL": manifest_url,
             "CONFIG_UL_OTA_BEARER_TOKEN": token,
         }
+
+        metadata_payload = registration.hardware_metadata or {}
+        if metadata_payload:
+            values["CONFIG_UL_NODE_METADATA"] = json.dumps(
+                metadata_payload, separators=(",", ":"), sort_keys=True
+            )
 
         updated_files: List[Path] = []
         for cfg in normalized_configs:
@@ -226,22 +281,71 @@ def _provision(args: argparse.Namespace) -> int:
 
         node_credentials.sync_registry_nodes(session)
 
+        final_registration = node_credentials.get_registration_by_node_id(
+            session, args.node_id
+        )
+        final_credential = node_credentials.get_by_node_id(session, args.node_id)
+
+        expected_hash = registry.hash_node_token(token)
+        needs_sync = False
+        if final_registration and final_registration.token_hash != expected_hash:
+            needs_sync = True
+        if final_credential and final_credential.token_hash != expected_hash:
+            needs_sync = True
+
+        if needs_sync:
+            node_credentials.rotate_token(session, args.node_id, token=token)
+            final_registration = node_credentials.get_registration_by_node_id(
+                session, args.node_id
+            )
+            final_credential = node_credentials.get_by_node_id(session, args.node_id)
+
     _, _, node = registry.find_node(args.node_id)
-    name = node.get("name") if isinstance(node, dict) else ""
+    name = ""
+    if isinstance(node, dict):
+        name = str(node.get("name") or "")
+    if not name and final_registration:
+        name = final_registration.display_name or ""
+    if not name and final_credential:
+        name = final_credential.display_name or ""
+
+    assignment_parts: List[str] = []
+    if final_registration:
+        if final_registration.house_slug:
+            assignment_parts.append(final_registration.house_slug)
+        if final_registration.room_id:
+            assignment_parts.append(final_registration.room_id)
+    if not assignment_parts and final_credential:
+        assignment_parts.append(final_credential.house_slug)
+        assignment_parts.append(final_credential.room_id)
+    assignment_display = " / ".join(part for part in assignment_parts if part) or "—"
+
+    status = "available"
+    if final_registration and final_registration.provisioned_at:
+        status = "provisioned"
+    elif final_registration and final_registration.assigned_at:
+        status = "assigned"
 
     print("\n--- Firmware provisioning ---")
     if name:
         print(f"Node: {args.node_id} ({name})")
     else:
         print(f"Node: {args.node_id}")
+    print(f"Status: {status}")
+    print(f"Assignment: {assignment_display}")
     print(f"Download ID: {download_id}")
     print(f"Manifest URL: {manifest_url}")
     print(f"Bearer Token: {token}")
+    if metadata_payload:
+        print("Hardware metadata:")
+        print(json.dumps(metadata_payload, indent=2, sort_keys=True))
     if updated_files:
         print("Updated configuration files:")
         for cfg in updated_files:
             print(f"  - {cfg}")
     print(f"Firmware directory: {download_dir}")
+    if previous_download and previous_download != download_id:
+        print(f"Previous download id was {previous_download}")
     return 0
 
 

--- a/Server/tests/test_ota_credentials.py
+++ b/Server/tests/test_ota_credentials.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import json
 import re
 import sys
 from pathlib import Path
@@ -16,7 +17,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from app import database, node_credentials, ota, registry
 from app.auth.service import init_auth_storage
 from app.config import settings
-from scripts import manage_node_credentials, provision_node_firmware
+from scripts import generate_node_ids, manage_node_credentials, provision_node_firmware
 
 
 class _NoopBus:
@@ -77,9 +78,6 @@ def ota_environment(tmp_path, monkeypatch):
     monkeypatch.setattr(ota.settings, "AUTH_DB_URL", db_url)
     init_auth_storage()
 
-    with database.SessionLocal() as session:
-        node_credentials.sync_registry_nodes(session)
-
     yield {
         "registry": settings.DEVICE_REGISTRY,
         "firmware_dir": firmware_dir,
@@ -101,7 +99,6 @@ def ota_environment(tmp_path, monkeypatch):
 
 @pytest.fixture()
 def node_credential_info(ota_environment):
-    token = "node-token-value"
     download_id = "DLTESTID1234"
     with database.SessionLocal() as session:
         node_credentials.ensure_for_node(
@@ -111,9 +108,9 @@ def node_credential_info(ota_environment):
             room_id="lab",
             display_name="Test Node",
             download_id=download_id,
-            token_hash=registry.hash_node_token(token),
         )
-        node_credentials.sync_registry_nodes(session)
+        credential, token = node_credentials.rotate_token(session, "test-node")
+        download_id = credential.download_id
 
     node_dir = settings.FIRMWARE_DIR / "test-node"
     node_dir.mkdir(parents=True, exist_ok=True)
@@ -246,6 +243,9 @@ def test_manage_node_credentials_cli_creates_token(tmp_path, monkeypatch):
     firmware_dir.mkdir()
     monkeypatch.setattr(settings, "FIRMWARE_DIR", firmware_dir)
     monkeypatch.setattr(registry.settings, "FIRMWARE_DIR", firmware_dir)
+    monkeypatch.setattr(settings, "PUBLIC_BASE", "https://example.test")
+    monkeypatch.setattr(registry.settings, "PUBLIC_BASE", "https://example.test")
+    monkeypatch.setattr(ota.settings, "PUBLIC_BASE", "https://example.test")
 
     db_path = tmp_path / "auth.sqlite3"
     db_url = f"sqlite:///{db_path}"
@@ -380,7 +380,8 @@ def test_provision_node_firmware_updates_sdkconfig(tmp_path, monkeypatch, capsys
     with database.SessionLocal() as session:
         record = node_credentials.get_by_node_id(session, "provision-node")
         assert record is not None
-        assert record.download_id in manifest_url
+        expected_suffix = f"/firmware/{record.download_id}/manifest.json"
+        assert manifest_url.endswith(expected_suffix)
         assert record.token_hash == registry.hash_node_token(token_value)
         assert record.provisioned_at is not None
 
@@ -399,3 +400,39 @@ def test_provision_node_firmware_updates_sdkconfig(tmp_path, monkeypatch, capsys
     database.reset_session_factory(original_db_url)
     monkeypatch.setattr(settings, "AUTH_DB_URL", original_db_url)
     monkeypatch.setattr(ota.settings, "AUTH_DB_URL", original_db_url)
+
+
+def test_pre_registered_node_provisioning(tmp_path, ota_environment, capsys):
+    metadata = {"gpio": {"relay": 5}, "enabled": True}
+    records = generate_node_ids.generate_nodes(
+        count=1, metadata_entries=[metadata]
+    )
+    record = records[0]
+    node_id = record["node_id"]
+
+    sdkconfig = tmp_path / "sdkconfig"
+    sdkconfig.write_text("\n")
+
+    exit_code = provision_node_firmware.main(
+        [node_id, "--config", str(sdkconfig)]
+    )
+    assert exit_code == 0
+    output = capsys.readouterr().out
+
+    config_text = sdkconfig.read_text()
+    assert f'CONFIG_UL_NODE_ID="{node_id}"' in config_text
+    assert f'CONFIG_UL_OTA_BEARER_TOKEN="{record["ota_token"]}"' in config_text
+    metadata_json = json.dumps(metadata, separators=(",", ":"), sort_keys=True)
+    assert f'CONFIG_UL_NODE_METADATA="{metadata_json}"' in config_text
+
+    download_dir = settings.FIRMWARE_DIR / record["download_id"]
+    assert download_dir.exists()
+    assert download_dir.is_dir()
+
+    with database.SessionLocal() as session:
+        registration = node_credentials.get_registration_by_node_id(session, node_id)
+        assert registration is not None
+        assert registration.provisioning_token == record["ota_token"]
+        assert registration.provisioned_at is not None
+
+    assert "Hardware metadata" in output


### PR DESCRIPTION
## Summary
- add a NodeRegistration table and refactor node credential helpers to support batch pre-generation and assignment workflows
- introduce a generate_node_ids CLI, refresh provisioning tooling to consume pre-registered metadata, and disable the legacy add-node API/UI wiring
- document the new batch provisioning process and extend OTA tests to cover pre-generated identifiers

## Testing
- pytest Server/tests/test_ota_credentials.py

------
https://chatgpt.com/codex/tasks/task_e_68d6b12a2a948326bb709b85e019bc90