### PR TITLE
Backfill node registration auth columns on startup

### DIFF
--- a/Server/app/account_linker.py
+++ b/Server/app/account_linker.py
@@ -1,0 +1,123 @@
+"""Bridge MQTT account credential events into the database."""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any, Optional
+
+import paho.mqtt.client as mqtt
+
+from . import database, node_credentials
+from .mqtt_tls import connect_mqtt_client
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AccountLinker:
+    """Listen for account credential events and persist associations."""
+
+    def __init__(self) -> None:
+        self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+        enable_logger = getattr(self.client, "enable_logger", None)
+        if callable(enable_logger):
+            enable_logger()
+        self.client.on_connect = self._on_connect
+        self.client.on_message = self._on_message
+        self._loop_thread: Optional[threading.Thread] = None
+        self._running = False
+
+    def start(self) -> None:
+        if self._running:
+            return
+        connect_mqtt_client(
+            self.client,
+            keepalive=30,
+            start_async=True,
+            raise_on_failure=False,
+        )
+        loop_start = getattr(self.client, "loop_start", None)
+        if callable(loop_start):
+            loop_start()
+        else:
+            self._loop_thread = threading.Thread(
+                target=self.client.loop_forever,
+                daemon=True,
+            )
+            self._loop_thread.start()
+        self._running = True
+
+    def stop(self) -> None:
+        if not self._running:
+            return
+        loop_stop = getattr(self.client, "loop_stop", None)
+        if callable(loop_stop):
+            loop_stop()
+        if self._loop_thread is not None:
+            self._loop_thread.join(timeout=5.0)
+            self._loop_thread = None
+        self.client.disconnect()
+        self._running = False
+
+    # MQTT callbacks -------------------------------------------------
+    def _on_connect(
+        self, client: mqtt.Client, userdata, flags, reason_code, properties=None
+    ) -> None:
+        client.subscribe("ul/+/evt/account")
+
+    def _on_message(self, client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:  # type: ignore[override]
+        topic = msg.topic or ""
+        parts = topic.split("/")
+        if len(parts) < 4 or parts[0] != "ul" or parts[2] != "evt":
+            return
+        node_id = parts[1]
+        try:
+            payload = json.loads(msg.payload.decode("utf-8"))
+        except Exception:
+            _LOGGER.warning("Failed to decode account payload from node '%s'", node_id)
+            return
+        if not isinstance(payload, dict):
+            return
+        event = payload.get("event")
+        if event and event != "account_credentials":
+            return
+        username = payload.get("username")
+        password = payload.get("password")
+        if not isinstance(username, str) or not isinstance(password, str):
+            _LOGGER.warning(
+                "Malformed account payload for node '%s': missing username/password",
+                node_id,
+            )
+            return
+        self.handle_credentials(node_id, username, password)
+
+    # Persistence helpers -------------------------------------------
+    def handle_credentials(
+        self, node_id: str, username: str, password: str
+    ) -> Optional[Any]:
+        """Record credentials for ``node_id``. Separated for tests."""
+
+        try:
+            with database.SessionLocal() as session:
+                return node_credentials.record_account_credentials(
+                    session, node_id, username, password
+                )
+        except ValueError:
+            _LOGGER.warning(
+                "Ignoring empty account credentials for node '%s'", node_id
+            )
+        except KeyError:
+            _LOGGER.warning(
+                "Received account credentials for unknown node '%s'", node_id
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            _LOGGER.exception(
+                "Failed to persist account credentials for node '%s'", node_id
+            )
+        return None
+
+
+account_linker = AccountLinker()
+
+__all__ = ["account_linker", "AccountLinker"]

--- a/Server/app/auth/models.py
+++ b/Server/app/auth/models.py
@@ -128,6 +128,76 @@ class AuditLog(SQLModel, table=True):
     created_at: datetime = Field(default_factory=_utcnow, sa_column=_timestamp_column())
 
 
+class NodeRegistration(SQLModel, table=True):
+    """Opaque node identifiers that may be claimed and provisioned later."""
+
+    __tablename__ = "node_registrations"
+    __table_args__ = (
+        UniqueConstraint("download_id", name="uq_node_registrations_download_id"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    node_id: str = Field(
+        sa_column=Column(String(64), unique=True, nullable=False, index=True)
+    )
+    download_id: str = Field(
+        sa_column=Column(String(64), unique=True, nullable=False, index=True)
+    )
+    token_hash: str = Field(sa_column=Column(String(64), nullable=False))
+    provisioning_token: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    created_at: datetime = Field(default_factory=_utcnow, sa_column=_timestamp_column())
+    token_issued_at: datetime = Field(
+        default_factory=_utcnow, sa_column=_timestamp_column(onupdate=True)
+    )
+    provisioned_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    assigned_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    assigned_user_id: Optional[int] = Field(
+        default=None,
+        foreign_key="users.id",
+    )
+    assigned_house_id: Optional[int] = Field(
+        default=None,
+        foreign_key="houses.id",
+    )
+    house_slug: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(64), nullable=True, index=True),
+    )
+    room_id: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(120), nullable=True, index=True),
+    )
+    display_name: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(120), nullable=True),
+    )
+    hardware_metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False, default=dict),
+    )
+    account_username: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(64), nullable=True, index=True),
+    )
+    account_password_hash: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    account_credentials_received_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+
+
 class NodeCredential(SQLModel, table=True):
     __tablename__ = "node_credentials"
     __table_args__ = (
@@ -153,13 +223,6 @@ class NodeCredential(SQLModel, table=True):
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),
     )
-    token_issued_at: datetime = Field(
-        default_factory=datetime.utcnow, sa_column=_timestamp_column(onupdate=True)
-    )
-    provisioned_at: Optional[datetime] = Field(
-        default=None,
-        sa_column=Column(DateTime(timezone=True), nullable=True),
-    )
 
 
 __all__ = [
@@ -168,6 +231,7 @@ __all__ = [
     "HouseMembership",
     "HouseRole",
     "NodeCredential",
+    "NodeRegistration",
     "RoomAccess",
     "User",
 ]

--- a/Server/app/auth/service.py
+++ b/Server/app/auth/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
+from sqlalchemy import inspect, text
 from sqlmodel import SQLModel, Session, select
 
 from .. import node_credentials, registry
@@ -16,6 +17,7 @@ def init_auth_storage() -> None:
     """Ensure tables exist and seed initial data."""
 
     SQLModel.metadata.create_all(database.engine)
+    _ensure_node_registration_columns()
 
     with database.SessionLocal() as session:
         _seed_initial_admin(session)
@@ -67,6 +69,39 @@ def _sync_registry_nodes(session: Session) -> None:
     """Ensure credential rows exist for every registry node."""
 
     node_credentials.sync_registry_nodes(session)
+
+
+def _ensure_node_registration_columns() -> None:
+    """Backfill newly added ``node_registrations`` columns if missing."""
+
+    inspector = inspect(database.engine)
+    try:
+        columns = {
+            column_info["name"] for column_info in inspector.get_columns("node_registrations")
+        }
+    except Exception:  # pragma: no cover - table may not exist yet
+        return
+
+    statements = []
+    if "account_username" not in columns:
+        statements.append(
+            "ALTER TABLE node_registrations ADD COLUMN account_username VARCHAR(64)"
+        )
+    if "account_password_hash" not in columns:
+        statements.append(
+            "ALTER TABLE node_registrations ADD COLUMN account_password_hash VARCHAR(255)"
+        )
+    if "account_credentials_received_at" not in columns:
+        statements.append(
+            "ALTER TABLE node_registrations ADD COLUMN account_credentials_received_at TIMESTAMP"
+        )
+
+    if not statements:
+        return
+
+    with database.engine.begin() as connection:
+        for statement in statements:
+            connection.execute(text(statement))
 
 
 def create_user(

--- a/Server/app/main.py
+++ b/Server/app/main.py
@@ -9,6 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
 
 from . import registry
+from .account_linker import account_linker
 from .auth import SESSION_TOKEN_TTL_SECONDS, init_auth_storage
 from .auth.throttling import reset_login_rate_limiter
 from .config import settings
@@ -55,6 +56,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     motion_manager.start()
     status_monitor.start()
+    account_linker.start()
 
     registry.ensure_house_external_ids()
     init_auth_storage()
@@ -74,6 +76,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 pass
         motion_manager.stop()
         status_monitor.stop()
+        account_linker.stop()
 
 
 app = FastAPI(title="UltraLights Hub", version="2.0", lifespan=lifespan)

--- a/Server/app/mqtt_tls.py
+++ b/Server/app/mqtt_tls.py
@@ -85,7 +85,14 @@ def configure_client_tls(client: mqtt.Client) -> None:
 
     set_context = getattr(client, "tls_set_context", None)
     if callable(set_context):
-        set_context(context)
+        try:
+            set_context(context)
+        except ValueError as exc:
+            message = str(exc).lower()
+            if "already been configured" in message:
+                logger.debug("MQTT client TLS context already configured; reusing existing context")
+            else:  # pragma: no cover - propagate unexpected errors
+                raise
         return
 
     # Fall back to the legacy ``tls_set`` API for test doubles and older Paho

--- a/Server/app/node_builder.py
+++ b/Server/app/node_builder.py
@@ -1,0 +1,484 @@
+"""Utilities for building firmware artifacts from node registrations."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from sqlmodel import Session, select
+
+from . import node_credentials, registry
+from .auth.models import NodeRegistration
+from .config import settings
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIRMWARE_ROOT = PROJECT_ROOT / "UltraNodeV5"
+SDKCONFIG_TEMPLATE = FIRMWARE_ROOT / "sdkconfig.defaults"
+SDKCONFIG_WORK_DIR = FIRMWARE_ROOT / "node_configs"
+
+
+@dataclass
+class CommandResult:
+    """Outcome from invoking a command line helper."""
+
+    command: List[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    cwd: Path
+
+
+@dataclass
+class BuildResult(CommandResult):
+    """Return value for individual node builds."""
+
+    node_id: str
+    sdkconfig_path: Path
+    manifest_url: str
+    download_id: str
+    target: str
+
+
+class NodeBuilderError(RuntimeError):
+    """Raised when a firmware helper fails."""
+
+
+SUPPORTED_TARGETS: Dict[str, str] = {
+    "esp32": "esp32",
+    "esp32c3": "esp32c3",
+    "esp32s3": "esp32s3",
+}
+
+
+def _sanitize_node_for_path(node_id: str) -> str:
+    safe = [ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in node_id]
+    return "".join(safe).strip() or "node"
+
+
+def _config_value(value: Any, *, quoted: bool = False) -> Tuple[Any, bool]:
+    return value, quoted
+
+
+def _bool_flag(value: bool) -> Tuple[str, bool]:
+    return ("y" if value else "n"), False
+
+
+def _coerce_numeric(value: Any) -> Tuple[Any, bool]:
+    if value in (None, ""):
+        return "", False
+    if isinstance(value, bool):
+        return value, False
+    if isinstance(value, (int, float)):
+        return int(value), False
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed:
+            return "", False
+        try:
+            numeric = int(trimmed, 0)
+            return numeric, False
+        except ValueError:
+            return trimmed, True
+    return value, True
+
+
+def _ensure_work_dir() -> Path:
+    SDKCONFIG_WORK_DIR.mkdir(parents=True, exist_ok=True)
+    return SDKCONFIG_WORK_DIR
+
+
+def _extract_key(line: str) -> Optional[str]:
+    line = line.rstrip()
+    if not line:
+        return None
+    if line.startswith("CONFIG_"):
+        return line.split("=", 1)[0]
+    if line.startswith("# CONFIG_") and line.endswith(" is not set"):
+        parts = line.split()
+        if len(parts) >= 3:
+            return parts[1]
+    return None
+
+
+def _format_value(key: str, entry: Tuple[Any, bool]) -> str:
+    value, quoted = entry
+    if isinstance(value, tuple) and len(value) == 2:
+        # Allow nested tuple unpacking
+        value, quoted = value
+
+    if isinstance(value, bool):
+        return f"{key}={'y' if value else 'n'}"
+
+    if value is None:
+        return f"{key}="
+
+    if isinstance(value, (int, float)) and not quoted:
+        return f"{key}={value}"
+
+    text = str(value)
+    if not quoted and text.isdigit():
+        return f"{key}={text}"
+
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{key}="{escaped}"'
+
+
+def _merge_sdkconfig(base_lines: Iterable[str], overrides: Dict[str, Tuple[Any, bool]]) -> List[str]:
+    applied: set[str] = set()
+    merged: List[str] = []
+
+    for raw_line in base_lines:
+        key = _extract_key(raw_line)
+        if key and key in overrides:
+            merged.append(_format_value(key, overrides[key]))
+            applied.add(key)
+        else:
+            merged.append(raw_line.rstrip())
+
+    for key, entry in overrides.items():
+        if key in applied:
+            continue
+        merged.append(_format_value(key, entry))
+
+    merged.append("")
+    return merged
+
+
+def _board_overrides(board: str) -> Dict[str, Tuple[Any, bool]]:
+    board = board.lower()
+    target = SUPPORTED_TARGETS.get(board, "esp32")
+    overrides: Dict[str, Tuple[Any, bool]] = {
+        "CONFIG_UL_TARGET_CHIP": _config_value(target, quoted=True),
+        "CONFIG_UL_IS_ESP32C3": _bool_flag(board == "esp32c3"),
+        "CONFIG_UL_IS_ESP32S3": _bool_flag(board == "esp32s3"),
+    }
+    return overrides
+
+
+def _ws_overrides(metadata: Dict[str, Any]) -> Dict[str, Tuple[Any, bool]]:
+    channels = metadata.get("ws2812") or []
+    overrides: Dict[str, Tuple[Any, bool]] = {}
+    indexed = {int(entry.get("index", -1)): entry for entry in channels if isinstance(entry, dict)}
+    for idx in range(2):
+        entry = indexed.get(idx) or {}
+        enabled = bool(entry.get("enabled"))
+        overrides[f"CONFIG_UL_WS{idx}_ENABLED"] = _bool_flag(enabled)
+        gpio = entry.get("gpio")
+        pixels = entry.get("pixels")
+        overrides[f"CONFIG_UL_WS{idx}_GPIO"] = _config_value(*_coerce_numeric(gpio))
+        overrides[f"CONFIG_UL_WS{idx}_PIXELS"] = _config_value(*_coerce_numeric(pixels))
+    return overrides
+
+
+def _white_overrides(metadata: Dict[str, Any]) -> Dict[str, Tuple[Any, bool]]:
+    channels = metadata.get("white") or []
+    overrides: Dict[str, Tuple[Any, bool]] = {}
+    indexed = {int(entry.get("index", -1)): entry for entry in channels if isinstance(entry, dict)}
+    for idx in range(4):
+        entry = indexed.get(idx) or {}
+        enabled = bool(entry.get("enabled"))
+        overrides[f"CONFIG_UL_WHT{idx}_ENABLED"] = _bool_flag(enabled)
+        for key in ("GPIO", "LEDC_CH", "PWM_HZ", "MIN", "MAX"):
+            field_key = key.lower()
+            value = entry.get(field_key)
+            overrides[f"CONFIG_UL_WHT{idx}_{key}"] = _config_value(*_coerce_numeric(value))
+    return overrides
+
+
+def _rgb_overrides(metadata: Dict[str, Any]) -> Dict[str, Tuple[Any, bool]]:
+    channels = metadata.get("rgb") or []
+    overrides: Dict[str, Tuple[Any, bool]] = {}
+    indexed = {int(entry.get("index", -1)): entry for entry in channels if isinstance(entry, dict)}
+    for idx in range(4):
+        entry = indexed.get(idx) or {}
+        enabled = bool(entry.get("enabled"))
+        overrides[f"CONFIG_UL_RGB{idx}_ENABLED"] = _bool_flag(enabled)
+        pwm_hz = entry.get("pwm_hz")
+        ledc_mode = entry.get("ledc_mode")
+        overrides[f"CONFIG_UL_RGB{idx}_PWM_HZ"] = _config_value(*_coerce_numeric(pwm_hz))
+        overrides[f"CONFIG_UL_RGB{idx}_LEDC_MODE"] = _config_value(*_coerce_numeric(ledc_mode))
+        for channel, suffix in (("r", "R"), ("g", "G"), ("b", "B")):
+            gpio = entry.get(f"{channel}_gpio")
+            ledc = entry.get(f"{channel}_ledc_ch")
+            overrides[f"CONFIG_UL_RGB{idx}_{suffix}_GPIO"] = _config_value(*_coerce_numeric(gpio))
+            overrides[f"CONFIG_UL_RGB{idx}_{suffix}_LEDC_CH"] = _config_value(*_coerce_numeric(ledc))
+    return overrides
+
+
+def _pir_overrides(metadata: Dict[str, Any]) -> Dict[str, Tuple[Any, bool]]:
+    pir = metadata.get("pir") or {}
+    if not isinstance(pir, dict):
+        return {
+            "CONFIG_UL_PIR_ENABLED": _bool_flag(False),
+            "CONFIG_UL_PIR_GPIO": _config_value("", quoted=False),
+        }
+    enabled = bool(pir.get("enabled"))
+    gpio = pir.get("gpio")
+    return {
+        "CONFIG_UL_PIR_ENABLED": _bool_flag(enabled),
+        "CONFIG_UL_PIR_GPIO": _config_value(*_coerce_numeric(gpio)),
+    }
+
+
+def _override_entries(metadata: Dict[str, Any]) -> Dict[str, Tuple[Any, bool]]:
+    overrides = metadata.get("overrides") or {}
+    result: Dict[str, Tuple[Any, bool]] = {}
+    if isinstance(overrides, dict):
+        for key, value in overrides.items():
+            if not isinstance(key, str) or not key.startswith("CONFIG_"):
+                continue
+            if isinstance(value, bool):
+                result[key] = _bool_flag(value)
+            else:
+                coerced, quoted = _coerce_numeric(value)
+                result[key] = _config_value(coerced, quoted)
+    return result
+
+
+def metadata_to_overrides(metadata: Dict[str, Any]) -> Dict[str, Tuple[Any, bool]]:
+    metadata = metadata or {}
+    overrides: Dict[str, Tuple[Any, bool]] = {}
+    overrides.update(_board_overrides(str(metadata.get("board", "esp32"))))
+    overrides.update(_ws_overrides(metadata))
+    overrides.update(_white_overrides(metadata))
+    overrides.update(_rgb_overrides(metadata))
+    overrides.update(_pir_overrides(metadata))
+    overrides.update(_override_entries(metadata))
+    return overrides
+
+
+def render_sdkconfig(
+    *,
+    node_id: str,
+    download_id: str,
+    token: str,
+    metadata: Dict[str, Any],
+    manifest_url: Optional[str] = None,
+    base_config: Path = SDKCONFIG_TEMPLATE,
+) -> Path:
+    """Write a node-specific sdkconfig and return its path."""
+
+    if manifest_url is None:
+        manifest_url = f"{settings.PUBLIC_BASE}/firmware/{download_id}/manifest.json"
+
+    work_dir = _ensure_work_dir()
+    target = _sanitize_node_for_path(node_id)
+    output_path = work_dir / f"sdkconfig.{target}"
+
+    overrides = metadata_to_overrides(metadata)
+    overrides.update(
+        {
+            "CONFIG_UL_NODE_ID": _config_value(node_id, quoted=True),
+            "CONFIG_UL_OTA_MANIFEST_URL": _config_value(manifest_url, quoted=True),
+            "CONFIG_UL_OTA_BEARER_TOKEN": _config_value(token, quoted=True),
+            "CONFIG_UL_NODE_METADATA": _config_value(
+                json.dumps(metadata, separators=(",", ":"), sort_keys=True),
+                quoted=True,
+            ),
+        }
+    )
+
+    if not base_config.exists():
+        raise FileNotFoundError(f"base sdkconfig not found: {base_config}")
+
+    base_lines = base_config.read_text().splitlines()
+    merged = _merge_sdkconfig(base_lines, overrides)
+    output_path.write_text("\n".join(merged))
+    return output_path
+
+
+def _prepare_environment(board: str, extra_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    env = os.environ.copy()
+    target = SUPPORTED_TARGETS.get(board.lower(), "esp32")
+    env.setdefault("IDF_TARGET", target)
+    if extra_env:
+        env.update(extra_env)
+    return env
+
+
+def _run_command(
+    args: List[str],
+    *,
+    env: Optional[Dict[str, str]] = None,
+    cwd: Path = FIRMWARE_ROOT,
+) -> CommandResult:
+    completed = subprocess.run(
+        args,
+        cwd=str(cwd),
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return CommandResult(
+        command=list(args),
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        cwd=cwd,
+    )
+
+
+def update_all_nodes(firmware_version: str, *, env: Optional[Dict[str, str]] = None) -> CommandResult:
+    """Invoke the bulk updater script."""
+
+    script = FIRMWARE_ROOT / "updateAllNodes.sh"
+    if not script.exists():
+        raise FileNotFoundError(f"updateAllNodes.sh not found at {script}")
+    command = [str(script), firmware_version]
+    return _run_command(command, env=_prepare_environment("esp32", env))
+
+
+def build_individual_node(
+    session: Session,
+    node_id: str,
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+    board: Optional[str] = None,
+    regenerate_token: bool = False,
+    run_build: bool = True,
+    ota_token: Optional[str] = None,
+) -> BuildResult:
+    """Generate an sdkconfig for ``node_id`` and optionally run ``idf.py build``."""
+
+    node_credentials.sync_registry_nodes(session)
+    registration = node_credentials.get_registration_by_node_id(session, node_id)
+    if registration is None:
+        raise NodeBuilderError(f"Unknown node id: {node_id}")
+
+    token_value: Optional[str] = None
+
+    if ota_token:
+        supplied = ota_token.strip()
+        if not supplied:
+            raise NodeBuilderError("OTA token must not be empty")
+        expected_hash = registry.hash_node_token(supplied)
+        if registration.token_hash and registration.token_hash != expected_hash:
+            raise NodeBuilderError(
+                "Provided OTA token does not match the stored hash for this node"
+            )
+        if registration.token_hash != expected_hash:
+            node_credentials.rotate_token(session, node_id, token=supplied)
+            registration = node_credentials.get_registration_by_node_id(session, node_id)
+        token_value = supplied
+    else:
+        _, token_value = node_credentials.rotate_token(session, node_id)
+        registration = node_credentials.get_registration_by_node_id(session, node_id)
+
+    if not token_value:
+        raise NodeBuilderError("Failed to resolve OTA token for node")
+
+    download_id = registration.download_id
+    manifest_url = f"{settings.PUBLIC_BASE}/firmware/{download_id}/manifest.json"
+
+    metadata_payload = metadata or dict(registration.hardware_metadata or {})
+    if board:
+        metadata_payload["board"] = board
+    else:
+        metadata_payload.setdefault("board", "esp32")
+
+    sdkconfig_path = render_sdkconfig(
+        node_id=node_id,
+        download_id=download_id,
+        token=token_value,
+        metadata=metadata_payload,
+        manifest_url=manifest_url,
+    )
+
+    env = _prepare_environment(str(metadata_payload.get("board", "esp32")))
+    env["SDKCONFIG"] = str(sdkconfig_path)
+
+    if run_build:
+        result = _run_command(["idf.py", "build"], env=env)
+    else:
+        result = CommandResult(command=["idf.py", "build"], returncode=0, stdout="", stderr="", cwd=FIRMWARE_ROOT)
+
+    return BuildResult(
+        command=result.command,
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        cwd=result.cwd,
+        node_id=node_id,
+        sdkconfig_path=sdkconfig_path,
+        manifest_url=manifest_url,
+        download_id=download_id,
+        target=SUPPORTED_TARGETS.get(str(metadata_payload.get("board", "esp32")).lower(), "esp32"),
+    )
+
+
+def first_time_flash(
+    session: Session,
+    node_id: str,
+    *,
+    port: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    board: Optional[str] = None,
+    ota_token: Optional[str] = None,
+) -> BuildResult:
+    """Perform ``idf.py -p <port> build flash`` for ``node_id``."""
+
+    build_result = build_individual_node(
+        session,
+        node_id,
+        metadata=metadata,
+        board=board,
+        regenerate_token=False,
+        run_build=False,
+        ota_token=ota_token,
+    )
+
+    env = _prepare_environment(str(metadata or {}).get("board", board or "esp32"))
+    env["SDKCONFIG"] = str(build_result.sdkconfig_path)
+    command = ["idf.py", "-p", port, "build", "flash"]
+    result = _run_command(command, env=env)
+
+    return BuildResult(
+        command=result.command,
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        cwd=result.cwd,
+        node_id=build_result.node_id,
+        sdkconfig_path=build_result.sdkconfig_path,
+        manifest_url=build_result.manifest_url,
+        download_id=build_result.download_id,
+        target=build_result.target,
+    )
+
+
+def ensure_test_registration(
+    session: Session,
+    *,
+    display_name: str = "Firmware Test Node",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> NodeRegistration:
+    """Return a persistent registration used for firmware testing."""
+
+    existing = session.exec(
+        select(NodeRegistration).where(NodeRegistration.display_name == display_name)
+    ).first()
+    if existing:
+        if metadata:
+            merged = dict(existing.hardware_metadata or {})
+            merged.update(metadata)
+            if merged != existing.hardware_metadata:
+                existing.hardware_metadata = merged
+                session.add(existing)
+                session.commit()
+                session.refresh(existing)
+        return existing
+
+    batch = node_credentials.create_batch(session, 1, metadata=[metadata or {}])
+    registration = batch[0].registration
+    registration.display_name = display_name
+    session.add(registration)
+    session.commit()
+    session.refresh(registration)
+    return registration
+

--- a/Server/app/node_credentials.py
+++ b/Server/app/node_credentials.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, List, Optional, Tuple
+import logging
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from sqlmodel import Session, select
 
 from . import registry
-from .auth.models import NodeCredential
+from .auth.models import (
+    HouseMembership,
+    NodeCredential,
+    NodeRegistration,
+    User,
+)
+from .auth.security import hash_password, verify_password
 
 
 @dataclass
@@ -18,6 +25,14 @@ class NodeCredentialWithToken:
 
     credential: NodeCredential
     plaintext_token: Optional[str]
+
+
+@dataclass
+class NodeRegistrationWithToken:
+    """Batch generation return type including the plaintext token."""
+
+    registration: NodeRegistration
+    plaintext_token: str
 
 
 def _now() -> datetime:
@@ -53,6 +68,15 @@ def _get_by_node_id(session: Session, node_id: str) -> Optional[NodeCredential]:
     return _first_result(result)
 
 
+def _get_registration_by_node_id(
+    session: Session, node_id: str
+) -> Optional[NodeRegistration]:
+    result = session.exec(
+        select(NodeRegistration).where(NodeRegistration.node_id == node_id)
+    )
+    return _first_result(result)
+
+
 def get_by_node_id(session: Session, node_id: str) -> Optional[NodeCredential]:
     return _get_by_node_id(session, node_id)
 
@@ -71,9 +95,237 @@ def get_by_token_hash(session: Session, token_hash: str) -> Optional[NodeCredent
     return _first_result(result)
 
 
+def get_registration_by_node_id(
+    session: Session, node_id: str
+) -> Optional[NodeRegistration]:
+    return _get_registration_by_node_id(session, node_id)
+
+
+def get_registration_by_download_id(
+    session: Session, download_id: str
+) -> Optional[NodeRegistration]:
+    result = session.exec(
+        select(NodeRegistration).where(NodeRegistration.download_id == download_id)
+    )
+    return _first_result(result)
+
+
 def any_tokens(session: Session) -> bool:
-    result = session.exec(select(NodeCredential.id))
-    return _first_result(result) is not None
+    """Return True if any node credentials or registrations exist."""
+
+    if _first_result(session.exec(select(NodeCredential.id))):
+        return True
+    return _first_result(session.exec(select(NodeRegistration.id))) is not None
+
+
+def create_batch(
+    session: Session,
+    count: int,
+    *,
+    metadata: Optional[Iterable[Dict[str, Any]]] = None,
+) -> List[NodeRegistrationWithToken]:
+    """Generate ``count`` opaque registrations and persist them."""
+
+    if count <= 0:
+        raise ValueError("count must be positive")
+
+    registrations: List[NodeRegistrationWithToken] = []
+
+    def _collect_strings(statement) -> set[str]:
+        values: set[str] = set()
+        for row in session.exec(statement).all():
+            candidate = row[0] if isinstance(row, tuple) else row
+            if isinstance(candidate, str):
+                values.add(candidate)
+        return values
+
+    existing_node_ids = _collect_strings(select(NodeRegistration.node_id))
+    existing_node_ids.update(_collect_strings(select(NodeCredential.node_id)))
+    existing_download_ids = _collect_strings(select(NodeRegistration.download_id))
+    existing_download_ids.update(_collect_strings(select(NodeCredential.download_id)))
+
+    metadata_list: List[Dict[str, Any]] = []
+    if metadata is not None:
+        for entry in metadata:
+            metadata_list.append(dict(entry))
+
+    for index in range(count):
+        node_id = registry.generate_node_id()
+        while node_id in existing_node_ids:
+            node_id = registry.generate_node_id()
+        existing_node_ids.add(node_id)
+
+        download_id = registry.generate_download_id()
+        while download_id in existing_download_ids:
+            download_id = registry.generate_download_id()
+        existing_download_ids.add(download_id)
+
+        plaintext_token = registry.generate_node_token()
+        token_hash = registry.hash_node_token(plaintext_token)
+
+        metadata_entry: Dict[str, Any] = (
+            dict(metadata_list[index]) if index < len(metadata_list) else {}
+        )
+
+        registration = NodeRegistration(
+            node_id=node_id,
+            download_id=download_id,
+            token_hash=token_hash,
+            hardware_metadata=metadata_entry,
+        )
+        session.add(registration)
+        registrations.append(
+            NodeRegistrationWithToken(
+                registration=registration, plaintext_token=plaintext_token
+            )
+        )
+
+    session.commit()
+    for entry in registrations:
+        session.refresh(entry.registration)
+
+        if entry.registration.provisioning_token:
+            entry.registration.provisioning_token = None
+            session.add(entry.registration)
+
+    session.commit()
+
+    return registrations
+
+
+def list_available_registrations(session: Session) -> List[NodeRegistration]:
+    """Return registrations that have not been assigned to a house/user."""
+
+    result = session.exec(
+        select(NodeRegistration).where(NodeRegistration.assigned_at.is_(None))
+    )
+    return result.all()
+
+
+def list_assigned_registrations(session: Session) -> List[NodeRegistration]:
+    """Return registrations that have been associated with a house or user."""
+
+    result = session.exec(
+        select(NodeRegistration).where(NodeRegistration.assigned_at.is_not(None))
+    )
+    return result.all()
+
+
+def list_pending_registrations_for_user(
+    session: Session, user_id: Optional[int]
+) -> List[NodeRegistration]:
+    """Return unassigned registrations claimed by ``user_id``."""
+
+    if not user_id:
+        return []
+
+    result = session.exec(
+        select(NodeRegistration)
+        .where(NodeRegistration.assigned_user_id == user_id)
+        .where(NodeRegistration.room_id.is_(None))
+        .order_by(NodeRegistration.created_at)
+    )
+    return result.all()
+
+
+def claim_registration(
+    session: Session,
+    node_id: str,
+    *,
+    house_slug: Optional[str] = None,
+    room_id: Optional[str] = None,
+    display_name: Optional[str] = None,
+    assigned_user_id: Optional[int] = None,
+    assigned_house_id: Optional[int] = None,
+    hardware_metadata: Optional[Dict[str, Any]] = None,
+) -> NodeRegistration:
+    """Mark a pre-generated registration as claimed for later assignment."""
+
+    registration = _get_registration_by_node_id(session, node_id)
+    if registration is None:
+        raise KeyError("node registration not found")
+
+    changed = False
+    now = _now()
+
+    if registration.assigned_at is None:
+        registration.assigned_at = now
+        changed = True
+
+    if house_slug is not None and registration.house_slug != house_slug:
+        registration.house_slug = house_slug
+        changed = True
+    if room_id is not None and registration.room_id != room_id:
+        registration.room_id = room_id
+        changed = True
+    if display_name is not None and registration.display_name != display_name:
+        registration.display_name = display_name
+        changed = True
+    if assigned_user_id is not None and registration.assigned_user_id != assigned_user_id:
+        registration.assigned_user_id = assigned_user_id
+        changed = True
+    if assigned_house_id is not None and registration.assigned_house_id != assigned_house_id:
+        registration.assigned_house_id = assigned_house_id
+        changed = True
+    if hardware_metadata:
+        merged = dict(registration.hardware_metadata)
+        merged.update(hardware_metadata)
+        if merged != registration.hardware_metadata:
+            registration.hardware_metadata = merged
+            changed = True
+
+    if registration.provisioning_token:
+        registration.provisioning_token = None
+        changed = True
+
+    if changed:
+        session.add(registration)
+        session.commit()
+        session.refresh(registration)
+
+    return registration
+
+
+def _sync_registration_assignment(
+    registration: NodeRegistration,
+    *,
+    house_slug: str,
+    room_id: str,
+    display_name: str,
+    assigned_house_id: Optional[int],
+    assigned_user_id: Optional[int],
+    hardware_metadata: Optional[Dict[str, Any]],
+) -> Tuple[NodeRegistration, bool]:
+    changed = False
+    now = _now()
+
+    if registration.assigned_at is None:
+        registration.assigned_at = now
+        changed = True
+
+    if registration.house_slug != house_slug:
+        registration.house_slug = house_slug
+        changed = True
+    if registration.room_id != room_id:
+        registration.room_id = room_id
+        changed = True
+    if registration.display_name != display_name:
+        registration.display_name = display_name
+        changed = True
+    if assigned_house_id is not None and registration.assigned_house_id != assigned_house_id:
+        registration.assigned_house_id = assigned_house_id
+        changed = True
+    if assigned_user_id is not None and registration.assigned_user_id != assigned_user_id:
+        registration.assigned_user_id = assigned_user_id
+        changed = True
+    if hardware_metadata:
+        merged = dict(registration.hardware_metadata)
+        merged.update(hardware_metadata)
+        if merged != registration.hardware_metadata:
+            registration.hardware_metadata = merged
+            changed = True
+
+    return registration, changed
 
 
 def ensure_for_node(
@@ -86,141 +338,533 @@ def ensure_for_node(
     download_id: Optional[str] = None,
     token_hash: Optional[str] = None,
     rotate_token: bool = False,
+    assigned_house_id: Optional[int] = None,
+    assigned_user_id: Optional[int] = None,
+    hardware_metadata: Optional[Dict[str, Any]] = None,
 ) -> NodeCredentialWithToken:
     """Ensure a credential row exists for ``node_id`` and return it."""
 
-    credential = _get_by_node_id(session, node_id)
     plaintext: Optional[str] = None
+    registration = _get_registration_by_node_id(session, node_id)
+    registration_changed = False
 
-    if credential:
-        changed = False
-        if credential.house_slug != house_slug:
-            credential.house_slug = house_slug
-            changed = True
-        if credential.room_id != room_id:
-            credential.room_id = room_id
-            changed = True
-        if credential.display_name != display_name:
-            credential.display_name = display_name
-            changed = True
-        if download_id and credential.download_id != download_id:
-            credential.download_id = download_id
-            changed = True
+    if registration is None:
+        if download_id is None:
+            download_id = registry.generate_download_id()
+        if rotate_token or token_hash is None:
+            plaintext = registry.generate_node_token()
+            token_hash = registry.hash_node_token(plaintext)
+        else:
+            plaintext = None
+        registration = NodeRegistration(
+            node_id=node_id,
+            download_id=download_id,
+            token_hash=token_hash,
+            assigned_at=_now(),
+            house_slug=house_slug,
+            room_id=room_id,
+            display_name=display_name,
+            assigned_house_id=assigned_house_id,
+            assigned_user_id=assigned_user_id,
+            hardware_metadata=hardware_metadata or {},
+        )
+        registration_changed = True
+    else:
+        registration, updated = _sync_registration_assignment(
+            registration,
+            house_slug=house_slug,
+            room_id=room_id,
+            display_name=display_name,
+            assigned_house_id=assigned_house_id,
+            assigned_user_id=assigned_user_id,
+            hardware_metadata=hardware_metadata,
+        )
+        registration_changed |= updated
+
+        if registration.provisioning_token:
+            registration.provisioning_token = None
+            registration_changed = True
+
+        if download_id and registration.download_id != download_id:
+            registration.download_id = download_id
+            registration_changed = True
 
         if rotate_token:
             plaintext = registry.generate_node_token()
-            credential.token_hash = registry.hash_node_token(plaintext)
-            credential.token_issued_at = _now()
-            changed = True
-        elif token_hash and credential.token_hash != token_hash:
-            credential.token_hash = token_hash
-            credential.token_issued_at = _now()
-            changed = True
+            registration.token_hash = registry.hash_node_token(plaintext)
+            registration.token_issued_at = _now()
+            registration_changed = True
+        elif token_hash and registration.token_hash != token_hash:
+            registration.token_hash = token_hash
+            registration.token_issued_at = _now()
+            registration_changed = True
 
-        if changed:
-            session.add(credential)
-            session.commit()
+    credential = _get_by_node_id(session, node_id)
+    credential_changed = False
+
+    if credential:
+        if credential.house_slug != house_slug:
+            credential.house_slug = house_slug
+            credential_changed = True
+        if credential.room_id != room_id:
+            credential.room_id = room_id
+            credential_changed = True
+        if credential.display_name != display_name:
+            credential.display_name = display_name
+            credential_changed = True
+        if credential.download_id != registration.download_id:
+            credential.download_id = registration.download_id
+            credential_changed = True
+
+        if rotate_token:
+            plaintext = plaintext or registry.generate_node_token()
+            registration.token_hash = registry.hash_node_token(plaintext)
+            registration.token_issued_at = _now()
+            credential.token_hash = registration.token_hash
+            credential.token_issued_at = registration.token_issued_at
+            credential_changed = True
+            registration_changed = True
+        elif credential.token_hash != registration.token_hash:
+            credential.token_hash = registration.token_hash
+            credential.token_issued_at = registration.token_issued_at
+            credential_changed = True
+    else:
+        if plaintext:
+            token_hash = registry.hash_node_token(plaintext)
+            if registration.token_hash != token_hash:
+                registration.token_hash = token_hash
+                registration.token_issued_at = _now()
+                registration_changed = True
+        credential = NodeCredential(
+            node_id=node_id,
+            house_slug=house_slug,
+            room_id=room_id,
+            display_name=display_name,
+            download_id=registration.download_id,
+            token_hash=registration.token_hash,
+            created_at=_now(),
+            token_issued_at=registration.token_issued_at,
+        )
+        credential_changed = True
+
+    if registration_changed:
+        session.add(registration)
+    if credential_changed:
+        session.add(credential)
+    if registration_changed or credential_changed:
+        session.commit()
+        if registration_changed:
+            session.refresh(registration)
+        if credential_changed:
             session.refresh(credential)
 
-        return NodeCredentialWithToken(credential=credential, plaintext_token=plaintext)
+    return NodeCredentialWithToken(credential=credential, plaintext_token=plaintext)
 
-    if download_id is None:
-        download_id = registry.generate_download_id()
 
-    if rotate_token:
-        plaintext = registry.generate_node_token()
-        token_hash = registry.hash_node_token(plaintext)
-    elif token_hash is None:
-        plaintext = registry.generate_node_token()
-        token_hash = registry.hash_node_token(plaintext)
-    else:
-        plaintext = None
+def assign_registration_to_room(
+    session: Session,
+    *,
+    node_id: str,
+    house_slug: str,
+    room_id: str,
+    display_name: str,
+    assigned_house_id: Optional[int] = None,
+    assigned_user_id: Optional[int] = None,
+) -> NodeRegistration:
+    """Place ``node_id`` into ``house_slug``/``room_id`` and update metadata."""
 
-    credential = NodeCredential(
+    if not node_id:
+        raise ValueError("node_id must be provided")
+
+    normalized_name = str(display_name or "").strip() or node_id
+
+    house, room = registry.find_room(house_slug, room_id)
+    if room is None:
+        raise KeyError("room not found")
+
+    existing_registration = _get_registration_by_node_id(session, node_id)
+    existing_credential = _get_by_node_id(session, node_id)
+
+    previous_house_slug = existing_registration.house_slug if existing_registration else None
+    previous_room_id = existing_registration.room_id if existing_registration else None
+    previous_display = (
+        existing_registration.display_name if existing_registration else None
+    )
+    previous_assigned_house = (
+        existing_registration.assigned_house_id if existing_registration else None
+    )
+    previous_assigned_user = (
+        existing_registration.assigned_user_id if existing_registration else None
+    )
+
+    if assigned_house_id is None and existing_registration:
+        assigned_house_id = existing_registration.assigned_house_id
+    if assigned_user_id is None and existing_registration:
+        assigned_user_id = existing_registration.assigned_user_id
+
+    normalized_lower = normalized_name.lower()
+    raw_nodes = room.get("nodes")
+    nodes_in_room = raw_nodes if isinstance(raw_nodes, list) else []
+    for entry in nodes_in_room:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("id") == node_id:
+            continue
+        raw_name = entry.get("name")
+        if isinstance(raw_name, str) and raw_name.strip().lower() == normalized_lower:
+            raise ValueError("node name already exists")
+
+    download_id = (
+        existing_registration.download_id
+        if existing_registration is not None
+        else (
+            existing_credential.download_id
+            if existing_credential is not None
+            else None
+        )
+    )
+    token_hash = (
+        existing_registration.token_hash
+        if existing_registration is not None
+        else (
+            existing_credential.token_hash
+            if existing_credential is not None
+            else None
+        )
+    )
+    hardware_metadata: Optional[Dict[str, Any]] = (
+        existing_registration.hardware_metadata
+        if existing_registration is not None
+        else None
+    )
+
+    ensured = ensure_for_node(
+        session,
         node_id=node_id,
         house_slug=house_slug,
         room_id=room_id,
-        display_name=display_name,
+        display_name=normalized_name,
         download_id=download_id,
         token_hash=token_hash,
-        created_at=_now(),
-        token_issued_at=_now(),
+        assigned_house_id=assigned_house_id,
+        assigned_user_id=assigned_user_id,
+        hardware_metadata=hardware_metadata,
     )
-    session.add(credential)
-    session.commit()
-    session.refresh(credential)
 
-    return NodeCredentialWithToken(credential=credential, plaintext_token=plaintext)
+    registration = _get_registration_by_node_id(session, node_id)
+    if registration is None:
+        raise KeyError("node registration not found")
+
+    metadata = (
+        registration.hardware_metadata if isinstance(registration.hardware_metadata, dict) else {}
+    )
+    modules_meta: Optional[List[str]] = None
+    modules_value = metadata.get("modules") if isinstance(metadata, dict) else None
+    if isinstance(modules_value, list):
+        cleaned: List[str] = []
+        for entry in modules_value:
+            text = str(entry).strip()
+            if text:
+                cleaned.append(text)
+        modules_meta = cleaned or None
+
+    try:
+        registry.place_node_in_room(
+            node_id,
+            house_slug,
+            room_id,
+            name=normalized_name,
+            modules=modules_meta,
+        )
+    except Exception:
+        if previous_house_slug is not None and previous_room_id is not None:
+            ensure_for_node(
+                session,
+                node_id=node_id,
+                house_slug=previous_house_slug,
+                room_id=previous_room_id,
+                display_name=previous_display or node_id,
+                download_id=registration.download_id,
+                token_hash=registration.token_hash,
+                assigned_house_id=previous_assigned_house,
+                assigned_user_id=previous_assigned_user,
+                hardware_metadata=metadata,
+            )
+        raise
+
+    session.refresh(registration)
+    return registration
 
 
 def rotate_token(
     session: Session, node_id: str, *, token: Optional[str] = None
 ) -> Tuple[NodeCredential, str]:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+    if credential is None and registration is None:
         raise KeyError("node credentials not found")
 
     plaintext = token or registry.generate_node_token()
-    credential.token_hash = registry.hash_node_token(plaintext)
-    credential.token_issued_at = _now()
-    session.add(credential)
+    token_hash = registry.hash_node_token(plaintext)
+    issued_at = _now()
+
+    if credential is not None:
+        credential.token_hash = token_hash
+        credential.token_issued_at = issued_at
+        session.add(credential)
+
+    if registration is not None:
+        registration.token_hash = token_hash
+        registration.token_issued_at = issued_at
+        if registration.provisioning_token:
+            registration.provisioning_token = None
+        session.add(registration)
+
     session.commit()
-    session.refresh(credential)
-    return credential, plaintext
+
+    if credential is not None:
+        session.refresh(credential)
+        return credential, plaintext
+
+    session.refresh(registration)
+    # Legacy callers expect a credential, so fabricate a placeholder when
+    # only a registration exists.
+    legacy = NodeCredential(
+        node_id=registration.node_id,
+        house_slug=registration.house_slug or "",
+        room_id=registration.room_id or "",
+        display_name=registration.display_name or registration.node_id,
+        download_id=registration.download_id,
+        token_hash=registration.token_hash,
+        created_at=registration.created_at,
+        token_issued_at=registration.token_issued_at,
+    )
+    return legacy, plaintext
+
+
+def record_account_credentials(
+    session: Session, node_id: str, username: str, password: str
+) -> Optional[NodeRegistration]:
+    """Persist account credentials observed from firmware."""
+
+    username = (username or "").strip()
+    password = password or ""
+    if not username or not password:
+        raise ValueError("username and password are required")
+
+    registration = _get_registration_by_node_id(session, node_id)
+    if registration is None:
+        raise KeyError("node registration not found")
+
+    user = _first_result(session.exec(select(User).where(User.username == username)))
+    if user is None:
+        logging.warning(
+            "Received credentials for unknown user '%s' on node '%s'",
+            username,
+            node_id,
+        )
+        return None
+
+    if not verify_password(password, user.hashed_password):
+        logging.warning(
+            "Credential verification failed for user '%s' on node '%s'",
+            username,
+            node_id,
+        )
+        return None
+
+    hashed = hash_password(password)
+    now = _now()
+    changed = False
+
+    if registration.account_username != username:
+        registration.account_username = username
+        changed = True
+    if registration.account_password_hash != hashed:
+        registration.account_password_hash = hashed
+        changed = True
+    registration.account_credentials_received_at = now
+    changed = True
+
+    if registration.assigned_user_id != user.id:
+        registration.assigned_user_id = user.id
+        changed = True
+
+    membership = _first_result(
+        session.exec(
+            select(HouseMembership).where(HouseMembership.user_id == user.id)
+        )
+    )
+    if membership and registration.assigned_house_id != membership.house_id:
+        registration.assigned_house_id = membership.house_id
+        changed = True
+
+    if changed:
+        session.add(registration)
+        session.commit()
+        session.refresh(registration)
+
+    logging.info(
+        "Associated node '%s' with user '%s'%s",
+        node_id,
+        username,
+        "" if not membership else f" in house {membership.house_id}",
+    )
+
+    return registration
 
 
 def update_download_id(
     session: Session, node_id: str, download_id: Optional[str] = None
 ) -> NodeCredential:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+    if credential is None and registration is None:
         raise KeyError("node credentials not found")
 
     new_download = download_id or registry.generate_download_id()
-    credential.download_id = new_download
-    session.add(credential)
+
+    if credential is not None:
+        credential.download_id = new_download
+        session.add(credential)
+
+    if registration is not None:
+        registration.download_id = new_download
+        session.add(registration)
+
     session.commit()
-    session.refresh(credential)
-    return credential
+
+    if credential is not None:
+        session.refresh(credential)
+        if registration is not None:
+            session.refresh(registration)
+        return credential
+
+    session.refresh(registration)
+    legacy = NodeCredential(
+        node_id=registration.node_id,
+        house_slug=registration.house_slug or "",
+        room_id=registration.room_id or "",
+        display_name=registration.display_name or registration.node_id,
+        download_id=registration.download_id,
+        token_hash=registration.token_hash,
+        created_at=registration.created_at,
+        token_issued_at=registration.token_issued_at,
+    )
+    return legacy
 
 
 def mark_provisioned(
     session: Session, node_id: str, *, timestamp: Optional[datetime] = None
 ) -> NodeCredential:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+    if credential is None and registration is None:
         raise KeyError("node credentials not found")
 
-    credential.provisioned_at = timestamp or _now()
-    session.add(credential)
+    stamp = timestamp or _now()
+
+    if credential is not None:
+        credential.provisioned_at = stamp
+        session.add(credential)
+    if registration is not None:
+        registration.provisioned_at = stamp
+        session.add(registration)
+
     session.commit()
-    session.refresh(credential)
-    return credential
+
+    if credential is not None:
+        session.refresh(credential)
+        if registration is not None:
+            session.refresh(registration)
+        return credential
+
+    session.refresh(registration)
+    legacy = NodeCredential(
+        node_id=registration.node_id,
+        house_slug=registration.house_slug or "",
+        room_id=registration.room_id or "",
+        display_name=registration.display_name or registration.node_id,
+        download_id=registration.download_id,
+        token_hash=registration.token_hash,
+        created_at=registration.created_at,
+        token_issued_at=registration.token_issued_at,
+        provisioned_at=registration.provisioned_at,
+    )
+    return legacy
+
+
+def clear_stored_provisioning_token(session: Session, node_id: str) -> bool:
+    """Remove any legacy plaintext provisioning token for ``node_id``."""
+
+    registration = _get_registration_by_node_id(session, node_id)
+    if registration is None or not registration.provisioning_token:
+        return False
+
+    registration.provisioning_token = None
+    session.add(registration)
+    session.commit()
+    session.refresh(registration)
+    return True
 
 
 def clear_provisioned(session: Session, node_id: str) -> NodeCredential:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+    if credential is None and registration is None:
         raise KeyError("node credentials not found")
 
-    credential.provisioned_at = None
-    session.add(credential)
+    if credential is not None:
+        credential.provisioned_at = None
+        session.add(credential)
+    if registration is not None:
+        registration.provisioned_at = None
+        session.add(registration)
+
     session.commit()
-    session.refresh(credential)
-    return credential
+
+    if credential is not None:
+        session.refresh(credential)
+        return credential
+
+    session.refresh(registration)
+    legacy = NodeCredential(
+        node_id=registration.node_id,
+        house_slug=registration.house_slug or "",
+        room_id=registration.room_id or "",
+        display_name=registration.display_name or registration.node_id,
+        download_id=registration.download_id,
+        token_hash=registration.token_hash,
+        created_at=registration.created_at,
+        token_issued_at=registration.token_issued_at,
+    )
+    return legacy
 
 
 def delete_credentials(session: Session, node_id: str) -> None:
     credential = _get_by_node_id(session, node_id)
-    if credential is None:
+    registration = _get_registration_by_node_id(session, node_id)
+
+    if credential is None and registration is None:
         return
-    session.delete(credential)
+
+    if credential is not None:
+        session.delete(credential)
+    if registration is not None:
+        session.delete(registration)
+
     session.commit()
 
 
 def list_unprovisioned(session: Session) -> List[NodeCredential]:
     return session.exec(
         select(NodeCredential).where(NodeCredential.provisioned_at.is_(None))
+    ).all()
+
+
+def list_unprovisioned_registrations(session: Session) -> List[NodeRegistration]:
+    return session.exec(
+        select(NodeRegistration).where(NodeRegistration.provisioned_at.is_(None))
     ).all()
 
 
@@ -253,15 +897,25 @@ def sync_registry_nodes(session: Session) -> None:
             else None
         )
 
-        existing = get_by_node_id(session, node_id)
+        existing_registration = _get_registration_by_node_id(session, node_id)
+        existing_credential = _get_by_node_id(session, node_id)
+        existing_download = None
+        existing_token = None
+        if existing_registration is not None:
+            existing_download = existing_registration.download_id
+            existing_token = existing_registration.token_hash
+        elif existing_credential is not None:
+            existing_download = existing_credential.download_id
+            existing_token = existing_credential.token_hash
+
         ensured = ensure_for_node(
             session,
             node_id=node_id,
             house_slug=house_slug,
             room_id=room_id,
             display_name=display_name,
-            download_id=download_id if existing is None or not existing.download_id else None,
-            token_hash=token_hash if existing is None or not existing.token_hash else None,
+            download_id=download_id if not existing_download else None,
+            token_hash=token_hash if not existing_token else None,
         )
 
         credential = ensured.credential
@@ -279,15 +933,27 @@ def sync_registry_nodes(session: Session) -> None:
 
 __all__ = [
     "NodeCredentialWithToken",
+    "NodeRegistrationWithToken",
     "any_tokens",
+    "claim_registration",
+    "clear_stored_provisioning_token",
     "clear_provisioned",
+    "create_batch",
     "delete_credentials",
     "ensure_for_node",
+    "assign_registration_to_room",
     "get_by_node_id",
     "get_by_download_id",
     "get_by_token_hash",
+    "get_registration_by_download_id",
+    "get_registration_by_node_id",
+    "list_assigned_registrations",
+    "list_available_registrations",
+    "list_pending_registrations_for_user",
     "list_unprovisioned",
+    "list_unprovisioned_registrations",
     "mark_provisioned",
+    "record_account_credentials",
     "rotate_token",
     "sync_registry_nodes",
     "update_download_id",

--- a/Server/app/routes_api.py
+++ b/Server/app/routes_api.py
@@ -1,12 +1,14 @@
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlmodel import Session
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlmodel import Session, select
 from .mqtt_bus import MqttBus
 from . import node_credentials, registry
 from .auth.access import AccessPolicy, HouseContext
 from .auth.dependencies import get_current_user
-from .auth.models import User
+from .auth.models import House, User
 from .effects import WS_EFFECTS, WHITE_EFFECTS, RGB_EFFECTS
 from .presets import (
     get_preset,
@@ -39,6 +41,61 @@ def _build_policy(session: Session, user: User) -> AccessPolicy:
     return AccessPolicy.from_session(session, user)
 
 
+class AssignNodePayload(BaseModel):
+    """Request body for assigning a pending node to a room."""
+
+    node_id: str = Field(..., alias="nodeId")
+    room_id: str = Field(..., alias="roomId")
+    name: Optional[str] = Field(None, alias="name", max_length=MAX_NODE_NAME_LENGTH)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("node_id", "room_id")
+    @classmethod
+    def _require_value(cls, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError("must be a string")
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("must be a non-empty string")
+        return cleaned
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _clean_name(cls, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        return cleaned or None
+
+
+class MoveNodePayload(BaseModel):
+    """Request body for moving an assigned node to another room."""
+
+    room_id: str = Field(..., alias="roomId")
+    name: Optional[str] = Field(None, alias="name", max_length=MAX_NODE_NAME_LENGTH)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("room_id")
+    @classmethod
+    def _clean_room(cls, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError("must be a string")
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("must be a non-empty string")
+        return cleaned
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _clean_name(cls, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        return cleaned or None
+
+
 def _require_house(policy: AccessPolicy, house_id: str):
     try:
         return policy.ensure_house(house_id)
@@ -69,6 +126,15 @@ def _require_node(policy: AccessPolicy, node_id: str):
 def _ensure_can_manage_house(house_ctx: HouseContext, user: User) -> None:
     if not house_ctx.access.can_manage(user):
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Forbidden")
+
+
+def _house_record(session: Session, house_ctx: HouseContext) -> Optional[House]:
+    house = house_ctx.access.house
+    if house is not None:
+        return house
+    return session.exec(
+        select(House).where(House.external_id == house_ctx.external_id)
+    ).first()
 
 
 def get_bus() -> MqttBus:
@@ -450,11 +516,139 @@ def api_delete_room(
     return {"ok": True, "room": removed, "removed_nodes": node_ids}
 
 
+@router.post("/api/house/{house_id}/nodes/assign")
+def api_assign_pending_node(
+    house_id: str,
+    payload: AssignNodePayload,
+    *,
+    current_user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    policy = _build_policy(session, current_user)
+    house_ctx = _require_house(policy, house_id)
+    _ensure_can_manage_house(house_ctx, current_user)
+    room_ctx = _require_room(policy, house_id, payload.room_id)
+
+    registration = node_credentials.get_registration_by_node_id(
+        session, payload.node_id
+    )
+    if registration is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Unknown node id")
+    if registration.room_id:
+        raise HTTPException(status.HTTP_409_CONFLICT, "Node already assigned")
+    if (
+        registration.assigned_user_id not in (None, current_user.id)
+        and not current_user.server_admin
+    ):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Forbidden")
+
+    desired_name = (
+        payload.name
+        or registration.display_name
+        or registration.node_id
+        or payload.node_id
+    )
+
+    house_db = _house_record(session, house_ctx)
+    assigned_house_id = house_db.id if house_db is not None else None
+    assigned_user_id = registration.assigned_user_id or current_user.id
+
+    try:
+        updated = node_credentials.assign_registration_to_room(
+            session,
+            node_id=payload.node_id,
+            house_slug=house_ctx.slug,
+            room_id=payload.room_id,
+            display_name=desired_name,
+            assigned_house_id=assigned_house_id,
+            assigned_user_id=assigned_user_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+
+    room_name = str(room_ctx.room.get("name") or room_ctx.room.get("id") or "")
+    return {
+        "ok": True,
+        "node": {
+            "id": updated.node_id,
+            "name": updated.display_name,
+            "roomId": updated.room_id,
+            "roomName": room_name,
+            "house": updated.house_slug,
+        },
+    }
+
+
+@router.post("/api/house/{house_id}/nodes/{node_id}/move")
+def api_move_node(
+    house_id: str,
+    node_id: str,
+    payload: MoveNodePayload,
+    *,
+    current_user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    policy = _build_policy(session, current_user)
+    house_ctx = _require_house(policy, house_id)
+    _ensure_can_manage_house(house_ctx, current_user)
+    room_ctx = _require_room(policy, house_id, payload.room_id)
+
+    registration = node_credentials.get_registration_by_node_id(session, node_id)
+    credential = node_credentials.get_by_node_id(session, node_id)
+    if registration is None and credential is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Unknown node id")
+
+    desired_name = (
+        payload.name
+        or (registration.display_name if registration and registration.display_name else None)
+        or (credential.display_name if credential else None)
+        or node_id
+    )
+
+    assigned_house_id = (
+        registration.assigned_house_id if registration else None
+    )
+    if assigned_house_id is None:
+        house_db = _house_record(session, house_ctx)
+        assigned_house_id = house_db.id if house_db is not None else None
+
+    assigned_user_id = registration.assigned_user_id if registration else None
+
+    try:
+        updated = node_credentials.assign_registration_to_room(
+            session,
+            node_id=node_id,
+            house_slug=house_ctx.slug,
+            room_id=payload.room_id,
+            display_name=desired_name,
+            assigned_house_id=assigned_house_id,
+            assigned_user_id=assigned_user_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+
+    room_name = str(room_ctx.room.get("name") or room_ctx.room.get("id") or "")
+    return {
+        "ok": True,
+        "node": {
+            "id": updated.node_id,
+            "name": updated.display_name,
+            "roomId": updated.room_id,
+            "roomName": room_name,
+            "house": updated.house_slug,
+        },
+    }
+
+
 @router.post("/api/house/{house_id}/room/{room_id}/nodes")
 def api_add_node(
     house_id: str,
     room_id: str,
-    payload: Dict[str, Any],
+    _payload: Dict[str, Any],
     *,
     current_user: User = Depends(get_current_user),
     session: Session = Depends(get_session),
@@ -462,41 +656,10 @@ def api_add_node(
     policy = _build_policy(session, current_user)
     room_ctx = _require_room(policy, house_id, room_id)
     _ensure_can_manage_house(room_ctx.house, current_user)
-    name = str(payload.get("name", "")).strip()
-    if not name:
-        raise HTTPException(400, "missing name")
-    kind = str(payload.get("kind", "ultranode"))
-    modules = payload.get("modules")
-    try:
-        node = registry.add_node(house_id, room_id, name, kind, modules)
-    except KeyError:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Unknown room")
-    except ValueError as exc:
-        raise HTTPException(400, str(exc))
-    ensured = node_credentials.ensure_for_node(
-        session,
-        node_id=str(node.get("id")),
-        house_slug=room_ctx.house.slug,
-        room_id=room_id,
-        display_name=str(node.get("name") or name),
-        rotate_token=True,
+    raise HTTPException(
+        status.HTTP_501_NOT_IMPLEMENTED,
+        "Node creation now requires pre-registered identifiers. Use the offline provisioning workflow to claim nodes.",
     )
-
-    credential = ensured.credential
-    registry.set_node_download_id(credential.node_id, credential.download_id)
-
-    manifest_url = f"{settings.PUBLIC_BASE}/firmware/{credential.download_id}/manifest"
-    binary_url = f"{settings.PUBLIC_BASE}/firmware/{credential.download_id}/latest.bin"
-
-    return {
-        "ok": True,
-        "node": node,
-        "credentials": {
-            "downloadId": credential.download_id,
-            "manifestUrl": manifest_url,
-            "binaryUrl": binary_url,
-        },
-    }
 
 
 @router.get("/api/house/{house_id}/room/{room_id}/presets")

--- a/Server/app/routes_server_admin.py
+++ b/Server/app/routes_server_admin.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import delete, func
 from sqlmodel import Session, select
 
-from . import registry
+from . import node_builder, node_credentials, registry
 from .auth.dependencies import require_admin
-from .auth.models import House, HouseMembership, HouseRole, RoomAccess, User
+from .auth.models import (
+    House,
+    HouseMembership,
+    HouseRole,
+    NodeRegistration,
+    RoomAccess,
+    User,
+)
 from .auth.service import create_user, record_audit_event
 from .config import settings
 from .database import get_session
@@ -98,6 +105,207 @@ class HouseCreateResponse(BaseModel):
     external_id: str = Field(..., alias="externalId")
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+BOARD_CHOICES = tuple(sorted(node_builder.SUPPORTED_TARGETS))
+
+
+class Ws2812ChannelConfig(BaseModel):
+    index: int = Field(..., ge=0, le=1)
+    enabled: bool = False
+    gpio: Optional[int] = Field(default=None, ge=0, le=48)
+    pixels: Optional[int] = Field(default=None, ge=0, le=4096)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WhiteChannelConfig(BaseModel):
+    index: int = Field(..., ge=0, le=3)
+    enabled: bool = False
+    gpio: Optional[int] = Field(default=None, ge=0, le=48)
+    ledc_channel: Optional[int] = Field(default=None, alias="ledcChannel", ge=0, le=7)
+    pwm_hz: Optional[int] = Field(default=None, alias="pwmHz", ge=1, le=50000)
+    minimum: Optional[int] = Field(default=None, alias="minimum", ge=0, le=4095)
+    maximum: Optional[int] = Field(default=None, alias="maximum", ge=0, le=4095)
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class RgbChannelConfig(BaseModel):
+    index: int = Field(..., ge=0, le=3)
+    enabled: bool = False
+    pwm_hz: Optional[int] = Field(default=None, alias="pwmHz", ge=1, le=50000)
+    ledc_mode: Optional[int] = Field(default=None, alias="ledcMode", ge=0, le=1)
+    r_gpio: Optional[int] = Field(default=None, alias="rGpio", ge=0, le=48)
+    r_ledc_ch: Optional[int] = Field(default=None, alias="rLedcChannel", ge=0, le=7)
+    g_gpio: Optional[int] = Field(default=None, alias="gGpio", ge=0, le=48)
+    g_ledc_ch: Optional[int] = Field(default=None, alias="gLedcChannel", ge=0, le=7)
+    b_gpio: Optional[int] = Field(default=None, alias="bGpio", ge=0, le=48)
+    b_ledc_ch: Optional[int] = Field(default=None, alias="bLedcChannel", ge=0, le=7)
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class PirSensorConfig(BaseModel):
+    enabled: bool = False
+    gpio: Optional[int] = Field(default=None, ge=0, le=48)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class NodeHardwareConfig(BaseModel):
+    board: str = Field(default="esp32")
+    ws2812: List[Ws2812ChannelConfig] = Field(default_factory=list)
+    white: List[WhiteChannelConfig] = Field(default_factory=list)
+    rgb: List[RgbChannelConfig] = Field(default_factory=list)
+    pir: Optional[PirSensorConfig] = None
+    overrides: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("board")
+    @classmethod
+    def _validate_board(cls, value: str) -> str:
+        normalized = value.lower().strip()
+        if normalized not in node_builder.SUPPORTED_TARGETS:
+            raise ValueError("Unsupported board")
+        return normalized
+
+    @field_validator("overrides")
+    @classmethod
+    def _validate_overrides(cls, value: Dict[str, Any]) -> Dict[str, Any]:
+        cleaned: Dict[str, Any] = {}
+        for key, raw in value.items():
+            if not isinstance(key, str) or not key.startswith("CONFIG_"):
+                raise ValueError("Override keys must start with CONFIG_")
+            cleaned[key] = raw
+        return cleaned
+
+
+class NodeFactoryCreateRequest(BaseModel):
+    count: int = Field(default=1, ge=1, le=50)
+    display_name: Optional[str] = Field(default=None, alias="displayName")
+    hardware: NodeHardwareConfig
+    assign_house_slug: Optional[str] = Field(default=None, alias="assignHouseSlug")
+    assign_room_id: Optional[str] = Field(default=None, alias="assignRoomId")
+    assign_user_id: Optional[int] = Field(default=None, alias="assignUserId")
+    assign_house_id: Optional[int] = Field(default=None, alias="assignHouseId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NodeFactoryCreatedNode(BaseModel):
+    node_id: str = Field(..., alias="nodeId")
+    download_id: str = Field(..., alias="downloadId")
+    ota_token: str = Field(..., alias="otaToken")
+    manifest_url: str = Field(..., alias="manifestUrl")
+    metadata: Dict[str, Any]
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NodeFactoryCreateResponse(BaseModel):
+    nodes: List[NodeFactoryCreatedNode]
+
+
+class CommandOutput(BaseModel):
+    command: List[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    cwd: str
+
+
+class NodeFactoryBuildRequest(BaseModel):
+    node_id: Optional[str] = Field(default=None, alias="nodeId")
+    use_test_node: bool = Field(default=False, alias="useTestNode")
+    regenerate_token: bool = Field(default=False, alias="regenerateToken")
+    skip_build: bool = Field(default=False, alias="skipBuild")
+    hardware: Optional[NodeHardwareConfig] = None
+    ota_token: Optional[str] = Field(default=None, alias="otaToken")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NodeFactoryBuildResponse(CommandOutput):
+    node_id: str = Field(..., alias="nodeId")
+    download_id: str = Field(..., alias="downloadId")
+    manifest_url: str = Field(..., alias="manifestUrl")
+    sdkconfig_path: str = Field(..., alias="sdkconfigPath")
+    target: str
+    metadata: Dict[str, Any]
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NodeFactoryFlashRequest(BaseModel):
+    node_id: Optional[str] = Field(default=None, alias="nodeId")
+    use_test_node: bool = Field(default=False, alias="useTestNode")
+    port: str
+    hardware: Optional[NodeHardwareConfig] = None
+    ota_token: Optional[str] = Field(default=None, alias="otaToken")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NodeFactoryUpdateRequest(BaseModel):
+    firmware_version: str = Field(..., alias="firmwareVersion")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NodeFactoryCommandResponse(CommandOutput):
+    message: Optional[str] = None
+
+
+class NodeFactoryRegistrationInfo(BaseModel):
+    node_id: str = Field(..., alias="nodeId")
+    download_id: str = Field(..., alias="downloadId")
+    display_name: Optional[str] = Field(default=None, alias="displayName")
+    board: Optional[str] = None
+    assigned: bool
+    house_slug: Optional[str] = Field(default=None, alias="houseSlug")
+    room_id: Optional[str] = Field(default=None, alias="roomId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NodeFactoryListResponse(BaseModel):
+    available: List[NodeFactoryRegistrationInfo]
+    assigned: List[NodeFactoryRegistrationInfo]
+
+
+def _hardware_to_metadata(config: NodeHardwareConfig) -> Dict[str, Any]:
+    return config.model_dump(mode="python", by_alias=False, exclude_none=True)
+
+
+def _command_output(result: node_builder.CommandResult) -> CommandOutput:
+    return CommandOutput(
+        command=[str(part) for part in result.command],
+        returncode=result.returncode,
+        stdout=result.stdout or "",
+        stderr=result.stderr or "",
+        cwd=str(result.cwd),
+    )
+
+
+def _registration_summary(registration: NodeRegistration) -> NodeFactoryRegistrationInfo:
+    metadata = registration.hardware_metadata or {}
+    board = None
+    if isinstance(metadata, dict):
+        raw_board = metadata.get("board")
+        if isinstance(raw_board, str):
+            board = raw_board
+    assigned = bool(registration.assigned_at or registration.house_slug or registration.room_id)
+    return NodeFactoryRegistrationInfo(
+        node_id=registration.node_id,
+        download_id=registration.download_id,
+        display_name=registration.display_name,
+        board=board,
+        assigned=assigned,
+        house_slug=registration.house_slug,
+        room_id=registration.room_id,
+    )
 
 
 def _get_house_row(session: Session, external_id: str, *, display_name: str) -> House:
@@ -357,6 +565,280 @@ def delete_account(
         },
     )
     session.commit()
+
+
+@router.get(
+    "/node-factory/registrations",
+    response_model=NodeFactoryListResponse,
+)
+def list_node_factory(
+    current_user: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> NodeFactoryListResponse:
+    registrations = session.exec(
+        select(NodeRegistration).order_by(NodeRegistration.created_at)
+    ).all()
+    available: List[NodeFactoryRegistrationInfo] = []
+    assigned: List[NodeFactoryRegistrationInfo] = []
+    for registration in registrations:
+        info = _registration_summary(registration)
+        if info.assigned:
+            assigned.append(info)
+        else:
+            available.append(info)
+    return NodeFactoryListResponse(available=available, assigned=assigned)
+
+
+@router.post(
+    "/node-factory/registrations",
+    status_code=status.HTTP_201_CREATED,
+    response_model=NodeFactoryCreateResponse,
+)
+def create_node_factory_registrations(
+    payload: NodeFactoryCreateRequest,
+    current_user: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> NodeFactoryCreateResponse:
+    metadata = _hardware_to_metadata(payload.hardware)
+    metadata.setdefault("board", payload.hardware.board)
+    entries = node_credentials.create_batch(
+        session,
+        payload.count,
+        metadata=(metadata.copy() for _ in range(payload.count)),
+    )
+
+    created_nodes: List[NodeFactoryCreatedNode] = []
+    node_ids: List[str] = []
+    needs_commit = False
+    base_display = (payload.display_name or "").strip()
+
+    for index, entry in enumerate(entries, start=1):
+        registration = entry.registration
+        display_name = base_display
+        if base_display:
+            if payload.count > 1:
+                display_name = f"{base_display} {index}"
+            registration.display_name = display_name
+            needs_commit = True
+
+        registration.hardware_metadata = metadata.copy()
+        needs_commit = True
+
+        if (
+            payload.assign_house_slug
+            or payload.assign_room_id
+            or payload.assign_user_id
+            or payload.assign_house_id
+        ):
+            registration = node_credentials.claim_registration(
+                session,
+                registration.node_id,
+                house_slug=payload.assign_house_slug,
+                room_id=payload.assign_room_id,
+                display_name=display_name or registration.display_name,
+                assigned_user_id=payload.assign_user_id,
+                assigned_house_id=payload.assign_house_id,
+                hardware_metadata=metadata,
+            )
+        else:
+            session.add(registration)
+
+        manifest_url = f"{settings.PUBLIC_BASE}/firmware/{registration.download_id}/manifest.json"
+        created_nodes.append(
+            NodeFactoryCreatedNode(
+                nodeId=registration.node_id,
+                downloadId=registration.download_id,
+                otaToken=entry.plaintext_token,
+                manifestUrl=manifest_url,
+                metadata=metadata.copy(),
+            )
+        )
+        node_ids.append(registration.node_id)
+
+    if needs_commit:
+        session.commit()
+
+    record_audit_event(
+        session,
+        actor=current_user,
+        action="node_factory_created",
+        summary=f"Generated {len(created_nodes)} node registrations",
+        data={
+            "nodes": node_ids,
+            "board": metadata.get("board"),
+        },
+    )
+    session.commit()
+
+    return NodeFactoryCreateResponse(nodes=created_nodes)
+
+
+@router.post(
+    "/node-factory/build",
+    response_model=NodeFactoryBuildResponse,
+)
+def build_node_factory_firmware(
+    payload: NodeFactoryBuildRequest,
+    current_user: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> NodeFactoryBuildResponse:
+    registration: Optional[NodeRegistration] = None
+    metadata: Dict[str, Any]
+
+    if payload.use_test_node:
+        test_metadata = (
+            _hardware_to_metadata(payload.hardware)
+            if payload.hardware
+            else {}
+        )
+        registration = node_builder.ensure_test_registration(
+            session,
+            metadata=test_metadata,
+        )
+        node_id = registration.node_id
+        metadata = test_metadata or dict(registration.hardware_metadata or {})
+    else:
+        if not payload.node_id:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "nodeId is required")
+        node_id = payload.node_id
+        registration = node_credentials.get_registration_by_node_id(session, node_id)
+        if registration is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Node not found")
+        metadata = (
+            _hardware_to_metadata(payload.hardware)
+            if payload.hardware
+            else dict(registration.hardware_metadata or {})
+        )
+
+    if payload.hardware:
+        registration.hardware_metadata = metadata.copy()
+        session.add(registration)
+        session.commit()
+
+    try:
+        result = node_builder.build_individual_node(
+            session,
+            node_id,
+            metadata=metadata,
+            board=metadata.get("board"),
+            regenerate_token=payload.regenerate_token,
+            run_build=not payload.skip_build,
+            ota_token=payload.ota_token,
+        )
+    except node_builder.NodeBuilderError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
+
+    command_output = _command_output(result)
+    registration = node_credentials.get_registration_by_node_id(session, node_id)
+    metadata_payload = metadata.copy()
+    return NodeFactoryBuildResponse(
+        nodeId=node_id,
+        downloadId=result.download_id,
+        manifestUrl=result.manifest_url,
+        sdkconfigPath=str(result.sdkconfig_path),
+        target=result.target,
+        metadata=metadata_payload,
+        **command_output.model_dump(),
+    )
+
+
+@router.post(
+    "/node-factory/flash",
+    response_model=NodeFactoryBuildResponse,
+)
+def flash_node_factory_firmware(
+    payload: NodeFactoryFlashRequest,
+    current_user: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> NodeFactoryBuildResponse:
+    if payload.use_test_node:
+        registration = node_builder.ensure_test_registration(
+            session,
+            metadata=(
+                _hardware_to_metadata(payload.hardware)
+                if payload.hardware
+                else None
+            ),
+        )
+        node_id = registration.node_id
+        metadata = (
+            _hardware_to_metadata(payload.hardware)
+            if payload.hardware
+            else dict(registration.hardware_metadata or {})
+        )
+    else:
+        if not payload.node_id:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "nodeId is required")
+        node_id = payload.node_id
+        registration = node_credentials.get_registration_by_node_id(session, node_id)
+        if registration is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Node not found")
+        metadata = (
+            _hardware_to_metadata(payload.hardware)
+            if payload.hardware
+            else dict(registration.hardware_metadata or {})
+        )
+
+    if payload.hardware:
+        registration.hardware_metadata = metadata.copy()
+        session.add(registration)
+        session.commit()
+
+    try:
+        result = node_builder.first_time_flash(
+            session,
+            node_id,
+            port=payload.port,
+            metadata=metadata,
+            board=metadata.get("board"),
+            ota_token=payload.ota_token,
+        )
+    except node_builder.NodeBuilderError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
+
+    command_output = _command_output(result)
+    return NodeFactoryBuildResponse(
+        nodeId=node_id,
+        downloadId=result.download_id,
+        manifestUrl=result.manifest_url,
+        sdkconfigPath=str(result.sdkconfig_path),
+        target=result.target,
+        metadata=metadata.copy(),
+        **command_output.model_dump(),
+    )
+
+
+@router.post(
+    "/node-factory/update-all",
+    response_model=NodeFactoryCommandResponse,
+)
+def update_all_nodes_command(
+    payload: NodeFactoryUpdateRequest,
+    current_user: User = Depends(require_admin),
+    session: Session = Depends(get_session),
+) -> NodeFactoryCommandResponse:
+    result = node_builder.update_all_nodes(payload.firmware_version)
+    output = _command_output(result)
+    message = (
+        "Bulk firmware update completed"
+        if result.returncode == 0
+        else "Bulk firmware update failed"
+    )
+    record_audit_event(
+        session,
+        actor=current_user,
+        action="node_factory_update_all",
+        summary="Triggered updateAllNodes",
+        data={
+            "firmware_version": payload.firmware_version,
+            "returncode": result.returncode,
+        },
+    )
+    session.commit()
+    return NodeFactoryCommandResponse(
+        message=message,
+        **output.model_dump(),
+    )
 
 
 __all__ = ["router"]

--- a/Server/app/templates/admin.html
+++ b/Server/app/templates/admin.html
@@ -55,6 +55,51 @@
       </div>
     </div>
     {% endif %}
+    {% if house_node_assignments %}
+    <div class="relative md:self-end w-full md:w-auto" data-node-room-menu>
+      <button
+        type="button"
+        class="flex items-center justify-between gap-2 w-full md:w-auto px-4 py-2 pill bg-slate-800 hover:bg-slate-700 text-sm font-semibold transition"
+        data-node-room-toggle
+        aria-haspopup="true"
+        aria-expanded="false">
+        <span>Move Nodes</span>
+        <span aria-hidden="true" class="text-xs opacity-70">▾</span>
+      </button>
+      <div
+        class="absolute right-0 mt-2 w-full md:w-[24rem] glass rounded-xl p-4 shadow-xl z-20 hidden"
+        data-node-room-panel>
+        <div class="text-sm font-semibold">Reassign nodes</div>
+        <div class="text-xs opacity-60">Change a node’s room without leaving this page.</div>
+        <div class="mt-3 flex flex-col gap-3 max-h-72 overflow-y-auto">
+          {% for node in house_node_assignments %}
+          <div class="border border-slate-700/50 rounded-lg p-3 space-y-3" data-node-room-entry="{{ node.id }}">
+            <div>
+              <div class="text-sm font-semibold">{{ node.name }}</div>
+              <div class="text-xs opacity-60 break-all">ID: {{ node.id }}</div>
+            </div>
+            <label class="block text-xs font-semibold">
+              <span>Room</span>
+              <select class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1.5 text-sm" data-node-room-select>
+                {% for room in house_rooms or [] %}
+                <option value="{{ room.id }}"{% if node.roomId == room.id %} selected{% endif %}>{{ room.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>Display name (optional)</span>
+              <input type="text" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1.5 text-sm" value="{{ node.name }}" data-node-room-name>
+            </label>
+            <div class="flex flex-wrap items-center gap-2">
+              <button type="button" class="px-3 py-1.5 pill bg-indigo-600 hover:bg-indigo-500 text-xs font-semibold" data-node-room-save>Save</button>
+              <div class="text-xs opacity-70" data-node-room-status role="status" aria-live="polite"></div>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+    {% endif %}
     <div class="text-xs opacity-70 md:text-right">
       <div>Healthy if last <code>{"status": "ok"}</code> within {{ status_timeout }}s.</div>
       <div id="statusRefresh" class="mt-1">Waiting for update…</div>
@@ -482,6 +527,124 @@ if (roomMenuContainer) {
       });
     });
   }
+}
+
+const nodeRoomMenu = document.querySelector('[data-node-room-menu]');
+if (nodeRoomMenu) {
+  const toggle = nodeRoomMenu.querySelector('[data-node-room-toggle]');
+  const panel = nodeRoomMenu.querySelector('[data-node-room-panel]');
+  let menuOpen = false;
+
+  const setExpanded = (value) => {
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', value ? 'true' : 'false');
+    }
+  };
+
+  const openMenu = () => {
+    if (!panel) return;
+    panel.classList.remove('hidden');
+    setExpanded(true);
+    menuOpen = true;
+  };
+
+  const closeMenu = () => {
+    if (!panel) return;
+    panel.classList.add('hidden');
+    setExpanded(false);
+    menuOpen = false;
+  };
+
+  if (toggle && panel) {
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (menuOpen || !panel.classList.contains('hidden')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+
+    panel.addEventListener('click', (event) => {
+      event.stopPropagation();
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!nodeRoomMenu.contains(event.target)) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+      }
+    });
+  }
+
+  panel?.querySelectorAll('[data-node-room-save]').forEach((button) => {
+    button.addEventListener('click', async (event) => {
+      event.stopPropagation();
+      if (!STATUS_HOUSE_ID) {
+        alert('Missing house identifier.');
+        return;
+      }
+      if (button.disabled) {
+        return;
+      }
+      const entry = button.closest('[data-node-room-entry]');
+      if (!entry) {
+        return;
+      }
+      const nodeId = entry.dataset.nodeRoomEntry;
+      const roomSelect = entry.querySelector('[data-node-room-select]');
+      const nameInput = entry.querySelector('[data-node-room-name]');
+      const statusEl = entry.querySelector('[data-node-room-status]');
+      if (!nodeId || !roomSelect || !roomSelect.value) {
+        if (statusEl) {
+          statusEl.textContent = 'Select a room before saving.';
+        }
+        return;
+      }
+      const payload = { roomId: roomSelect.value };
+      if (nameInput && nameInput.value.trim()) {
+        payload.name = nameInput.value.trim();
+      }
+      const original = button.textContent;
+      button.disabled = true;
+      button.textContent = 'Saving…';
+      if (statusEl) {
+        statusEl.textContent = '';
+      }
+      try {
+        const res = await fetch(
+          `/api/house/${encodeURIComponent(STATUS_HOUSE_ID)}/nodes/${encodeURIComponent(nodeId)}/move`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify(payload),
+          },
+        );
+        if (!res.ok) {
+          const message = await readErrorMessage(res);
+          throw new Error(message);
+        }
+        location.reload();
+      } catch (err) {
+        console.error('Failed to move node', err);
+        if (statusEl) {
+          statusEl.textContent = err instanceof Error ? err.message : 'Failed to move node.';
+        } else {
+          alert('Failed to move node.');
+        }
+      } finally {
+        button.disabled = false;
+        button.textContent = original || 'Save';
+      }
+    });
+  });
 }
 
 document.querySelectorAll('[data-node-ota]').forEach((btn) => {

--- a/Server/app/templates/house.html
+++ b/Server/app/templates/house.html
@@ -9,6 +9,54 @@
     {% endif %}
   </div>
 </div>
+{% if can_manage_house and house_pending_nodes %}
+<section class="glass rounded-xl p-6 mb-6" data-node-assignment data-house-id="{{ house_public_id }}">
+  <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+    <div>
+      <h3 class="text-xl font-semibold">Unassigned Nodes</h3>
+      <p class="text-sm opacity-70">Place captured nodes into rooms and give them a friendly name.</p>
+    </div>
+  </div>
+  {% if house_room_options %}
+  <div class="mt-4 grid gap-4" data-node-assignment-list>
+    {% for node in house_pending_nodes %}
+    <div class="glass rounded-lg p-4 border border-slate-700/60" data-node-entry="{{ node.id }}">
+      <div class="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <div class="text-sm font-semibold uppercase tracking-wide opacity-70">Node</div>
+          <div class="text-lg font-semibold">{{ node.name }}</div>
+          <div class="text-xs opacity-60">ID: {{ node.id }}</div>
+        </div>
+        <div class="text-xs opacity-60 break-all">Download ID: {{ node.downloadId }}</div>
+      </div>
+      <div class="mt-4 grid gap-3 md:grid-cols-2">
+        <label class="block text-sm font-semibold">
+          <span>Display name</span>
+          <input type="text" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" value="{{ node.name }}" data-node-name>
+        </label>
+        <label class="block text-sm font-semibold">
+          <span>Room</span>
+          <select class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" data-node-room>
+            {% for room in house_room_options %}
+            <option value="{{ room.id }}">{{ room.name }}</option>
+            {% endfor %}
+          </select>
+        </label>
+      </div>
+      <div class="mt-4 flex flex-wrap items-center gap-3">
+        <button type="button" class="px-4 py-2 pill bg-indigo-600 hover:bg-indigo-500 text-sm font-semibold" data-node-assign>Assign Node</button>
+        <div class="text-sm opacity-70" data-node-status role="status" aria-live="polite"></div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="mt-4 text-sm opacity-70">
+    Create a room before assigning nodes.
+  </div>
+  {% endif %}
+</section>
+{% endif %}
 {% if house.rooms %}
 <div class="grid md:grid-cols-3 gap-4" data-room-grid data-can-manage="{{ 'true' if can_manage_house else 'false' }}">
   {% for r in house.rooms %}
@@ -123,6 +171,65 @@ if(grid && grid.dataset.canManage === 'true'){
     if(!dragging) return;
     event.preventDefault();
     dropOccurred = true;
+  });
+}
+
+const assignmentSection = document.querySelector('[data-node-assignment]');
+if (assignmentSection) {
+  const houseId = assignmentSection.dataset.houseId;
+  assignmentSection.querySelectorAll('[data-node-assign]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      if (!houseId || button.disabled) {
+        return;
+      }
+      const entry = button.closest('[data-node-entry]');
+      if (!entry) {
+        return;
+      }
+      const nodeId = entry.dataset.nodeEntry;
+      const nameInput = entry.querySelector('[data-node-name]');
+      const roomSelect = entry.querySelector('[data-node-room]');
+      const statusEl = entry.querySelector('[data-node-status]');
+      if (!nodeId || !roomSelect || !roomSelect.value) {
+        if (statusEl) {
+          statusEl.textContent = 'Select a room before assigning.';
+        }
+        return;
+      }
+      const payload = {
+        nodeId,
+        roomId: roomSelect.value,
+        name: nameInput ? nameInput.value.trim() : undefined,
+      };
+      button.disabled = true;
+      button.textContent = 'Assigning…';
+      if (statusEl) {
+        statusEl.textContent = '';
+      }
+      try {
+        const res = await fetch(`/api/house/${encodeURIComponent(houseId)}/nodes/assign`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          const message = await res.text();
+          throw new Error(message || `HTTP ${res.status}`);
+        }
+        location.reload();
+      } catch (err) {
+        console.error('Failed to assign node', err);
+        if (statusEl) {
+          statusEl.textContent = err instanceof Error ? err.message : 'Failed to assign node.';
+        } else {
+          alert('Failed to assign node.');
+        }
+      } finally {
+        button.disabled = false;
+        button.textContent = 'Assign Node';
+      }
+    });
   });
 }
 </script>

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -150,39 +150,12 @@
 <script type="module" src="/static/presets.js"></script>
 <script>
 const addNodeButton = document.getElementById('addNode');
-if(addNodeButton){
-  addNodeButton.onclick = async () => {
-    const name = prompt('New node name');
-    if (!name) {
-      return;
-    }
-    let res;
-    try {
-      res = await fetch('/api/house/{{ house_public_id }}/room/{{ room.id }}/nodes', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        credentials: 'same-origin',
-        body: JSON.stringify({name}),
-      });
-    } catch (error) {
-      alert('Failed to add node');
-      return;
-    }
-    if (res.ok) {
-      location.reload();
-      return;
-    }
-    let message = 'Failed to add node';
-    try {
-      const data = await res.json();
-      if (data && typeof data.detail === 'string' && data.detail.trim()) {
-        message = data.detail;
-      }
-    } catch (error) {
-      // ignore JSON parse errors
-    }
-    alert(message);
-  };
+if (addNodeButton) {
+  addNodeButton.classList.add('opacity-50', 'cursor-not-allowed');
+  addNodeButton.disabled = true;
+  addNodeButton.addEventListener('click', () => {
+    alert('Nodes are now provisioned in batches. Please use the offline provisioning workflow.');
+  });
 }
 {% if motion_config %}
 (function(){

--- a/Server/app/templates/server_admin.html
+++ b/Server/app/templates/server_admin.html
@@ -85,6 +85,222 @@
   {% endif %}
 </section>
 
+<section class="mt-12 space-y-4" aria-labelledby="nodeFactoryHeading">
+  <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+    <div>
+      <h3 id="nodeFactoryHeading" class="text-2xl font-semibold">Node factory</h3>
+      <p class="text-sm opacity-70">Pre-register nodes, customize firmware, and trigger builds directly from the server.</p>
+    </div>
+    <div class="text-xs opacity-60 md:text-right">
+      Use the same hardware definition when flashing or building to ensure consistent sdkconfig values.
+    </div>
+  </div>
+  <div class="grid gap-6 lg:grid-cols-2">
+    <div class="glass rounded-xl p-4 space-y-4" data-node-factory>
+      <form class="space-y-4" data-node-factory-form>
+        <div class="grid gap-4 md:grid-cols-2">
+          <label class="block text-sm font-semibold">
+            <span>How many nodes?</span>
+            <input type="number" name="count" min="1" max="50" value="1" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2">
+          </label>
+          <label class="block text-sm font-semibold">
+            <span>Display name (optional)</span>
+            <input type="text" name="displayName" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2">
+          </label>
+        </div>
+        <label class="block text-sm font-semibold">
+          <span>ESP32 target</span>
+          <select name="board" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" required>
+            {% for option in node_factory.board_options %}
+            <option value="{{ option }}">{{ option|upper }}</option>
+            {% endfor %}
+          </select>
+        </label>
+        <div class="grid gap-4" data-channel-group="ws" data-channel-type="ws2812">
+          <div class="text-sm font-semibold">WS2812 strips</div>
+          {% for idx in range(2) %}
+          <div class="grid gap-3 md:grid-cols-4 items-end" data-channel-row data-index="{{ idx }}">
+            <label class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+              <input type="checkbox" data-channel-enabled>
+              Enable strip {{ idx }}
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>GPIO</span>
+              <input type="number" data-channel-field="gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>Pixels</span>
+              <input type="number" data-channel-field="pixels" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+          </div>
+          {% endfor %}
+        </div>
+        <div class="grid gap-4" data-channel-group="white" data-channel-type="white">
+          <div class="text-sm font-semibold">White channels</div>
+          {% for idx in range(4) %}
+          <div class="grid gap-3 md:grid-cols-6 items-end" data-channel-row data-index="{{ idx }}">
+            <label class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+              <input type="checkbox" data-channel-enabled>
+              Enable {{ idx }}
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>GPIO</span>
+              <input type="number" data-channel-field="gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>LEDC</span>
+              <input type="number" data-channel-field="ledc_channel" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>PWM Hz</span>
+              <input type="number" data-channel-field="pwm_hz" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>Min</span>
+              <input type="number" data-channel-field="minimum" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>Max</span>
+              <input type="number" data-channel-field="maximum" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+          </div>
+          {% endfor %}
+        </div>
+        <div class="grid gap-4" data-channel-group="rgb" data-channel-type="rgb">
+          <div class="text-sm font-semibold">RGB channels</div>
+          {% for idx in range(4) %}
+          <div class="grid gap-3 md:grid-cols-7 items-end" data-channel-row data-index="{{ idx }}">
+            <label class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+              <input type="checkbox" data-channel-enabled>
+              Enable {{ idx }}
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>PWM Hz</span>
+              <input type="number" data-channel-field="pwm_hz" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>Mode</span>
+              <input type="number" data-channel-field="ledc_mode" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>R GPIO</span>
+              <input type="number" data-channel-field="r_gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>R LEDC</span>
+              <input type="number" data-channel-field="r_ledc_ch" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>G GPIO</span>
+              <input type="number" data-channel-field="g_gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>G LEDC</span>
+              <input type="number" data-channel-field="g_ledc_ch" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>B GPIO</span>
+              <input type="number" data-channel-field="b_gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+            <label class="block text-xs font-semibold">
+              <span>B LEDC</span>
+              <input type="number" data-channel-field="b_ledc_ch" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
+            </label>
+          </div>
+          {% endfor %}
+        </div>
+        <div class="grid gap-4 md:grid-cols-2">
+          <label class="flex items-center gap-3 text-sm font-semibold">
+            <input type="checkbox" data-pir-enabled>
+            Enable PIR sensor
+          </label>
+          <label class="block text-sm font-semibold">
+            <span>PIR GPIO</span>
+            <input type="number" data-pir-gpio class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2">
+          </label>
+        </div>
+        <label class="block text-sm font-semibold">
+          <span>Overrides (JSON object)</span>
+          <textarea data-overrides class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2 h-24" placeholder="{\"CONFIG_UL_WIFI_RESET_BUTTON_GPIO\": 0}"></textarea>
+        </label>
+        <button type="submit" class="px-4 py-2 pill bg-emerald-600 hover:bg-emerald-500 text-sm font-semibold">Generate node IDs</button>
+      </form>
+      <div class="space-y-2 text-xs">
+        <div class="font-semibold uppercase opacity-70">Generated nodes</div>
+        <pre class="bg-slate-900/80 border border-slate-800 rounded p-3 text-xs overflow-x-auto" data-node-factory-output>No nodes generated yet.</pre>
+      </div>
+    </div>
+    <div class="space-y-4">
+      <div class="glass rounded-xl p-4 space-y-4">
+        <div>
+          <h4 class="text-xl font-semibold">Available registrations</h4>
+          <p class="text-xs opacity-70">New nodes appear here after generation.</p>
+        </div>
+        <div class="space-y-2 text-xs" data-node-factory-list></div>
+      </div>
+      <div class="glass rounded-xl p-4 space-y-4">
+        <div>
+          <h4 class="text-xl font-semibold">Build &amp; provisioning tools</h4>
+          <p class="text-xs opacity-70">Reuse the hardware configuration above when building or flashing firmware.</p>
+        </div>
+        <form class="space-y-3" data-node-build-form>
+          <div class="grid gap-3 md:grid-cols-2">
+            <label class="block text-sm font-semibold">
+              <span>Node ID</span>
+              <input type="text" name="nodeId" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" placeholder="auto if test node">
+            </label>
+            <label class="block text-sm font-semibold">
+              <span>Use hardware from form</span>
+              <input type="checkbox" name="useHardware" class="ml-2 align-middle">
+            </label>
+            <label class="block text-sm font-semibold md:col-span-2">
+              <span>OTA token (optional)</span>
+              <input type="text" name="otaToken" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" placeholder="Paste pre-generated token to reuse">
+            </label>
+          </div>
+          <div class="flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-wide">
+            <label class="flex items-center gap-2"><input type="checkbox" name="useTestNode"> Test node</label>
+            <label class="flex items-center gap-2"><input type="checkbox" name="regenerateToken"> Rotate token</label>
+            <label class="flex items-center gap-2"><input type="checkbox" name="skipBuild"> Skip build (sdkconfig only)</label>
+          </div>
+          <button type="submit" class="px-3 py-2 pill bg-indigo-600 hover:bg-indigo-500 text-sm font-semibold">Build firmware</button>
+        </form>
+        <pre class="bg-slate-900/80 border border-slate-800 rounded p-3 text-xs overflow-x-auto" data-node-build-output>Build output will appear here.</pre>
+        <form class="space-y-3" data-node-flash-form>
+          <div class="grid gap-3 md:grid-cols-2">
+            <label class="block text-sm font-semibold">
+              <span>Node ID</span>
+              <input type="text" name="nodeId" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" placeholder="auto if test node">
+            </label>
+            <label class="block text-sm font-semibold">
+              <span>USB port</span>
+              <input type="text" name="port" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" placeholder="/dev/ttyUSB0" required>
+            </label>
+            <label class="block text-sm font-semibold md:col-span-2">
+              <span>OTA token (optional)</span>
+              <input type="text" name="otaToken" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" placeholder="Reuse the batch-generated token if available">
+            </label>
+          </div>
+          <div class="flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-wide">
+            <label class="flex items-center gap-2"><input type="checkbox" name="useTestNode"> Test node</label>
+            <label class="flex items-center gap-2"><input type="checkbox" name="useHardware"> Use hardware from form</label>
+          </div>
+          <button type="submit" class="px-3 py-2 pill bg-amber-600 hover:bg-amber-500 text-sm font-semibold">Build &amp; flash</button>
+        </form>
+        <pre class="bg-slate-900/80 border border-slate-800 rounded p-3 text-xs overflow-x-auto" data-node-flash-output>Flash output will appear here.</pre>
+        <form class="space-y-3" data-update-all-form>
+          <label class="block text-sm font-semibold">
+            <span>Firmware version</span>
+            <input type="text" name="firmwareVersion" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-3 py-2" placeholder="2024.07.0" required>
+          </label>
+          <button type="submit" class="px-3 py-2 pill bg-rose-600 hover:bg-rose-500 text-sm font-semibold">Run updateAllNodes</button>
+        </form>
+        <pre class="bg-slate-900/80 border border-slate-800 rounded p-3 text-xs overflow-x-auto" data-update-all-output>updateAllNodes output will appear here.</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="mt-12 grid gap-6 md:grid-cols-2" aria-labelledby="accountHeading">
   <div class="space-y-4">
     <div>
@@ -186,7 +402,18 @@
   {% endif %}
 </section>
 
+<script type="application/json" id="nodeFactoryData">{{ node_factory | tojson }}</script>
 <script>
+const nodeFactoryDataEl = document.getElementById('nodeFactoryData');
+let nodeFactoryData = {available: [], assigned: [], board_options: []};
+if (nodeFactoryDataEl) {
+  try {
+    nodeFactoryData = JSON.parse(nodeFactoryDataEl.textContent) || nodeFactoryData;
+  } catch (err) {
+    console.warn('Failed to parse node factory data', err);
+  }
+}
+
 const houseCards = Array.from(document.querySelectorAll('[data-house-card]'));
 houseCards.forEach((card) => {
   const revealButton = card.querySelector('[data-reveal-id]');
@@ -366,6 +593,290 @@ if (accountList) {
     } finally {
       button.disabled = false;
       button.textContent = originalText;
+    }
+  });
+}
+
+function collectChannels(groupEl) {
+  const rows = Array.from(groupEl.querySelectorAll('[data-channel-row]'));
+  const channels = [];
+  rows.forEach((row) => {
+    const index = parseInt(row.getAttribute('data-index') || '0', 10);
+    const enabled = row.querySelector('[data-channel-enabled]')?.checked || false;
+    const fields = row.querySelectorAll('[data-channel-field]');
+    const payload = {index, enabled};
+    fields.forEach((field) => {
+      const key = field.getAttribute('data-channel-field');
+      if (!key) return;
+      const raw = field.value.trim();
+      if (raw === '') {
+        return;
+      }
+      const num = Number(raw);
+      payload[key] = Number.isFinite(num) ? num : raw;
+    });
+    if (enabled || Object.keys(payload).length > 2) {
+      channels.push(payload);
+    }
+  });
+  return channels;
+}
+
+function collectHardwarePayload(root) {
+  const board = root.querySelector('select[name="board"]')?.value || 'esp32';
+  const wsGroup = root.querySelector('[data-channel-group="ws"]');
+  const whiteGroup = root.querySelector('[data-channel-group="white"]');
+  const rgbGroup = root.querySelector('[data-channel-group="rgb"]');
+  const overridesText = root.querySelector('[data-overrides]')?.value || '';
+  const pirEnabled = root.querySelector('[data-pir-enabled]')?.checked || false;
+  const pirGpioRaw = root.querySelector('[data-pir-gpio]')?.value || '';
+
+  let overrides = {};
+  if (overridesText.trim()) {
+    try {
+      const parsed = JSON.parse(overridesText);
+      if (parsed && typeof parsed === 'object') {
+        overrides = parsed;
+      }
+    } catch (err) {
+      throw new Error('Overrides must be valid JSON');
+    }
+  }
+
+  const hardware = {
+    board,
+    ws2812: wsGroup ? collectChannels(wsGroup) : [],
+    white: whiteGroup ? collectChannels(whiteGroup) : [],
+    rgb: rgbGroup ? collectChannels(rgbGroup) : [],
+    overrides,
+  };
+
+  if (pirEnabled || pirGpioRaw.trim()) {
+    const pirGpio = Number(pirGpioRaw);
+    hardware.pir = {
+      enabled: pirEnabled,
+      gpio: Number.isFinite(pirGpio) ? pirGpio : undefined,
+    };
+  }
+
+  return hardware;
+}
+
+function renderNodeList(container, available, assigned) {
+  if (!container) return;
+  const parts = [];
+  if (available.length) {
+    parts.push('<div class="font-semibold text-xs uppercase opacity-70">Available</div>');
+    available.forEach((entry) => {
+      parts.push(`<div class="border border-slate-800/60 rounded px-3 py-2"><div class="font-semibold">${entry.nodeId}</div><div class="opacity-70">${entry.board || 'board?'}</div></div>`);
+    });
+  }
+  if (assigned.length) {
+    parts.push('<div class="font-semibold text-xs uppercase opacity-70 mt-2">Assigned</div>');
+    assigned.forEach((entry) => {
+      const location = entry.house && entry.room ? `${entry.house} / ${entry.room}` : (entry.house || entry.room || '—');
+      parts.push(`<div class="border border-slate-800/60 rounded px-3 py-2"><div class="font-semibold">${entry.nodeId}</div><div class="opacity-70">${location}</div></div>`);
+    });
+  }
+  if (!parts.length) {
+    parts.push('<div class="opacity-60">No registrations yet.</div>');
+  }
+  container.innerHTML = parts.join('');
+}
+
+function renderCommandOutput(target, data) {
+  if (!target) return;
+  const lines = [];
+  if (data.message) {
+    lines.push(`# ${data.message}`);
+  }
+  lines.push(`Return code: ${data.returncode}`);
+  if (data.command) {
+    lines.push(`Command: ${data.command.join(' ')}`);
+  }
+  if (data.cwd) {
+    lines.push(`CWD: ${data.cwd}`);
+  }
+  if (data.stdout) {
+    lines.push('\n# stdout');
+    lines.push(data.stdout.trim());
+  }
+  if (data.stderr) {
+    lines.push('\n# stderr');
+    lines.push(data.stderr.trim());
+  }
+  target.textContent = lines.join('\n');
+}
+
+const nodeListContainer = document.querySelector('[data-node-factory-list]');
+if (nodeListContainer) {
+  renderNodeList(nodeListContainer, nodeFactoryData.available || [], nodeFactoryData.assigned || []);
+}
+
+async function refreshNodeFactory() {
+  try {
+    const res = await fetch('/api/server-admin/node-factory/registrations', {credentials: 'same-origin'});
+    if (!res.ok) return;
+    const data = await res.json();
+    renderNodeList(nodeListContainer, data.available || [], data.assigned || []);
+  } catch (err) {
+    console.warn('Failed to refresh node factory list', err);
+  }
+}
+
+const nodeFactoryForm = document.querySelector('[data-node-factory-form]');
+if (nodeFactoryForm) {
+  const outputEl = document.querySelector('[data-node-factory-output]');
+  nodeFactoryForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    try {
+      const hardware = collectHardwarePayload(nodeFactoryForm);
+      const count = Number(nodeFactoryForm.querySelector('input[name="count"]').value) || 1;
+      const displayName = nodeFactoryForm.querySelector('input[name="displayName"]').value;
+      const payload = {
+        count,
+        displayName: displayName || undefined,
+        hardware,
+      };
+      const res = await fetch('/api/server-admin/node-factory/registrations', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(errText || `HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      const lines = [];
+      (data.nodes || []).forEach((node) => {
+        lines.push(`Node ${node.nodeId}`);
+        lines.push(`  Download: ${node.downloadId}`);
+        lines.push(`  Manifest: ${node.manifestUrl}`);
+        lines.push(`  Token: ${node.otaToken}`);
+        lines.push('');
+      });
+      outputEl.textContent = lines.join('\n') || 'No nodes generated yet.';
+      await refreshNodeFactory();
+    } catch (err) {
+      outputEl.textContent = `Error generating nodes: ${err}`;
+    }
+  });
+}
+
+function maybeHardwarePayload(formEl) {
+  if (!formEl.querySelector('input[name="useHardware"]')?.checked) {
+    return undefined;
+  }
+  const factoryRoot = document.querySelector('[data-node-factory]');
+  if (!factoryRoot) return undefined;
+  try {
+    return collectHardwarePayload(factoryRoot);
+  } catch (err) {
+    alert(err.message || 'Hardware configuration invalid');
+    throw err;
+  }
+}
+
+const buildForm = document.querySelector('[data-node-build-form]');
+if (buildForm) {
+  const outputEl = document.querySelector('[data-node-build-output]');
+  buildForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    try {
+      const payload = {
+        nodeId: buildForm.querySelector('input[name="nodeId"]').value || undefined,
+        useTestNode: buildForm.querySelector('input[name="useTestNode"]').checked,
+        regenerateToken: buildForm.querySelector('input[name="regenerateToken"]').checked,
+        skipBuild: buildForm.querySelector('input[name="skipBuild"]').checked,
+      };
+      const tokenField = buildForm.querySelector('input[name="otaToken"]');
+      if (tokenField && tokenField.value.trim()) {
+        payload.otaToken = tokenField.value.trim();
+      }
+      const hardware = maybeHardwarePayload(buildForm);
+      if (hardware) {
+        payload.hardware = hardware;
+      }
+      const res = await fetch('/api/server-admin/node-factory/build', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(errText || `HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      renderCommandOutput(outputEl, data);
+      await refreshNodeFactory();
+    } catch (err) {
+      outputEl.textContent = `Build failed: ${err}`;
+    }
+  });
+}
+
+const flashForm = document.querySelector('[data-node-flash-form]');
+if (flashForm) {
+  const outputEl = document.querySelector('[data-node-flash-output]');
+  flashForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    try {
+      const payload = {
+        nodeId: flashForm.querySelector('input[name="nodeId"]').value || undefined,
+        port: flashForm.querySelector('input[name="port"]').value,
+        useTestNode: flashForm.querySelector('input[name="useTestNode"]').checked,
+      };
+      const tokenField = flashForm.querySelector('input[name="otaToken"]');
+      if (tokenField && tokenField.value.trim()) {
+        payload.otaToken = tokenField.value.trim();
+      }
+      const hardware = maybeHardwarePayload(flashForm);
+      if (hardware) {
+        payload.hardware = hardware;
+      }
+      const res = await fetch('/api/server-admin/node-factory/flash', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(errText || `HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      renderCommandOutput(outputEl, data);
+      await refreshNodeFactory();
+    } catch (err) {
+      outputEl.textContent = `Flash failed: ${err}`;
+    }
+  });
+}
+
+const updateAllForm = document.querySelector('[data-update-all-form]');
+if (updateAllForm) {
+  const outputEl = document.querySelector('[data-update-all-output]');
+  updateAllForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const firmwareVersion = updateAllForm.querySelector('input[name="firmwareVersion"]').value;
+    try {
+      const res = await fetch('/api/server-admin/node-factory/update-all', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
+        body: JSON.stringify({firmwareVersion}),
+      });
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(errText || `HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      renderCommandOutput(outputEl, data);
+    } catch (err) {
+      outputEl.textContent = `updateAllNodes failed: ${err}`;
     }
   });
 }

--- a/Server/docs/node-ids.md
+++ b/Server/docs/node-ids.md
@@ -1,110 +1,187 @@
 # Opaque Node Identifiers
 
-Nodes created through the admin UI or API now receive a random, opaque identifier
-at creation time. The identifier is a 31-character string composed of lowercase
-letters and digits (for example `dbrpr89wiexuejce52u9840juec77ul`). It no longer contains
-the house slug or any user-provided text, so capturing or guessing a node ID does
-not reveal which house owns it.
+Node identities are now generated ahead of time and stored in the
+`node_registrations` table. Each record reserves an opaque node ID, a firmware
+download ID, the hashed OTA bearer token, and a JSON payload for hardware-
+specific metadata. Registrations can optionally track which authenticated user
+or house eventually claims the identifier, but they can remain unassigned
+indefinitely so manufacturing teams can mint identifiers in bulk before any
+customer data exists.
 
-Alongside the node ID the server issues:
+## Batch pre-registration
 
-* a unique download identifier used to expose OTA binaries via
-  `/firmware/<download_id>/latest.bin`, and
-* a per-node bearer token whose SHA-256 hash is stored in the authentication
-  database (see [`NodeCredential`](../app/auth/models.py)).
+Operators can mint registrations either from the server-admin "Node factory"
+panel or with the
+[`Server/scripts/generate_node_ids.py`](../scripts/generate_node_ids.py) helper.
+The web UI wraps the same APIs exposed to the CLI: choose the ESP-IDF target
+(ESP32, ESP32-C3, or ESP32-S3), enable the strips you plan to populate, specify
+GPIO assignments, and supply any configuration overrides that should appear in
+`sdkconfig`. When you submit the form the server pre-generates the requested
+number of node IDs, records the metadata, and renders a download manifest URL
+plus the plaintext OTA token for each identifier. The sidebar tracks which
+registrations remain unclaimed so manufacturing can grab the next available
+identifier.
 
-Download identifiers now take advantage of the full 48-character default, while
-house external identifiers can stretch to 64 characters. The node ID remains at
-31 characters to match the ESP32 firmware limit.
+The CLI accepts a count and an optional JSON metadata file:
 
-All three values live in the SQLModel database instead of the JSON registry.
-`device_registry.json` continues to list houses, rooms and node metadata, but it
-no longer contains hashed OTA tokens.
+```bash
+python Server/scripts/generate_node_ids.py 25 \
+    --metadata-file tooling/batch-metadata.json > new_nodes.json
+```
 
-## Provisioning workflow
+The command initialises the auth database (creating tables if necessary),
+persists the requested number of registrations, and writes a machine-readable
+summary to stdout (JSON by default, or CSV when `--format csv` is supplied).
+Each entry includes the node ID, download ID, plaintext bearer token (returned
+only in the CLI response), hash, and creation timestamp. The metadata file may
+contain either a single JSON object
+(applied to every generated node) or a list of objects (applied positionally).
+Those metadata blobs are stored verbatim in the `hardware_metadata` column so
+future tooling—such as a firmware image generator—can inject per-device GPIO or
+feature flags. The Node factory UI simply builds these JSON objects for you.
 
-1. **Create the node in the UI.** When you add a node the admin API stores the
-   opaque node ID, download ID and hashed bearer token in the credential table.
-   The response includes the download alias so you can verify the record, but the
-   plaintext token is only returned via provisioning tools.
+The plaintext token is **not** stored in the database—only the hash is
+persisted—so the exported JSON/CSV is the sole record of the secret. Treat it
+like any other credential and keep it in your password manager or build system
+vault. If the token is lost you can mint a replacement during provisioning.
 
-2. **Generate firmware defaults with the provisioning CLI.** Use
-   [`Server/scripts/provision_node_firmware.py`](../scripts/provision_node_firmware.py)
-   to rotate the token, update `sdkconfig`, and manage the firmware directory in a
-   single command:
+To inspect reserved identifiers and their current assignment state, run the
+existing provisioning helper in list mode:
 
-   ```bash
-   python Server/scripts/provision_node_firmware.py provisioned-node \
-       --config UltraNodeV5/sdkconfig --rotate-download
-   ```
+```bash
+python Server/scripts/provision_node_firmware.py --list
+```
 
-   The command:
+The table now shows whether each node is still available, has been claimed for a
+house/room, or was already provisioned.
 
-   * generates a fresh bearer token and persists its hash,
-   * optionally rotates the download alias (use `--rotate-download`),
-   * writes `CONFIG_UL_NODE_ID`, `CONFIG_UL_OTA_MANIFEST_URL` and
-     `CONFIG_UL_OTA_BEARER_TOKEN` into the selected `sdkconfig` files, and
-   * ensures the `/srv/firmware/<download_id>` directory (under the default
-     `/srv/firmware/UltraLights` root) exists and stores the node’s firmware
-     artifacts directly.
+## Provisioning firmware
 
+When it is time to flash a device you have two options:
 
-   The plaintext token and manifest URL are printed once so you can archive them
-   securely.
+1. Use the server-admin Node factory to build or flash firmware directly. The
+   "Build firmware" action updates an `sdkconfig` snapshot using the stored
+   metadata (board type, enabled channels, overrides, etc.) and runs `idf.py`
+   with the correct `IDF_TARGET`. The "Build & flash" action performs
+   `idf.py -p <port> build flash` so you can program a device connected to the
+   server's USB port. Both actions accept an optional OTA token value (so you
+   can reuse the pre-generated secret) and otherwise mint a fresh credential
+   before writing `CONFIG_UL_NODE_ID`,
+   `CONFIG_UL_OTA_MANIFEST_URL`, `CONFIG_UL_OTA_BEARER_TOKEN`, and the compact
+   metadata string (`CONFIG_UL_NODE_METADATA`) into the generated `sdkconfig`.
+   Results are streamed back to the browser so you can review `idf.py` output
+   without leaving the console.
+2. Call [`Server/scripts/provision_node_firmware.py`](../scripts/provision_node_firmware.py)
+   with the pre-generated node ID when you prefer a CLI workflow:
 
-   > **Where to store the outputs.** Save the manifest URL, download ID and
-   > bearer token in the same vault you use for long-lived service credentials
-   > (for example 1Password, Bitwarden, or your infrastructure secrets manager).
-   > The API only keeps the SHA-256 hash of the token, so you cannot recover the
-   > plaintext later if it is misplaced.
+```bash
+python Server/scripts/provision_node_firmware.py abcd1234efgh5678 \
+    --config UltraNodeV5/sdkconfig \
+    --ota-token $(jq -r '.[0].ota_token' new_nodes.json)
+```
 
-   You will need the manifest URL and bearer token whenever you:
+Both approaches refuse unknown node IDs and no longer generate new identifiers
+on the fly. Instead they read the download ID, manifest URL, and metadata from
+the registration record. The CLI expects the pre-generated OTA token (or
+`--rotate-token` to mint a replacement) and then:
 
-   * patch another `sdkconfig` (or rebuild the firmware) for this node,
-   * re-flash hardware after a board replacement, or
-   * perform incident response—for example revoking the current token and
-     verifying that no other device is still using it.
+* patches the requested `sdkconfig` files with
+  `CONFIG_UL_NODE_ID`, `CONFIG_UL_OTA_MANIFEST_URL`,
+  `CONFIG_UL_OTA_BEARER_TOKEN`, `CONFIG_UL_TARGET_CHIP`, and (when metadata is
+  present) `CONFIG_UL_NODE_METADATA` containing a compact JSON string,
+* ensures the firmware download directory `${FIRMWARE_DIR}/<download_id>` exists,
+  and
+* updates the database to mark the node as provisioned unless
+  `--no-mark-provisioned` is supplied.
 
-   Keeping the download ID handy also lets you inspect the corresponding
+`--rotate-download` remains available when you need to retire a compromised
+manifest URL. Use `--rotate-token` to generate a brand new OTA token when the
+pre-generated secret is lost or needs to be rotated. The summary printed at the
+end of the run (and the Node factory build panel) highlights the node's status
+(available, assigned, or provisioned), current assignment target, metadata
+payload, and download directory. If the tool encounters a legacy record that
+still contains a plaintext token it will consume and erase it, warning you to
+switch to the explicit `--ota-token` workflow.
 
-   firmware folder on disk (`/srv/firmware/UltraLights/<download_id>`) during
-   troubleshooting without revealing the node slug. Firmware artifacts now live
-   directly inside the download directory, so the filesystem no longer exposes
-   node identifiers.
+The Node factory also exposes the legacy `UltraNodeV5/updateAllNodes.sh` script
+as a single click: enter the firmware version string, press "Run updateAllNodes",
+and the server executes the helper, archiving the previous `latest.bin` files and
+rolling manifests just like the original shell script. Output and return codes
+are streamed to the browser for easy auditing, and an audit log entry records who
+triggered the rotation.
 
-3. **Build and publish firmware.** After the CLI patches `sdkconfig`, build the
-   firmware and place the resulting `latest.bin` into
-   `${FIRMWARE_DIR}/<download_id>/latest.bin`. The provisioning tooling keeps
-   the download directory populated with the current binary.
+## End-to-end workflow
 
-4. **Audit provisioning status.** To see which nodes have already been
-   provisioned, run the CLI with `--list`; provisioned entries are marked with an
-   asterisk and include the timestamp the firmware was generated.
+Putting the pieces together, an end-to-end bring-up session typically looks like
+this:
 
-If you need to regenerate credentials manually, the
-[`manage_node_credentials`](../scripts/manage_node_credentials.py) helper still
-rotates tokens or download aliases and prints the new values, but the provisioning
-CLI is the recommended path because it keeps firmware defaults, download directories and the
-database in sync.
+1. **Generate a batch of identifiers.** An operator calls
+   `Server/scripts/generate_node_ids.py <count>` (or uses the Node factory
+   "Generate IDs" dialog) to mint the desired number of opaque node IDs. The
+   command prints JSON/CSV that includes the plaintext bearer tokens—store that
+   output securely because it will not be shown again.
+2. **Stage hardware metadata.** If you already know which GPIO channels, enable
+   lines, or other hardware toggles belong to each physical device, embed that
+   information in the metadata column while generating the IDs. Otherwise you can
+   leave the metadata blank and attach it later from the admin tools before
+   building firmware.
+3. **Build the firmware image.** When you are ready to program a specific board,
+   choose one of the pre-generated registrations in the Node factory UI (or pass
+   its node ID to `provision_node_firmware.py`). The tooling patches
+   `sdkconfig` with the stored metadata, target chip, manifest URL, and bearer
+   token so the compiled binary already knows how to authenticate.
+4. **Flash the ESP32.** Use the "Build & flash" control from the Node factory or
+   run `idf.py -p <port> build flash` manually against the generated configuration.
+   For brand-new boards you can also invoke the `firstTimeFlash` helper exposed in
+   the admin tooling to automate the initial erase/build/flash sequence.
+5. **Hand the device to the installer or customer.** On first boot the firmware
+   opens the captive portal (SoftAP). The user connects to the UltraLights access
+   point, submits their Wi-Fi SSID/password, and provides their UltraLights
+   account credentials (or the mutually agreed token). These inputs are stored in
+   NVS alongside the node ID metadata.
+6. **Automatic account association.** After the portal closes the node connects
+   to the broker via MQTTS using the captured UltraLights credentials. It publishes
+   the `ul/<node_id>/evt/account` event, which the server validates against the
+   `node_registrations` table and the user directory. When the credentials match,
+   the node registration is marked as assigned to the authenticated user and the
+   user’s house. Future room-assignment tooling will then let house administrators
+   place the node into a specific room menu.
+
+The `updateAllNodes.sh` wrapper remains available for fleet-wide OTA refreshes
+after the initial provisioning. Because the registrations already contain the
+download ID and metadata, the update script can build new images for every node
+without regenerating identifiers or touching customer associations.
+
+## Assigning registrations
+
+The UI no longer creates nodes directly. The "Add node" button is disabled and
+points administrators to the offline provisioning workflow, while the legacy
+`/api/house/{house_id}/room/{room_id}/nodes` endpoint returns
+`501 Not Implemented`. Future work will introduce an assignment flow that claims
+an existing registration for a specific house, user, and room. Until then,
+operators can use internal tooling (or direct database access) to populate the
+`house_slug`, `room_id`, `assigned_house_id`, and `assigned_user_id` fields once
+a device is tied to a customer.
 
 ## Why keep download identifiers?
 
 Opaque node IDs removed the original privacy concern—we no longer leak a house
-slug through the device identifier—but the dedicated download alias still buys
-us a few operational conveniences:
+slug through the device identifier—but the dedicated download alias still buys a
+few operational conveniences:
 
 * The provisioning CLI can rotate the externally visible firmware URL by issuing
-  a fresh download ID (`--rotate-download`) while leaving `CONFIG_UL_NODE_ID`
-  untouched. That lets us retire a leaked manifest URL or move a node’s firmware
-  folder without changing the identifier the device uses for MQTT and telemetry.
-* Older builds and scripts that were created before the SQLModel migration still
-  expect the download alias that lives in the registry. Maintaining the alias
-  keeps those installations functional while we roll forward to firmware that
-  understands opaque node IDs.
+  a fresh download ID (`--rotate-download`) while leaving
+  `CONFIG_UL_NODE_ID` untouched. That lets us retire a leaked manifest URL or
+  move a node’s firmware folder without changing the identifier the device uses
+  for MQTT and telemetry.
+* Older builds and scripts created before the SQLModel migration still expect the
+  download alias that lives in the registry. Maintaining the alias keeps those
+  installations functional while we roll forward to firmware that understands
+  opaque node IDs.
 * The alias gives support staff a shareable handle for diagnostics—you can point
   someone at `/firmware/<download_id>/latest.bin` without also disclosing the
-  node ID. Because the alias maps directly to an on-disk directory, you can rotate or delete it once
-  the troubleshooting session is over.
+  node ID. Because the alias maps directly to an on-disk directory, you can
+  rotate or delete it once the troubleshooting session is over.
 
 If these use cases eventually stop mattering we can collapse the indirection and
 serve binaries directly from the node ID, but for now the server and tooling are

--- a/Server/scripts/generate_node_ids.py
+++ b/Server/scripts/generate_node_ids.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Batch-generate opaque node registrations for manufacturing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import database, node_credentials  # noqa: E402
+from app.auth.service import init_auth_storage  # noqa: E402
+
+
+def _load_metadata_entries(path: Optional[str]) -> Optional[List[Dict[str, Any]]]:
+    if not path:
+        return None
+
+    metadata_path = Path(path).expanduser()
+    if not metadata_path.exists():
+        raise FileNotFoundError(f"metadata file not found: {metadata_path}")
+
+    payload = json.loads(metadata_path.read_text())
+    if isinstance(payload, list):
+        entries: List[Dict[str, Any]] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                raise ValueError("metadata list entries must be objects")
+            entries.append(dict(item))
+        return entries
+    if isinstance(payload, dict):
+        return [dict(payload)]
+
+    raise ValueError("metadata file must contain a JSON object or list of objects")
+
+
+def _emit_json(records: Iterable[Dict[str, Any]]) -> None:
+    print(json.dumps(list(records), indent=2))
+
+
+def _emit_csv(records: Iterable[Dict[str, Any]]) -> None:
+    import csv
+
+    fieldnames = [
+        "node_id",
+        "download_id",
+        "ota_token",
+        "token_hash",
+        "created_at",
+        "hardware_metadata",
+    ]
+    writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+    writer.writeheader()
+    for record in records:
+        row = dict(record)
+        metadata = row.get("hardware_metadata")
+        row["hardware_metadata"] = json.dumps(metadata or {})
+        writer.writerow(row)
+
+
+def _format_record(entry: node_credentials.NodeRegistrationWithToken) -> Dict[str, Any]:
+    registration = entry.registration
+    return {
+        "node_id": registration.node_id,
+        "download_id": registration.download_id,
+        "ota_token": entry.plaintext_token,
+        "token_hash": registration.token_hash,
+        "created_at": registration.created_at.isoformat()
+        if isinstance(registration.created_at, datetime)
+        else str(registration.created_at),
+        "hardware_metadata": registration.hardware_metadata,
+    }
+
+
+def generate_nodes(
+    *,
+    count: int,
+    metadata_entries: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    init_auth_storage()
+
+    metadata_iter: Optional[Iterable[Dict[str, Any]]] = None
+    if metadata_entries:
+        metadata_iter = metadata_entries
+
+    with database.SessionLocal() as session:
+        entries = node_credentials.create_batch(
+            session,
+            count,
+            metadata=metadata_iter,
+        )
+        return [_format_record(entry) for entry in entries]
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "count",
+        type=int,
+        help="Number of node identifiers to generate",
+    )
+    parser.add_argument(
+        "--metadata-file",
+        type=str,
+        default=None,
+        help="Optional JSON file containing hardware metadata objects",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "csv"),
+        default="json",
+        help="Output format (default: json)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+
+    metadata_entries = _load_metadata_entries(args.metadata_file)
+    records = generate_nodes(
+        count=args.count,
+        metadata_entries=metadata_entries,
+    )
+
+    if args.format == "csv":
+        _emit_csv(records)
+    else:
+        _emit_json(records)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/Server/scripts/provision_node_firmware.py
+++ b/Server/scripts/provision_node_firmware.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import argparse
+import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -16,7 +18,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from sqlmodel import Session, select  # noqa: E402
 
 from app import database, node_credentials, registry  # noqa: E402
-from app.auth.models import AuditLog, NodeCredential, User  # noqa: E402
+from app.auth.models import AuditLog, NodeCredential, NodeRegistration, User  # noqa: E402
 from app.auth.service import init_auth_storage  # noqa: E402
 from app.config import settings  # noqa: E402
 
@@ -138,25 +140,46 @@ def _list_nodes() -> int:
     init_auth_storage()
     with database.SessionLocal() as session:
         node_credentials.sync_registry_nodes(session)
-        entries = session.exec(select(NodeCredential)).all()
+        registrations = session.exec(select(NodeRegistration)).all()
+        credential_rows = session.exec(select(NodeCredential)).all()
         creators = _load_node_creators(session)
 
-    if not entries:
+    if not registrations:
         print("No nodes registered.")
         return 0
 
+    credential_map = {entry.node_id: entry for entry in credential_rows}
     print(
-        "Node ID                          Name                         Created By                  Provisioned"
+        f"{'Node ID':<30} {'Status':<12} {'Display Name':<24} {'Assignment':<24} {'Provisioned':<20} Creator"
     )
-    print("-" * 100)
-    for entry in entries:
-        mark = "" if entry.provisioned_at is None else "*"
-        name = entry.display_name or "—"
-        created_by = creators.get(entry.node_id, "—")
-        print(
-            f"{entry.node_id:<30} {name:<27} {created_by:<27} {_format_timestamp(entry.provisioned_at)}{mark}"
+    print("-" * 125)
+
+    def _status_for(reg: NodeRegistration, cred: Optional[NodeCredential]) -> str:
+        if reg.provisioned_at or (cred and cred.provisioned_at):
+            return "provisioned"
+        if reg.assigned_at or cred:
+            return "assigned"
+        return "available"
+
+    for registration in sorted(registrations, key=lambda r: r.node_id):
+        credential = credential_map.get(registration.node_id)
+        status = _status_for(registration, credential)
+        display_name = registration.display_name or (
+            credential.display_name if credential else "—"
         )
-    print("\n* indicates firmware already provisioned")
+        house = registration.house_slug or (credential.house_slug if credential else None)
+        room = registration.room_id or (credential.room_id if credential else None)
+        if house or room:
+            assignment = f"{house or '—'} / {room or '—'}"
+        else:
+            assignment = "—"
+        provisioned = registration.provisioned_at or (
+            credential.provisioned_at if credential else None
+        )
+        creator = creators.get(registration.node_id, "—")
+        print(
+            f"{registration.node_id:<30} {status:<12} {display_name:<24} {assignment:<24} {_format_timestamp(provisioned):<20} {creator}"
+        )
     return 0
 
 
@@ -177,15 +200,31 @@ def _provision(args: argparse.Namespace) -> int:
     init_auth_storage()
     registry.ensure_house_external_ids()
 
+    token: Optional[str] = None
+    download_id: Optional[str] = None
+    metadata_payload: Dict[str, Any] = {}
+    previous_download: Optional[str] = None
+    final_registration: Optional[NodeRegistration] = None
+    final_credential: Optional[NodeCredential] = None
+    manifest_url: Optional[str] = None
+    download_dir: Optional[Path] = None
+
     with database.SessionLocal() as session:
         node_credentials.sync_registry_nodes(session)
-        credential = node_credentials.get_by_node_id(session, args.node_id)
-        if credential is None:
+        registration = node_credentials.get_registration_by_node_id(
+            session, args.node_id
+        )
+        if registration is None:
             print(f"Unknown node id: {args.node_id}", file=sys.stderr)
             return 1
 
+        credential = node_credentials.get_by_node_id(session, args.node_id)
+
+        provisioned_at = registration.provisioned_at or (
+            credential.provisioned_at if credential else None
+        )
         if (
-            credential.provisioned_at is not None
+            provisioned_at is not None
             and not args.allow_reprovision
             and not args.no_mark_provisioned
         ):
@@ -195,22 +234,74 @@ def _provision(args: argparse.Namespace) -> int:
             )
             return 1
 
-        previous_download = credential.download_id
+        previous_download = registration.download_id
         if args.rotate_download:
-            credential = node_credentials.update_download_id(session, args.node_id)
+            node_credentials.update_download_id(session, args.node_id)
+            registration = node_credentials.get_registration_by_node_id(
+                session, args.node_id
+            )
+            credential = node_credentials.get_by_node_id(session, args.node_id)
 
-        download_id = credential.download_id
+        download_id = registration.download_id
 
         download_dir = _ensure_download_dir(download_id)
 
-        credential, token = node_credentials.rotate_token(session, args.node_id)
+        provided_token = (args.ota_token or "").strip() if args.ota_token else None
+        token_source = ""
 
-        manifest_url = f"{settings.PUBLIC_BASE}/firmware/UltraLights/{download_id}/manifest.json"
+        if args.rotate_token:
+            credential, token = node_credentials.rotate_token(session, args.node_id)
+            registration = node_credentials.get_registration_by_node_id(
+                session, args.node_id
+            )
+            token_source = "rotated"
+        elif provided_token:
+            expected_hash = registry.hash_node_token(provided_token)
+            if registration.token_hash and registration.token_hash != expected_hash:
+                print(
+                    "Provided OTA token does not match stored hash. Use --rotate-token to"
+                    " generate a replacement or supply the correct token.",
+                    file=sys.stderr,
+                )
+                return 1
+            if registration.token_hash != expected_hash:
+                node_credentials.rotate_token(
+                    session, args.node_id, token=provided_token
+                )
+                registration = node_credentials.get_registration_by_node_id(
+                    session, args.node_id
+                )
+                credential = node_credentials.get_by_node_id(session, args.node_id)
+            token = provided_token
+            token_source = "provided"
+        elif registration.provisioning_token:
+            token = registration.provisioning_token
+            node_credentials.clear_stored_provisioning_token(session, args.node_id)
+            registration = node_credentials.get_registration_by_node_id(
+                session, args.node_id
+            )
+            credential = node_credentials.get_by_node_id(session, args.node_id)
+            token_source = "legacy"
+        else:
+            print(
+                "No OTA token available. Provide --ota-token with the pre-generated token"
+                " or use --rotate-token to mint a new one.",
+                file=sys.stderr,
+            )
+            return 1
+
+        manifest_url = f"{settings.PUBLIC_BASE}/firmware/{download_id}/manifest.json"
         values = {
             "CONFIG_UL_NODE_ID": args.node_id,
             "CONFIG_UL_OTA_MANIFEST_URL": manifest_url,
             "CONFIG_UL_OTA_BEARER_TOKEN": token,
         }
+
+        metadata_payload = registration.hardware_metadata or {}
+        if metadata_payload:
+            values["CONFIG_UL_NODE_METADATA"] = json.dumps(
+                metadata_payload, separators=(",", ":"), sort_keys=True
+            )
 
         updated_files: List[Path] = []
         for cfg in normalized_configs:
@@ -226,22 +317,79 @@ def _provision(args: argparse.Namespace) -> int:
 
         node_credentials.sync_registry_nodes(session)
 
+        final_registration = node_credentials.get_registration_by_node_id(
+            session, args.node_id
+        )
+        final_credential = node_credentials.get_by_node_id(session, args.node_id)
+
+        expected_hash = registry.hash_node_token(token)
+        needs_sync = False
+        if final_registration and final_registration.token_hash != expected_hash:
+            needs_sync = True
+        if final_credential and final_credential.token_hash != expected_hash:
+            needs_sync = True
+
+        if needs_sync:
+            node_credentials.rotate_token(session, args.node_id, token=token)
+            final_registration = node_credentials.get_registration_by_node_id(
+                session, args.node_id
+            )
+            final_credential = node_credentials.get_by_node_id(session, args.node_id)
+
     _, _, node = registry.find_node(args.node_id)
-    name = node.get("name") if isinstance(node, dict) else ""
+    name = ""
+    if isinstance(node, dict):
+        name = str(node.get("name") or "")
+    if not name and final_registration:
+        name = final_registration.display_name or ""
+    if not name and final_credential:
+        name = final_credential.display_name or ""
+
+    assignment_parts: List[str] = []
+    if final_registration:
+        if final_registration.house_slug:
+            assignment_parts.append(final_registration.house_slug)
+        if final_registration.room_id:
+            assignment_parts.append(final_registration.room_id)
+    if not assignment_parts and final_credential:
+        assignment_parts.append(final_credential.house_slug)
+        assignment_parts.append(final_credential.room_id)
+    assignment_display = " / ".join(part for part in assignment_parts if part) or "—"
+
+    status = "available"
+    if final_registration and final_registration.provisioned_at:
+        status = "provisioned"
+    elif final_registration and final_registration.assigned_at:
+        status = "assigned"
 
     print("\n--- Firmware provisioning ---")
     if name:
         print(f"Node: {args.node_id} ({name})")
     else:
         print(f"Node: {args.node_id}")
+    print(f"Status: {status}")
+    print(f"Assignment: {assignment_display}")
     print(f"Download ID: {download_id}")
     print(f"Manifest URL: {manifest_url}")
     print(f"Bearer Token: {token}")
+    if token_source == "legacy":
+        print(
+            "Warning: consumed legacy stored OTA token; future runs must provide"
+            " --ota-token or --rotate-token.",
+            file=sys.stderr,
+        )
+    elif token_source == "rotated":
+        print("Generated new OTA token via --rotate-token.")
+    if metadata_payload:
+        print("Hardware metadata:")
+        print(json.dumps(metadata_payload, indent=2, sort_keys=True))
     if updated_files:
         print("Updated configuration files:")
         for cfg in updated_files:
             print(f"  - {cfg}")
     print(f"Firmware directory: {download_dir}")
+    if previous_download and previous_download != download_id:
+        print(f"Previous download id was {previous_download}")
     return 0
 
 
@@ -258,6 +406,17 @@ def _build_parser() -> argparse.ArgumentParser:
         "--rotate-download",
         action="store_true",
         help="Issue a new download identifier before provisioning.",
+    )
+    parser.add_argument(
+        "--ota-token",
+        dest="ota_token",
+        metavar="TOKEN",
+        help="Pre-generated OTA bearer token to embed in the firmware.",
+    )
+    parser.add_argument(
+        "--rotate-token",
+        action="store_true",
+        help="Generate a new OTA token instead of using a pre-generated one.",
     )
     parser.add_argument(
         "--allow-reprovision",

--- a/Server/tests/auth/test_house_admin.py
+++ b/Server/tests/auth/test_house_admin.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -12,7 +13,14 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from app import database
-from app.auth.models import House, HouseMembership, HouseRole, RoomAccess, User
+from app.auth.models import (
+    House,
+    HouseMembership,
+    HouseRole,
+    NodeRegistration,
+    RoomAccess,
+    User,
+)
 from app.auth.security import SESSION_COOKIE_NAME
 from app.auth.service import create_user, init_auth_storage
 from app.config import settings
@@ -67,12 +75,15 @@ def client(tmp_path, monkeypatch: pytest.MonkeyPatch):
 
     import app.motion
     import app.registry as registry_module
+    import app.account_linker as account_linker_module
     import app.status_monitor
     from app.main import app as fastapi_app
     monkeypatch.setattr(app.motion.motion_manager, "start", lambda: None)
     monkeypatch.setattr(app.motion.motion_manager, "stop", lambda: None)
     monkeypatch.setattr(app.status_monitor.status_monitor, "start", lambda: None)
     monkeypatch.setattr(app.status_monitor.status_monitor, "stop", lambda: None)
+    monkeypatch.setattr(account_linker_module.account_linker, "start", lambda: None)
+    monkeypatch.setattr(account_linker_module.account_linker, "stop", lambda: None)
 
     original_url = settings.AUTH_DB_URL
     db_path = tmp_path / "auth.sqlite3"
@@ -147,6 +158,22 @@ def _create_house_guest(username: str, password: str, *, house_external_id: str)
         house_external_id=house_external_id,
         role=HouseRole.GUEST,
     )
+
+
+def _create_house_admin_user(
+    username: str, password: str, *, house_external_id: str
+) -> User:
+    with database.SessionLocal() as session:
+        house = session.exec(
+            select(House).where(House.external_id == house_external_id)
+        ).first()
+        assert house is not None, "house missing in database"
+        user = create_user(session, username, password, server_admin=False)
+        membership = HouseMembership(user_id=user.id, house_id=house.id, role=HouseRole.ADMIN)
+        session.add(membership)
+        session.commit()
+        session.refresh(user)
+        return user
 
 
 def _membership_rooms(session, membership_id: int) -> set[str]:
@@ -312,3 +339,110 @@ def test_invalid_room_rejected_on_create(client: TestClient):
         },
     )
     assert response.status_code == 422
+
+
+def test_house_admin_assigns_pending_node_to_room(client: TestClient):
+    admin_user = _create_house_admin_user(
+        "alpha-admin", "admin-pass", house_external_id="alpha-public"
+    )
+    _login(client, "alpha-admin", "admin-pass")
+
+    import app.registry as registry_module
+
+    with database.SessionLocal() as session:
+        house = session.exec(
+            select(House).where(House.external_id == "alpha-public")
+        ).first()
+        assert house is not None
+        registration = NodeRegistration(
+            node_id="alpha-node-new",
+            download_id="alpha-download",
+            token_hash=registry_module.hash_node_token("pending-token"),
+            assigned_user_id=admin_user.id,
+            assigned_house_id=house.id,
+            assigned_at=datetime.now(timezone.utc),
+        )
+        session.add(registration)
+        session.commit()
+
+    response = client.post(
+        "/api/house/alpha-public/nodes/assign",
+        json={
+            "nodeId": "alpha-node-new",
+            "roomId": "alpha-room",
+            "name": "Kitchen Node",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["node"]["roomId"] == "alpha-room"
+    assert body["node"]["name"] == "Kitchen Node"
+
+    with database.SessionLocal() as session:
+        stored = session.exec(
+            select(NodeRegistration).where(NodeRegistration.node_id == "alpha-node-new")
+        ).one()
+        assert stored.room_id == "alpha-room"
+        assert stored.house_slug == "alpha"
+        assert stored.display_name == "Kitchen Node"
+
+    house, room, node = registry_module.find_node("alpha-node-new")
+    assert room is not None
+    assert room.get("id") == "alpha-room"
+    assert node and node.get("name") == "Kitchen Node"
+
+
+def test_house_admin_moves_node_between_rooms(client: TestClient):
+    admin_user = _create_house_admin_user(
+        "alpha-admin", "admin-pass", house_external_id="alpha-public"
+    )
+    _login(client, "alpha-admin", "admin-pass")
+
+    import app.registry as registry_module
+
+    with database.SessionLocal() as session:
+        house = session.exec(
+            select(House).where(House.external_id == "alpha-public")
+        ).first()
+        assert house is not None
+        registration = NodeRegistration(
+            node_id="alpha-node-existing",
+            download_id="alpha-existing",
+            token_hash=registry_module.hash_node_token("existing-token"),
+            assigned_user_id=admin_user.id,
+            assigned_house_id=house.id,
+            house_slug="alpha",
+            room_id="alpha-room",
+            display_name="Existing Node",
+            assigned_at=datetime.now(timezone.utc),
+        )
+        session.add(registration)
+        session.commit()
+
+    registry_module.place_node_in_room(
+        "alpha-node-existing", "alpha", "alpha-room", name="Existing Node"
+    )
+
+    response = client.post(
+        "/api/house/alpha-public/nodes/alpha-node-existing/move",
+        json={"roomId": "alpha-denied", "name": "Moved Node"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["node"]["roomId"] == "alpha-denied"
+    assert body["node"]["name"] == "Moved Node"
+
+    with database.SessionLocal() as session:
+        stored = session.exec(
+            select(NodeRegistration).where(
+                NodeRegistration.node_id == "alpha-node-existing"
+            )
+        ).one()
+        assert stored.room_id == "alpha-denied"
+        assert stored.house_slug == "alpha"
+        assert stored.display_name == "Moved Node"
+
+    house, room, node = registry_module.find_node("alpha-node-existing")
+    assert room is not None
+    assert room.get("id") == "alpha-denied"
+    assert node and node.get("name") == "Moved Node"

--- a/Server/tests/test_account_linker.py
+++ b/Server/tests/test_account_linker.py
@@ -1,0 +1,107 @@
+from copy import deepcopy
+import sys
+from pathlib import Path
+
+import pytest
+from sqlmodel import select
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import database, node_credentials, registry
+from app.account_linker import AccountLinker
+from app.auth.models import House, HouseMembership, HouseRole, NodeRegistration
+from app.auth.service import create_user, init_auth_storage
+from app.config import settings
+
+
+@pytest.fixture()
+def account_env(tmp_path, monkeypatch):
+    original_registry = deepcopy(settings.DEVICE_REGISTRY)
+    original_db_url = settings.AUTH_DB_URL
+
+    test_registry = [
+        {
+            "id": "test-house",
+            "name": "Test House",
+            "rooms": [],
+        }
+    ]
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", deepcopy(test_registry))
+    monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", settings.DEVICE_REGISTRY)
+    monkeypatch.setattr(registry, "save_registry", lambda: None)
+
+    db_path = tmp_path / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+    database.reset_session_factory(db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", db_url)
+
+    init_auth_storage()
+
+    yield
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(registry.settings, "DEVICE_REGISTRY", original_registry)
+    database.reset_session_factory(original_db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", original_db_url)
+
+
+def _create_membership(session, user_id: int) -> int:
+    house = session.exec(select(House).where(House.external_id == "test-house")).first()
+    if house is None:
+        house = House(display_name="Test House", external_id="test-house")
+        session.add(house)
+        session.commit()
+        session.refresh(house)
+    membership = HouseMembership(user_id=user_id, house_id=house.id, role=HouseRole.ADMIN)
+    session.add(membership)
+    session.commit()
+    session.refresh(membership)
+    return membership.house_id
+
+
+def _create_registration(session) -> NodeRegistration:
+    batch = node_credentials.create_batch(session, 1)
+    return batch[0].registration
+
+
+def test_handle_credentials_links_user(account_env):
+    linker = AccountLinker()
+    with database.SessionLocal() as session:
+        user = create_user(session, "alice", "wonderland", server_admin=False)
+        house_id = _create_membership(session, user.id)
+        registration = _create_registration(session)
+        node_id = registration.node_id
+        # ensure registration persisted for assertions later
+        session.refresh(registration)
+        user_id = user.id
+    result = linker.handle_credentials(node_id, "alice", "wonderland")
+    assert result is not None
+    with database.SessionLocal() as session:
+        refreshed = node_credentials.get_registration_by_node_id(session, node_id)
+        assert refreshed is not None
+        assert refreshed.assigned_user_id == user_id
+        assert refreshed.assigned_house_id == house_id
+        assert refreshed.account_username == "alice"
+        assert refreshed.account_password_hash is not None
+        assert refreshed.account_credentials_received_at is not None
+        assert refreshed.account_password_hash != "wonderland"
+
+
+def test_handle_credentials_rejects_invalid_password(account_env):
+    linker = AccountLinker()
+    with database.SessionLocal() as session:
+        user = create_user(session, "bob", "builder", server_admin=False)
+        _create_membership(session, user.id)
+        registration = _create_registration(session)
+        node_id = registration.node_id
+        session.refresh(registration)
+    result = linker.handle_credentials(node_id, "bob", "wrongpass")
+    assert result is None
+    with database.SessionLocal() as session:
+        refreshed = node_credentials.get_registration_by_node_id(session, node_id)
+        assert refreshed is not None
+        assert refreshed.account_username is None
+        assert refreshed.assigned_user_id is None

--- a/Server/tests/test_node_factory.py
+++ b/Server/tests/test_node_factory.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import database, node_credentials
+from app.auth.service import create_user, init_auth_storage
+from app.config import settings
+from app import node_builder
+
+
+class _NoopBus:
+    def __getattr__(self, name: str):  # pragma: no cover - simple stub
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+@pytest.fixture()
+def admin_client(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import app.mqtt_bus
+    import app.registry as registry_module
+    import app.motion
+    import app.status_monitor
+    from app.main import app as fastapi_app
+
+    monkeypatch.setattr(app.mqtt_bus, "MqttBus", lambda *args, **kwargs: _NoopBus())
+
+    registry_data: List[Dict] = [
+        {
+            "id": "alpha",
+            "name": "Alpha House",
+            "external_id": "alpha-public",
+            "rooms": [
+                {"id": "living", "name": "Living Room", "nodes": []},
+            ],
+        }
+    ]
+
+    registry_file = tmp_path / "registry.json"
+    registry_file.write_text(json.dumps(registry_data))
+    monkeypatch.setattr(settings, "REGISTRY_FILE", registry_file)
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", registry_data[:])
+    monkeypatch.setattr(registry_module.settings, "REGISTRY_FILE", registry_file)
+    monkeypatch.setattr(registry_module.settings, "DEVICE_REGISTRY", registry_data[:])
+    registry_module.ensure_house_external_ids(persist=False)
+
+    monkeypatch.setattr(app.motion.motion_manager, "start", lambda: None)
+    monkeypatch.setattr(app.motion.motion_manager, "stop", lambda: None)
+    monkeypatch.setattr(app.status_monitor.status_monitor, "start", lambda: None)
+    monkeypatch.setattr(app.status_monitor.status_monitor, "stop", lambda: None)
+
+    db_path = tmp_path / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+    original_db_url = settings.AUTH_DB_URL
+    database.reset_session_factory(db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", db_url)
+    monkeypatch.setattr(node_builder.settings, "AUTH_DB_URL", db_url)
+    init_auth_storage()
+
+    with database.SessionLocal() as session:
+        create_user(session, "admin", "pass", server_admin=True)
+
+    with TestClient(fastapi_app, base_url="https://testserver") as client:
+        login = client.post(
+            "/login",
+            data={"username": "admin", "password": "pass"},
+            follow_redirects=False,
+        )
+        assert login.status_code == 303
+        yield client
+
+    database.reset_session_factory(original_db_url)
+
+
+def test_create_node_registrations(admin_client: TestClient):
+    payload = {
+        "count": 2,
+        "displayName": "Batch Node",
+        "hardware": {
+            "board": "esp32c3",
+            "ws2812": [
+                {"index": 0, "enabled": True, "gpio": 6, "pixels": 60},
+            ],
+            "white": [],
+            "rgb": [],
+            "overrides": {"CONFIG_UL_WIFI_RESET_BUTTON_GPIO": 0},
+        },
+    }
+
+    response = admin_client.post(
+        "/api/server-admin/node-factory/registrations",
+        json=payload,
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert len(data["nodes"]) == 2
+
+    with database.SessionLocal() as session:
+        regs = node_credentials.list_available_registrations(session)
+        assert len(regs) == 2
+        assert all(reg.hardware_metadata.get("board") == "esp32c3" for reg in regs)
+        assert all(reg.display_name.startswith("Batch Node") for reg in regs)
+
+
+def test_build_node_uses_metadata(admin_client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    with database.SessionLocal() as session:
+        entry = node_credentials.create_batch(
+            session,
+            1,
+            metadata=[{"board": "esp32", "ws2812": []}],
+        )[0]
+        node_id = entry.registration.node_id
+        session.expunge_all()
+
+    captured = {}
+
+    def _fake_build(session, node_id_arg, **kwargs):
+        captured["node_id"] = node_id_arg
+        captured["metadata"] = kwargs.get("metadata")
+        return node_builder.BuildResult(
+            command=["idf.py", "build"],
+            returncode=0,
+            stdout="ok",
+            stderr="",
+            cwd=node_builder.FIRMWARE_ROOT,
+            node_id=node_id_arg,
+            sdkconfig_path=node_builder.FIRMWARE_ROOT / "sdkconfig.test",
+            manifest_url="https://example.com/manifest",
+            download_id="download123",
+            target="esp32",
+        )
+
+    monkeypatch.setattr(node_builder, "build_individual_node", _fake_build)
+
+    response = admin_client.post(
+        "/api/server-admin/node-factory/build",
+        json={"nodeId": node_id, "skipBuild": True},
+    )
+
+    assert response.status_code == 200
+    assert captured["node_id"] == node_id
+    assert captured["metadata"]["board"] == "esp32"
+    payload = response.json()
+    assert payload["downloadId"] == "download123"
+    assert payload["returncode"] == 0
+
+
+def test_flash_node_invokes_builder(admin_client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    with database.SessionLocal() as session:
+        entry = node_credentials.create_batch(session, 1, metadata=[{"board": "esp32"}])[0]
+        node_id = entry.registration.node_id
+        session.expunge_all()
+
+    def _fake_flash(session, node_id_arg, **kwargs):
+        return node_builder.BuildResult(
+            command=["idf.py", "-p", kwargs["port"], "build", "flash"],
+            returncode=0,
+            stdout="flashed",
+            stderr="",
+            cwd=node_builder.FIRMWARE_ROOT,
+            node_id=node_id_arg,
+            sdkconfig_path=node_builder.FIRMWARE_ROOT / "sdkconfig.flash",
+            manifest_url="https://example.com/manifest",
+            download_id="download456",
+            target="esp32",
+        )
+
+    monkeypatch.setattr(node_builder, "first_time_flash", _fake_flash)
+
+    response = admin_client.post(
+        "/api/server-admin/node-factory/flash",
+        json={"nodeId": node_id, "port": "/dev/ttyUSB0"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["stdout"].startswith("flashed")
+    assert payload["downloadId"] == "download456"
+
+
+def test_update_all_nodes(admin_client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    def _fake_update(version: str):
+        return node_builder.CommandResult(
+            command=["updateAllNodes.sh", version],
+            returncode=0,
+            stdout="ok",
+            stderr="",
+            cwd=node_builder.FIRMWARE_ROOT,
+        )
+
+    monkeypatch.setattr(node_builder, "update_all_nodes", _fake_update)
+
+    response = admin_client.post(
+        "/api/server-admin/node-factory/update-all",
+        json={"firmwareVersion": "2024.07"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["returncode"] == 0
+    assert payload["message"].startswith("Bulk firmware update")

--- a/UltraNodeV5/components/ul_mqtt/CMakeLists.txt
+++ b/UltraNodeV5/components/ul_mqtt/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "ul_mqtt.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES mqtt json nvs_flash esp_event esp_timer ul_core ul_ws_engine ul_white_engine ul_rgb_engine ul_ota ul_state
+                       REQUIRES mqtt json nvs_flash esp_event esp_timer ul_core ul_wifi ul_ws_engine ul_white_engine ul_rgb_engine ul_ota ul_state
                        PRIV_REQUIRES ul_health)

--- a/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
+++ b/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
@@ -112,6 +112,23 @@ esp_err_t esp_mqtt_client_start(esp_mqtt_client_handle_t client);
 esp_err_t esp_mqtt_client_stop(esp_mqtt_client_handle_t client);
 esp_err_t esp_mqtt_client_destroy(esp_mqtt_client_handle_t client);
 
+typedef struct {
+  char ssid[33];
+  char password[65];
+  char user[65];
+  char user_password[129];
+} ul_wifi_credentials_t;
+
+static inline bool ul_wifi_credentials_load(ul_wifi_credentials_t *out) {
+  if (!out)
+    return false;
+  out->ssid[0] = '\0';
+  out->password[0] = '\0';
+  out->user[0] = '\0';
+  out->user_password[0] = '\0';
+  return false;
+}
+
 bool ul_core_is_connected(void);
 void ul_health_notify_mqtt(bool connected);
 

--- a/UltraNodeV5/components/ul_provisioning/portal_index.html
+++ b/UltraNodeV5/components/ul_provisioning/portal_index.html
@@ -13,17 +13,30 @@
 </style>
 <body>
   <h1>Connect UltraLights to Wi-Fi</h1>
-  <p>Choose your home network, enter the password, and tap Connect.</p>
+  <p>Choose your home network, enter the password, and provide your UltraLights account credentials to finish setup.</p>
   <div class="row">
     <label for="ssid">Network</label>
     <select id="ssid"></select>
     <button id="rescan">Rescan</button>
   </div>
   <div class="row">
-    <label for="pwd">Password</label>
+    <label for="pwd">Wi-Fi Password</label>
     <input id="pwd" type="password" autocomplete="off" />
     <label style="font-weight: normal; margin-top: 8px;">
-      <input id="show" type="checkbox" /> Show password
+      <input id="showWifi" type="checkbox" /> Show Wi-Fi password
+    </label>
+  </div>
+  <h2 style="font-size: 1.2rem; margin-top: 32px;">UltraLights Account</h2>
+  <p>These credentials are sent securely to UltraLights to associate this device with your account.</p>
+  <div class="row">
+    <label for="user">Username</label>
+    <input id="user" type="text" autocomplete="username" />
+  </div>
+  <div class="row">
+    <label for="accountPassword">Account Password</label>
+    <input id="accountPassword" type="password" autocomplete="current-password" />
+    <label style="font-weight: normal; margin-top: 8px;">
+      <input id="showAccountPassword" type="checkbox" /> Show account password
     </label>
   </div>
   <div class="row">
@@ -34,14 +47,20 @@
 <script>
 const ssidSel = document.getElementById('ssid');
 const pwd = document.getElementById('pwd');
+const user = document.getElementById('user');
+const accountPassword = document.getElementById('accountPassword');
 const log = document.getElementById('log');
 
 function setLog(message) {
   log.textContent = message;
 }
 
-document.getElementById('show').addEventListener('change', (ev) => {
+document.getElementById('showWifi').addEventListener('change', (ev) => {
   pwd.type = ev.target.checked ? 'text' : 'password';
+});
+
+document.getElementById('showAccountPassword').addEventListener('change', (ev) => {
+  accountPassword.type = ev.target.checked ? 'text' : 'password';
 });
 
 document.getElementById('rescan').addEventListener('click', () => scan());
@@ -75,8 +94,18 @@ async function provision() {
     setLog('Select a network first.');
     return;
   }
+  const username = user.value.trim();
+  const passwordValue = accountPassword.value;
+  if (!username) {
+    setLog('Enter your UltraLights username.');
+    return;
+  }
+  if (!passwordValue) {
+    setLog('Enter your UltraLights password.');
+    return;
+  }
   setLog('Sending credentials...');
-  const body = { ssid, password: pwd.value };
+  const body = { ssid, password: pwd.value, username, account_password: passwordValue };
   try {
     const resp = await fetch('/api/provision', {
       method: 'POST',

--- a/UltraNodeV5/components/ul_wifi/include/ul_wifi_credentials.h
+++ b/UltraNodeV5/components/ul_wifi/include/ul_wifi_credentials.h
@@ -11,6 +11,8 @@ extern "C" {
 typedef struct {
   char ssid[33];
   char password[65];
+  char user[65];
+  char user_password[129];
 } ul_wifi_credentials_t;
 
 bool ul_wifi_credentials_load(ul_wifi_credentials_t *out);

--- a/UltraNodeV5/sdkconfig.defaults
+++ b/UltraNodeV5/sdkconfig.defaults
@@ -1,5 +1,7 @@
 # ---- System ----
+CONFIG_UL_TARGET_CHIP="esp32"
 CONFIG_UL_IS_ESP32C3=n
+CONFIG_UL_IS_ESP32S3=n
 
 # ---- Node / Network ----
 CONFIG_UL_NODE_ID="node-id"

--- a/UltraNodeV5/tests/ul_core/test_ul_core_wifi_event_group_failure.c
+++ b/UltraNodeV5/tests/ul_core/test_ul_core_wifi_event_group_failure.c
@@ -25,6 +25,8 @@
 typedef struct {
   char ssid[33];
   char password[65];
+  char user[65];
+  char user_password[129];
 } ul_wifi_credentials_t;
 
 bool ul_wifi_credentials_load(ul_wifi_credentials_t *out) {


### PR DESCRIPTION
## Summary
- ensure init_auth_storage backfills missing account credential columns on the node_registrations table
- guard existing databases by auto-applying ALTER TABLE statements when new columns are absent

## Testing
- pytest Server/tests/test_ota_credentials.py

------
https://chatgpt.com/codex/tasks/task_e_68d6b12a2a948326bb709b85e019bc90