### PR TITLE
Source optional ESP-IDF export script during server startup

### DIFF
--- a/Server/.env
+++ b/Server/.env
@@ -12,6 +12,11 @@ LAN_PUBLIC_BASE=https://192.168.1.101
 SSL_CERTFILE=/etc/letsencrypt/live/lights.evm100.com/fullchain.pem
 SSL_KEYFILE=/etc/letsencrypt/live/lights.evm100.com/privkey.pem
 
+# ESP-IDF toolchain
+# Path to export.sh (or export.ps1 on Windows) so the firmware builder picks up
+# the correct idf.py environment. Leave empty to skip automatic sourcing.
+ESP_IDF_EXPORT_SCRIPT=
+
 # ---------------------------------------------------------------------------
 # MQTT broker
 # ---------------------------------------------------------------------------

--- a/Server/README.md
+++ b/Server/README.md
@@ -88,6 +88,18 @@ The broker is configured with Let's Encrypt certificates at
 connections. Clients rely on the system CA bundle, so additional certificate
 paths are unnecessary unless a custom trust store is desired.
 
+## ESP-IDF toolchain integration
+
+Firmware builds launched from the Node factory or helper scripts call `idf.py`
+inside the `UltraNodeV5` directory. To ensure the correct ESP-IDF Python
+environment and tooling are available, set `ESP_IDF_EXPORT_SCRIPT` in your
+`.env` file to the path of the ESP-IDF export script (e.g.
+`/opt/esp/idf/export.sh`). `runServer.sh` sources this script during startup so
+`idf.py` can locate `idf_component_manager`, the managed component registry, and
+other ESP-IDF dependencies. The variable is optional—when it is not provided the
+server runs normally but firmware builds will fail unless the ESP-IDF
+environment is preloaded through other means.
+
 ## Operational notes
 
 - Authentication and administrative actions are persisted to the `audit_logs`

--- a/Server/runServer.sh
+++ b/Server/runServer.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-source .venv/bin/activate
 set -euo pipefail
 
 # Load .env (KEY=VALUE lines). This exports everything without parsing hacks.
@@ -8,6 +7,28 @@ if [[ -f .env ]]; then
   # shellcheck disable=SC1091
   . ./.env
   set +a
+fi
+
+# Optionally source the ESP-IDF environment so idf.py uses the correct toolchain.
+if [[ -n "${ESP_IDF_EXPORT_SCRIPT:-}" ]]; then
+  if [[ -f "${ESP_IDF_EXPORT_SCRIPT}" ]]; then
+    # shellcheck disable=SC1090
+    if ! . "${ESP_IDF_EXPORT_SCRIPT}"; then
+      echo "WARNING: Failed to source ESP-IDF environment from ${ESP_IDF_EXPORT_SCRIPT}" >&2
+    fi
+  else
+    echo "WARNING: ESP_IDF_EXPORT_SCRIPT points to ${ESP_IDF_EXPORT_SCRIPT} but the file does not exist" >&2
+  fi
+fi
+
+# Activate the application virtual environment after sourcing ESP-IDF so uvicorn
+# continues using the server dependencies while idf.py picks up ESP-IDF's python.
+if [[ -d .venv ]]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+else
+  echo "ERROR: Python virtual environment missing (.venv). Run installServer.sh first." >&2
+  exit 1
 fi
 
 # Sanity: warn if JSON looks multiline (common mistake)


### PR DESCRIPTION
## Summary
- allow `runServer.sh` to source an optional ESP-IDF export script before activating the app virtualenv so firmware builds use the correct toolchain
- document the `ESP_IDF_EXPORT_SCRIPT` setting and add it to the default `.env`

## Testing
- pytest tests/test_node_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68d73e4bdaa88326a62be031fa7d529d