### PR TITLE
Fix duplicate variable definition in Wi-Fi credentials loader

### DIFF
--- a/UltraNodeV5/components/ul_wifi/ul_wifi_credentials.c
+++ b/UltraNodeV5/components/ul_wifi/ul_wifi_credentials.c
@@ -61,12 +61,12 @@ bool ul_wifi_credentials_load(ul_wifi_credentials_t *out) {
     return false;
   }
 
-  size_t pass_len = sizeof(out->user_password);
-  err = nvs_get_str(handle, "user_password", out->user_password, &pass_len);
+  size_t user_pass_len = sizeof(out->user_password);
+  err = nvs_get_str(handle, "user_password", out->user_password, &user_pass_len);
   if (err == ESP_ERR_NVS_NOT_FOUND) {
     // Fall back to legacy key name "secret" for compatibility.
-    pass_len = sizeof(out->user_password);
-    err = nvs_get_str(handle, "secret", out->user_password, &pass_len);
+    user_pass_len = sizeof(out->user_password);
+    err = nvs_get_str(handle, "secret", out->user_password, &user_pass_len);
     if (err == ESP_ERR_NVS_NOT_FOUND) {
       out->user_password[0] = '\0';
       err = ESP_OK;


### PR DESCRIPTION
## Summary
- rename the second password length variable in `ul_wifi_credentials_load` so it no longer shadows the first definition
- keep the legacy secret fallback logic working by reusing the new variable name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d749256a5c8326bd0ba28ff246b30f