### PR TITLE
Fix first_time_flash metadata handling for board selection

### DIFF
--- a/Server/app/node_builder.py
+++ b/Server/app/node_builder.py
@@ -609,7 +609,11 @@ def first_time_flash(
         clean_build=clean_build,
     )
 
-    env = _prepare_environment(str(metadata or {}).get("board", board or "esp32"))
+    metadata_payload = dict(metadata) if isinstance(metadata, dict) else {}
+    board_name = board or metadata_payload.get("board") or build_result.target or "esp32"
+    if not isinstance(board_name, str) or not board_name.strip():
+        board_name = build_result.target or "esp32"
+    env = _prepare_environment(str(board_name))
     env["SDKCONFIG"] = str(build_result.sdkconfig_path)
     if clean_build:
         clean_build_dir()

--- a/UltraNodeV5/components/ul_wifi/ul_wifi_credentials.c
+++ b/UltraNodeV5/components/ul_wifi/ul_wifi_credentials.c
@@ -61,12 +61,12 @@ bool ul_wifi_credentials_load(ul_wifi_credentials_t *out) {
     return false;
   }
 
-  size_t pass_len = sizeof(out->user_password);
-  err = nvs_get_str(handle, "user_password", out->user_password, &pass_len);
+  size_t user_pass_len = sizeof(out->user_password);
+  err = nvs_get_str(handle, "user_password", out->user_password, &user_pass_len);
   if (err == ESP_ERR_NVS_NOT_FOUND) {
     // Fall back to legacy key name "secret" for compatibility.
-    pass_len = sizeof(out->user_password);
-    err = nvs_get_str(handle, "secret", out->user_password, &pass_len);
+    user_pass_len = sizeof(out->user_password);
+    err = nvs_get_str(handle, "secret", out->user_password, &user_pass_len);
     if (err == ESP_ERR_NVS_NOT_FOUND) {
       out->user_password[0] = '\0';
       err = ESP_OK;


### PR DESCRIPTION
## Summary
- ensure `first_time_flash` normalizes optional metadata before choosing the board
- fall back to the build result target so flashing works even without metadata overrides

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d749256a5c8326bd0ba28ff246b30f