### PR TITLE
Ensure firmware CLI applies node-specific sdkconfig

### DIFF
--- a/Server/tests/test_firmware_cli.py
+++ b/Server/tests/test_firmware_cli.py
@@ -45,6 +45,9 @@ def _make_build_result(node_id: str, download_id: str) -> node_builder.BuildResu
         manifest_url=f"https://example.com/{download_id}/manifest.json",
         download_id=download_id,
         target="esp32",
+        metadata={},
+        ota_token="token",
+        sdkconfig_values={},
     )
 
 
@@ -105,6 +108,10 @@ def test_cli_build_invokes_builder_and_archiver(cli_environment, monkeypatch: py
     assert exit_code == 0
     assert calls["build"]["node"] == node_id
     assert calls["build"]["kwargs"]["firmware_version"] == "2024.09"
+    assert (
+        calls["build"]["kwargs"]["sdkconfig_paths"]
+        == firmware_cli.PROJECT_SDKCONFIG_PATHS
+    )
     assert calls["store"][0]["node_id"] == node_id
     assert Path(calls["store"][0]["firmware_dir"]) == firmware_dir
     assert Path(calls["store"][0]["archive_root"]) == archive_dir
@@ -131,6 +138,7 @@ def test_cli_update_all_builds_every_registration(cli_environment, monkeypatch: 
     def fake_build(session, node_id_arg, **kwargs):
         built_nodes.append(node_id_arg)
         download = node_downloads.get(node_id_arg, f"fallback-{len(built_nodes)}")
+        assert kwargs.get("sdkconfig_paths") == firmware_cli.PROJECT_SDKCONFIG_PATHS
         return _make_build_result(node_id_arg, download)
 
     def fake_store(**kwargs):

--- a/UltraNodeV5/components/ul_wifi/ul_wifi_credentials.c
+++ b/UltraNodeV5/components/ul_wifi/ul_wifi_credentials.c
@@ -61,12 +61,12 @@ bool ul_wifi_credentials_load(ul_wifi_credentials_t *out) {
     return false;
   }
 
-  size_t pass_len = sizeof(out->user_password);
-  err = nvs_get_str(handle, "user_password", out->user_password, &pass_len);
+  size_t user_pass_len = sizeof(out->user_password);
+  err = nvs_get_str(handle, "user_password", out->user_password, &user_pass_len);
   if (err == ESP_ERR_NVS_NOT_FOUND) {
     // Fall back to legacy key name "secret" for compatibility.
-    pass_len = sizeof(out->user_password);
-    err = nvs_get_str(handle, "secret", out->user_password, &pass_len);
+    user_pass_len = sizeof(out->user_password);
+    err = nvs_get_str(handle, "secret", out->user_password, &user_pass_len);
     if (err == ESP_ERR_NVS_NOT_FOUND) {
       out->user_password[0] = '\0';
       err = ESP_OK;

--- a/tools/firmware_cli/cli.py
+++ b/tools/firmware_cli/cli.py
@@ -17,6 +17,10 @@ from app.auth.models import NodeRegistration  # noqa: E402
 from app.config import settings  # noqa: E402
 from sqlmodel import select  # noqa: E402
 
+PROJECT_SDKCONFIG_PATHS: tuple[Path, ...] = (
+    node_builder.FIRMWARE_ROOT / "sdkconfig",
+)
+
 
 def _resolve_paths(firmware_dir_arg: Optional[str], archive_dir_arg: Optional[str]) -> tuple[Path, Path]:
     firmware_dir = (
@@ -152,6 +156,7 @@ def _handle_build(args, firmware_dir: Path, archive_dir: Path) -> int:
                 run_build=True,
                 firmware_version=args.firmware_version,
                 clean_build=not args.no_clean,
+                sdkconfig_paths=PROJECT_SDKCONFIG_PATHS,
             )
         except node_builder.NodeBuilderError as exc:  # pragma: no cover - defensive
             print(f"error: {exc}", file=sys.stderr)
@@ -170,6 +175,10 @@ def _handle_build(args, firmware_dir: Path, archive_dir: Path) -> int:
         )
         print(f"Built {result.node_id} -> {artifact.manifest_path}")
         print(f"Binary SHA256: {artifact.sha256_hex}")
+        if result.project_configs:
+            print("Updated configuration files:")
+            for cfg in result.project_configs:
+                print(f"  - {cfg}")
         return 0
 
 
@@ -185,6 +194,7 @@ def _handle_flash(args, firmware_dir: Path, archive_dir: Path) -> int:
                 ota_token=None,
                 firmware_version=args.firmware_version,
                 clean_build=not args.no_clean,
+                sdkconfig_paths=PROJECT_SDKCONFIG_PATHS,
             )
         except node_builder.NodeBuilderError as exc:  # pragma: no cover - defensive
             print(f"error: {exc}", file=sys.stderr)
@@ -203,6 +213,10 @@ def _handle_flash(args, firmware_dir: Path, archive_dir: Path) -> int:
         )
         print(f"Flashed {result.node_id} ({args.port}) -> {artifact.manifest_path}")
         print(f"Binary SHA256: {artifact.sha256_hex}")
+        if result.project_configs:
+            print("Updated configuration files:")
+            for cfg in result.project_configs:
+                print(f"  - {cfg}")
         return 0
 
 
@@ -227,6 +241,7 @@ def _handle_update_all(args, firmware_dir: Path, archive_dir: Path) -> int:
                     run_build=True,
                     firmware_version=args.firmware_version,
                     clean_build=not args.no_clean,
+                    sdkconfig_paths=PROJECT_SDKCONFIG_PATHS,
                 )
             except node_builder.NodeBuilderError as exc:  # pragma: no cover - defensive
                 print(f"error: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- extend firmware build helpers to capture node metadata, ota tokens, and write node-specific values into sdkconfig files
- make the firmware CLI update the project sdkconfig before building or flashing and surface the touched config paths
- update CLI unit tests to exercise the new sdkconfig path plumbing

## Testing
- pytest Server/tests/test_firmware_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d749256a5c8326bd0ba28ff246b30f