### PR TITLE
Fix MotionManager disconnect callback signature

### DIFF
--- a/Server/app/motion.py
+++ b/Server/app/motion.py
@@ -188,7 +188,14 @@ class MotionManager:
         self._mqtt_connected = True
         logger.info("MotionManager MQTT connected: %s", reason_code)
 
-    def _on_disconnect(self, client, userdata, reason_code, properties=None) -> None:
+    def _on_disconnect(
+        self,
+        client,
+        userdata,
+        disconnect_flags,
+        reason_code,
+        properties=None,
+    ) -> None:
         if reason_code is None or int(reason_code) == 0:
             logger.info("MotionManager MQTT disconnected")
         else:


### PR DESCRIPTION
## Summary
- update MotionManager's MQTT disconnect callback signature to match Callback API v2

## Testing
- pytest Server/tests/test_motion.py *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68d767d3349483269300d921ed316b6e