### PR TITLE
Simplify node factory LEDC configuration

### DIFF
--- a/Server/app/routes_server_admin.py
+++ b/Server/app/routes_server_admin.py
@@ -223,7 +223,8 @@ class NodeFactoryListResponse(BaseModel):
 
 
 def _hardware_to_metadata(config: NodeHardwareConfig) -> Dict[str, Any]:
-    return config.model_dump(mode="python", by_alias=False, exclude_none=True)
+    raw = config.model_dump(mode="python", by_alias=False, exclude_none=True)
+    return node_builder.normalize_hardware_metadata(raw)
 
 
 def _registration_summary(registration: NodeRegistration) -> NodeFactoryRegistrationInfo:

--- a/Server/app/templates/server_admin.html
+++ b/Server/app/templates/server_admin.html
@@ -137,8 +137,9 @@
         </div>
         <div class="grid gap-4" data-channel-group="white" data-channel-type="white">
           <div class="text-sm font-semibold">White channels</div>
+          <p class="text-xs opacity-60">PWM frequency, LEDC channels, and output range are assigned automatically.</p>
           {% for idx in range(4) %}
-          <div class="grid gap-3 md:grid-cols-6 items-end" data-channel-row data-index="{{ idx }}">
+          <div class="grid gap-3 md:grid-cols-3 items-end" data-channel-row data-index="{{ idx }}">
             <label class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
               <input type="checkbox" data-channel-enabled>
               Enable {{ idx }}
@@ -147,64 +148,29 @@
               <span>GPIO</span>
               <input type="number" data-channel-field="gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
             </label>
-            <label class="block text-xs font-semibold">
-              <span>LEDC</span>
-              <input type="number" data-channel-field="ledc_channel" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
-            </label>
-            <label class="block text-xs font-semibold">
-              <span>PWM Hz</span>
-              <input type="number" data-channel-field="pwm_hz" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
-            </label>
-            <label class="block text-xs font-semibold">
-              <span>Min</span>
-              <input type="number" data-channel-field="minimum" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
-            </label>
-            <label class="block text-xs font-semibold">
-              <span>Max</span>
-              <input type="number" data-channel-field="maximum" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
-            </label>
           </div>
           {% endfor %}
         </div>
         <div class="grid gap-4" data-channel-group="rgb" data-channel-type="rgb">
           <div class="text-sm font-semibold">RGB channels</div>
+          <p class="text-xs opacity-60">PWM frequency, LEDC channels, and modes use board-specific defaults.</p>
           {% for idx in range(4) %}
-          <div class="grid gap-3 md:grid-cols-7 items-end" data-channel-row data-index="{{ idx }}">
+          <div class="grid gap-3 md:grid-cols-4 items-end" data-channel-row data-index="{{ idx }}">
             <label class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
               <input type="checkbox" data-channel-enabled>
               Enable {{ idx }}
-            </label>
-            <label class="block text-xs font-semibold">
-              <span>PWM Hz</span>
-              <input type="number" data-channel-field="pwm_hz" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
-            </label>
-            <label class="block text-xs font-semibold">
-              <span>Mode</span>
-              <input type="number" data-channel-field="ledc_mode" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
             </label>
             <label class="block text-xs font-semibold">
               <span>R GPIO</span>
               <input type="number" data-channel-field="r_gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
             </label>
             <label class="block text-xs font-semibold">
-              <span>R LEDC</span>
-              <input type="number" data-channel-field="r_ledc_ch" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
-            </label>
-            <label class="block text-xs font-semibold">
               <span>G GPIO</span>
               <input type="number" data-channel-field="g_gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
             </label>
             <label class="block text-xs font-semibold">
-              <span>G LEDC</span>
-              <input type="number" data-channel-field="g_ledc_ch" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
-            </label>
-            <label class="block text-xs font-semibold">
               <span>B GPIO</span>
               <input type="number" data-channel-field="b_gpio" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
-            </label>
-            <label class="block text-xs font-semibold">
-              <span>B LEDC</span>
-              <input type="number" data-channel-field="b_ledc_ch" class="mt-1 w-full bg-slate-900/60 border border-slate-700 rounded px-2 py-1">
             </label>
           </div>
           {% endfor %}


### PR DESCRIPTION
## Summary
- remove manual LEDC and PWM inputs from the node factory form and document the automatic defaults
- normalize hardware metadata so LEDC channels, PWM frequencies, and white range defaults are derived automatically per board
- ensure node factory metadata storage and sdkconfig generation use the normalized defaults

## Testing
- pytest Server *(fails: known API endpoints now require pre-registered nodes, returning HTTP 501)*

------
https://chatgpt.com/codex/tasks/task_e_68d769572bd08326a3b9b4910392ee85