### PR TITLE
Normalize node metadata for firmware builds

### DIFF
--- a/Server/app/node_builder.py
+++ b/Server/app/node_builder.py
@@ -704,8 +704,8 @@ def build_individual_node(
     metadata_payload = metadata or dict(registration.hardware_metadata or {})
     if board:
         metadata_payload["board"] = board
-    else:
-        metadata_payload.setdefault("board", "esp32")
+
+    metadata_payload = normalize_hardware_metadata(metadata_payload)
 
     metadata_serialized = json.dumps(
         metadata_payload or {}, separators=(",", ":"), sort_keys=True

--- a/Server/app/routes_server_admin.py
+++ b/Server/app/routes_server_admin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -559,7 +560,7 @@ def create_node_factory_registrations(
             registration.display_name = display_name
             needs_commit = True
 
-        registration.hardware_metadata = metadata.copy()
+        registration.hardware_metadata = copy.deepcopy(metadata)
         needs_commit = True
 
         if (
@@ -588,7 +589,7 @@ def create_node_factory_registrations(
                 downloadId=registration.download_id,
                 otaToken=entry.plaintext_token,
                 manifestUrl=manifest_url,
-                metadata=metadata.copy(),
+                metadata=copy.deepcopy(metadata),
             )
         )
         node_ids.append(registration.node_id)

--- a/tools/firmware_cli/cli.py
+++ b/tools/firmware_cli/cli.py
@@ -229,7 +229,9 @@ def _handle_update_all(args, firmware_dir: Path, archive_dir: Path) -> int:
 
         exit_code = 0
         for registration in registrations:
-            metadata = dict(registration.hardware_metadata or {})
+            metadata = node_builder.normalize_hardware_metadata(
+                dict(registration.hardware_metadata or {})
+            )
             board = metadata.get("board") if isinstance(metadata.get("board"), str) else None
             try:
                 result = node_builder.build_individual_node(


### PR DESCRIPTION
## Summary
- ensure Node Factory persists independent hardware metadata snapshots for each registration and API response
- normalize stored hardware metadata before generating firmware to keep GPIO assignments intact across builds
- update the firmware CLI to normalize metadata for mass builds before invoking the builder

## Testing
- `pytest Server/tests` *(fails: 3 tests in Server/tests/test_admin_api.py expecting API node creation support, but route currently raises HTTP 501)*

------
https://chatgpt.com/codex/tasks/task_e_68d85e68fae08326beaefcc332a6835a