### PR TITLE
Handle ReasonCode in MQTT disconnect gracefully

### DIFF
--- a/Server/app/motion.py
+++ b/Server/app/motion.py
@@ -196,7 +196,17 @@ class MotionManager:
         reason_code,
         properties=None,
     ) -> None:
-        if reason_code is None or int(reason_code) == 0:
+        clean_reason: Optional[int]
+        if reason_code is None:
+            clean_reason = None
+        else:
+            clean_reason = getattr(reason_code, "value", reason_code)
+            try:
+                clean_reason = int(clean_reason)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                clean_reason = None
+
+        if clean_reason in (None, 0):
             logger.info("MotionManager MQTT disconnected")
         else:
             logger.warning("MotionManager MQTT disconnected: %s", reason_code)


### PR DESCRIPTION
## Summary
- normalize MQTT disconnect reason codes to handle ReasonCode objects from paho 2.x
- prevent shutdown logging from raising TypeError by safely coercing the reason code value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8789bb1b483268aa872d29dd22667