### PR TITLE
Allow deleted nodes to be reassigned after credential migration

### DIFF
--- a/Server/app/node_credentials.py
+++ b/Server/app/node_credentials.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, select
 
 from . import registry
 from .auth.models import (
+    House,
     HouseMembership,
     NodeCredential,
     NodeRegistration,
@@ -699,9 +700,30 @@ def record_account_credentials(
     if not username or not password:
         raise ValueError("username and password are required")
 
+    credential = _get_by_node_id(session, node_id)
     registration = _get_registration_by_node_id(session, node_id)
+
+    created_registration = False
     if registration is None:
-        raise KeyError("node registration not found")
+        if credential is None:
+            raise KeyError("node registration not found")
+
+        registration = NodeRegistration(
+            node_id=credential.node_id,
+            download_id=credential.download_id,
+            token_hash=credential.token_hash,
+            created_at=credential.created_at,
+            token_issued_at=credential.token_issued_at,
+            provisioned_at=credential.provisioned_at,
+            house_slug=credential.house_slug or None,
+            room_id=credential.room_id or None,
+            display_name=credential.display_name or credential.node_id,
+        )
+        registration.assigned_at = credential.created_at
+        session.add(registration)
+        session.commit()
+        session.refresh(registration)
+        created_registration = True
 
     user = _first_result(session.exec(select(User).where(User.username == username)))
     if user is None:
@@ -720,6 +742,97 @@ def record_account_credentials(
         )
         return None
 
+    membership_candidates = session.exec(
+        select(HouseMembership).where(HouseMembership.user_id == user.id)
+    ).all()
+
+    membership: Optional[HouseMembership] = None
+    if membership_candidates:
+        for candidate in membership_candidates:
+            if (
+                registration.assigned_house_id is not None
+                and candidate.house_id == registration.assigned_house_id
+            ):
+                membership = candidate
+                break
+        if membership is None:
+            membership = membership_candidates[0]
+
+    house_row: Optional[House] = None
+    if membership:
+        house_row = _first_result(
+            session.exec(select(House).where(House.id == membership.house_id))
+        )
+
+    previous_user_id = registration.assigned_user_id
+    previous_house_id = registration.assigned_house_id
+    previous_room_id = registration.room_id
+    previous_house_slug = (registration.house_slug or "").strip() or None
+
+    target_external_id: Optional[str] = None
+    target_slug: Optional[str] = None
+    if house_row and isinstance(house_row.external_id, str):
+        candidate_external = house_row.external_id.strip()
+        if candidate_external:
+            target_external_id = candidate_external
+            try:
+                _, candidate_slug = registry.require_house(candidate_external)
+            except KeyError:
+                target_slug = None
+            else:
+                target_slug = candidate_slug
+
+    existing_house, existing_room, existing_node = registry.find_node(node_id)
+    existing_external: Optional[str] = None
+    if existing_house is not None:
+        existing_external = registry.get_house_external_id(existing_house)
+
+    existing_modules: Optional[List[str]] = None
+    existing_name: Optional[str] = None
+    if isinstance(existing_node, dict):
+        raw_modules = existing_node.get("modules")
+        if isinstance(raw_modules, list):
+            cleaned_modules = [
+                str(entry).strip()
+                for entry in raw_modules
+                if isinstance(entry, str) and entry.strip()
+            ]
+            existing_modules = cleaned_modules or None
+        raw_name = existing_node.get("name")
+        if isinstance(raw_name, str) and raw_name.strip():
+            existing_name = raw_name.strip()
+
+    metadata = (
+        registration.hardware_metadata
+        if isinstance(registration.hardware_metadata, dict)
+        else {}
+    )
+    metadata_modules: Optional[List[str]] = None
+    modules_value = metadata.get("modules") if isinstance(metadata, dict) else None
+    if isinstance(modules_value, list):
+        cleaned_meta = [
+            str(entry).strip()
+            for entry in modules_value
+            if str(entry).strip()
+        ]
+        metadata_modules = cleaned_meta or None
+
+    should_clear_assignment = created_registration
+    if previous_user_id is not None and previous_user_id != user.id:
+        should_clear_assignment = True
+    if previous_room_id and previous_user_id != user.id:
+        should_clear_assignment = True
+    if membership and previous_house_id not in (None, membership.house_id):
+        should_clear_assignment = True
+    if target_slug and previous_house_slug and previous_house_slug != target_slug:
+        should_clear_assignment = True
+    if (
+        target_external_id
+        and existing_external
+        and existing_external != target_external_id
+    ):
+        should_clear_assignment = True
+
     hashed = hash_password(password)
     now = _now()
     changed = False
@@ -737,17 +850,77 @@ def record_account_credentials(
         registration.assigned_user_id = user.id
         changed = True
 
-    membership = _first_result(
-        session.exec(
-            select(HouseMembership).where(HouseMembership.user_id == user.id)
-        )
-    )
     if membership and registration.assigned_house_id != membership.house_id:
         registration.assigned_house_id = membership.house_id
         changed = True
 
+    credential_removed = False
+
+    if should_clear_assignment and credential is not None:
+        session.delete(credential)
+        credential_removed = True
+
+    display_name = registration.display_name or existing_name or registration.node_id
+    if not registration.display_name and display_name:
+        registration.display_name = display_name
+        changed = True
+
+    if target_slug and registration.house_slug != target_slug:
+        registration.house_slug = target_slug
+        changed = True
+
+    if should_clear_assignment and registration.room_id is not None:
+        registration.room_id = None
+        changed = True
+
+    if (
+        target_external_id
+        and (should_clear_assignment or registration.room_id is None or previous_room_id is None)
+    ):
+        if existing_external and existing_external != target_external_id:
+            try:
+                registry.remove_node(node_id)
+            except KeyError:
+                pass
+        modules = existing_modules or metadata_modules
+        try:
+            registry.move_node_to_unassigned(
+                node_id,
+                target_external_id,
+                name=display_name,
+                modules=modules,
+            )
+        except KeyError:
+            logging.warning(
+                "Unable to place node '%s' in house '%s'", node_id, target_external_id
+            )
+
+    if (
+        should_clear_assignment
+        or (target_external_id and existing_external and existing_external != target_external_id)
+    ):
+        try:
+            from .motion import motion_manager  # type: ignore
+        except Exception:  # pragma: no cover - defensive
+            motion_manager = None  # type: ignore[assignment]
+        else:
+            motion_manager.forget_node(node_id)
+
+        try:
+            from .status_monitor import status_monitor  # type: ignore
+        except Exception:  # pragma: no cover - defensive
+            status_monitor = None  # type: ignore[assignment]
+        else:
+            status_monitor.forget(node_id)
+
+    if registration.assigned_at is None or should_clear_assignment:
+        registration.assigned_at = now
+        changed = True
+
     if changed:
         session.add(registration)
+
+    if changed or credential_removed:
         session.commit()
         session.refresh(registration)
 
@@ -895,12 +1068,47 @@ def delete_credentials(session: Session, node_id: str) -> None:
     if credential is None and registration is None:
         return
 
+    credential_removed = False
+    registration_changed = False
+
     if credential is not None:
         session.delete(credential)
-    if registration is not None:
-        session.delete(registration)
+        credential_removed = True
 
-    session.commit()
+    if registration is not None:
+        cleared = False
+
+        if registration.assigned_user_id is not None:
+            registration.assigned_user_id = None
+            cleared = True
+        if registration.assigned_house_id is not None:
+            registration.assigned_house_id = None
+            cleared = True
+        if registration.house_slug is not None:
+            registration.house_slug = None
+            cleared = True
+        if registration.room_id is not None:
+            registration.room_id = None
+            cleared = True
+        if registration.assigned_at is not None:
+            registration.assigned_at = None
+            cleared = True
+        if registration.account_username is not None:
+            registration.account_username = None
+            cleared = True
+        if registration.account_password_hash is not None:
+            registration.account_password_hash = None
+            cleared = True
+        if registration.account_credentials_received_at is not None:
+            registration.account_credentials_received_at = None
+            cleared = True
+
+        if cleared:
+            session.add(registration)
+            registration_changed = True
+
+    if credential_removed or registration_changed:
+        session.commit()
 
 
 def list_unprovisioned(session: Session) -> List[NodeCredential]:

--- a/Server/tests/test_account_linker.py
+++ b/Server/tests/test_account_linker.py
@@ -11,7 +11,13 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from app import database, node_credentials, registry
 from app.account_linker import AccountLinker
-from app.auth.models import House, HouseMembership, HouseRole, NodeRegistration
+from app.auth.models import (
+    House,
+    HouseMembership,
+    HouseRole,
+    NodeCredential as NodeCredentialModel,
+    NodeRegistration,
+)
 from app.auth.service import create_user, init_auth_storage
 from app.config import settings
 
@@ -25,6 +31,7 @@ def account_env(tmp_path, monkeypatch):
         {
             "id": "test-house",
             "name": "Test House",
+            "external_id": "test-house",
             "rooms": [],
         }
     ]
@@ -105,3 +112,230 @@ def test_handle_credentials_rejects_invalid_password(account_env):
         assert refreshed is not None
         assert refreshed.account_username is None
         assert refreshed.assigned_user_id is None
+
+
+def test_handle_credentials_migrates_between_users(account_env):
+    linker = AccountLinker()
+    with database.SessionLocal() as session:
+        legacy_owner = create_user(session, "legacy-owner", "oldpass", server_admin=False)
+        new_owner = create_user(session, "new-owner", "newpass", server_admin=False)
+        legacy_owner_id = legacy_owner.id
+        new_owner_id = new_owner.id
+
+        legacy_house = House(display_name="Legacy House", external_id="legacy-house")
+        session.add(legacy_house)
+        session.commit()
+        session.refresh(legacy_house)
+
+        membership_legacy = HouseMembership(
+            user_id=legacy_owner.id,
+            house_id=legacy_house.id,
+            role=HouseRole.ADMIN,
+        )
+        session.add(membership_legacy)
+        session.commit()
+
+        new_house_id = _create_membership(session, new_owner_id)
+
+        registration = _create_registration(session)
+        node_id = registration.node_id
+        registration.assigned_user_id = legacy_owner_id
+        registration.assigned_house_id = legacy_house.id
+        registration.house_slug = legacy_house.external_id
+        registration.room_id = "living"
+        registration.display_name = "Legacy Node"
+        session.add(registration)
+        session.commit()
+        session.refresh(registration)
+
+        credential_row = NodeCredentialModel(
+            node_id=node_id,
+            house_slug=legacy_house.external_id,
+            room_id="living",
+            display_name="Legacy Node",
+            download_id=registration.download_id,
+            token_hash=registration.token_hash,
+        )
+        session.add(credential_row)
+        session.commit()
+
+    settings.DEVICE_REGISTRY.append(
+        {
+            "id": "legacy-house",
+            "name": "Legacy House",
+            "external_id": "legacy-house",
+            "rooms": [
+                {
+                    "id": "living",
+                    "name": "Living Room",
+                    "nodes": [
+                        {"id": node_id, "name": "Legacy Node"},
+                    ],
+                }
+            ],
+        }
+    )
+
+    result = linker.handle_credentials(node_id, "new-owner", "newpass")
+    assert result is not None
+
+    with database.SessionLocal() as session:
+        refreshed = node_credentials.get_registration_by_node_id(session, node_id)
+        assert refreshed is not None
+        assert refreshed.assigned_user_id == new_owner_id
+        assert refreshed.assigned_house_id == new_house_id
+        assert refreshed.room_id is None
+        assert refreshed.house_slug == "test-house"
+        assert node_credentials.get_by_node_id(session, node_id) is None
+
+    house_entry, room_entry, node_entry = registry.find_node(node_id)
+    assert house_entry is not None
+    assert registry.get_house_external_id(house_entry) == "test-house"
+    assert room_entry is None
+    assert isinstance(node_entry, dict)
+    assert node_entry.get("id") == node_id
+
+    legacy_entry = next(
+        (house for house in settings.DEVICE_REGISTRY if house.get("id") == "legacy-house"),
+        None,
+    )
+    if legacy_entry:
+        for room in legacy_entry.get("rooms", []):
+            for node in room.get("nodes", []) or []:
+                assert node.get("id") != node_id
+
+
+def test_handle_credentials_recreates_missing_registration(account_env):
+    linker = AccountLinker()
+    with database.SessionLocal() as session:
+        owner = create_user(session, "recover", "secret", server_admin=False)
+        house_id = _create_membership(session, owner.id)
+        user_id = owner.id
+
+        registration = _create_registration(session)
+        node_id = registration.node_id
+        download_id = registration.download_id
+        token_hash = registration.token_hash
+        session.refresh(registration)
+
+        credential_row = NodeCredentialModel(
+            node_id=node_id,
+            house_slug="test-house",
+            room_id="den",
+            display_name="Recovered Node",
+            download_id=download_id,
+            token_hash=token_hash,
+        )
+        session.add(credential_row)
+        session.commit()
+
+        session.delete(registration)
+        session.commit()
+
+    settings.DEVICE_REGISTRY[0]["rooms"] = [
+        {
+            "id": "den",
+            "name": "Den",
+            "nodes": [
+                {"id": node_id, "name": "Recovered Node"},
+            ],
+        }
+    ]
+
+    result = linker.handle_credentials(node_id, "recover", "secret")
+    assert result is not None
+
+    with database.SessionLocal() as session:
+        refreshed = node_credentials.get_registration_by_node_id(session, node_id)
+        assert refreshed is not None
+        assert refreshed.assigned_user_id == user_id
+        assert refreshed.assigned_house_id == house_id
+        assert refreshed.room_id is None
+        assert refreshed.house_slug == "test-house"
+        assert node_credentials.get_by_node_id(session, node_id) is None
+
+    house_entry, room_entry, node_entry = registry.find_node(node_id)
+    assert house_entry is not None
+    assert registry.get_house_external_id(house_entry) == "test-house"
+    assert room_entry is None
+    assert isinstance(node_entry, dict)
+    assert node_entry.get("id") == node_id
+
+
+def test_handle_credentials_after_deletion(account_env):
+    linker = AccountLinker()
+    with database.SessionLocal() as session:
+        legacy_owner = create_user(session, "legacy", "oldpass", server_admin=False)
+        new_owner = create_user(session, "return", "newpass", server_admin=False)
+        new_owner_id = new_owner.id
+
+        legacy_house = House(display_name="Legacy House", external_id="legacy-house")
+        session.add(legacy_house)
+        session.commit()
+        session.refresh(legacy_house)
+
+        membership_legacy = HouseMembership(
+            user_id=legacy_owner.id,
+            house_id=legacy_house.id,
+            role=HouseRole.ADMIN,
+        )
+        session.add(membership_legacy)
+        session.commit()
+
+        new_house_id = _create_membership(session, new_owner.id)
+
+        registration = _create_registration(session)
+        node_id = registration.node_id
+        registration.assigned_user_id = legacy_owner.id
+        registration.assigned_house_id = legacy_house.id
+        registration.house_slug = legacy_house.external_id
+        registration.room_id = "office"
+        registration.display_name = "Returning Node"
+        registration.assigned_at = registration.created_at
+        session.add(registration)
+        session.commit()
+        session.refresh(registration)
+
+        credential_row = NodeCredentialModel(
+            node_id=node_id,
+            house_slug=legacy_house.external_id,
+            room_id="office",
+            display_name="Returning Node",
+            download_id=registration.download_id,
+            token_hash=registration.token_hash,
+        )
+        session.add(credential_row)
+        session.commit()
+
+        node_credentials.delete_credentials(session, node_id)
+
+        refreshed = node_credentials.get_registration_by_node_id(session, node_id)
+        assert refreshed is not None
+        assert refreshed.assigned_user_id is None
+        assert refreshed.assigned_house_id is None
+        assert refreshed.house_slug is None
+        assert refreshed.room_id is None
+        assert refreshed.account_username is None
+        assert refreshed.account_password_hash is None
+        assert refreshed.account_credentials_received_at is None
+        assert refreshed.assigned_at is None
+        assert node_credentials.get_by_node_id(session, node_id) is None
+
+    result = linker.handle_credentials(node_id, "return", "newpass")
+    assert result is not None
+
+    with database.SessionLocal() as session:
+        reassigned = node_credentials.get_registration_by_node_id(session, node_id)
+        assert reassigned is not None
+        assert reassigned.assigned_user_id == new_owner_id
+        assert reassigned.assigned_house_id == new_house_id
+        assert reassigned.room_id is None
+        assert reassigned.house_slug == "test-house"
+        assert node_credentials.get_by_node_id(session, node_id) is None
+
+    house_entry, room_entry, node_entry = registry.find_node(node_id)
+    assert house_entry is not None
+    assert registry.get_house_external_id(house_entry) == "test-house"
+    assert room_entry is None
+    assert isinstance(node_entry, dict)
+    assert node_entry.get("id") == node_id


### PR DESCRIPTION
## Summary
- preserve node registration metadata when credentials are deleted so removed nodes can be re-associated when they report account credentials
- cover the removal-and-reclaim workflow with a regression test that verifies deleted nodes migrate to the new owner’s house

## Testing
- pytest Server/tests/test_account_linker.py

------
https://chatgpt.com/codex/tasks/task_e_68d874942f648326a7441dd24873613e