### PR TITLE
Normalize authentication usernames to lowercase

### DIFF
--- a/Server/app/auth/security.py
+++ b/Server/app/auth/security.py
@@ -68,12 +68,21 @@ def needs_rehash(hashed_password: str) -> bool:
     return _pwd_context.needs_update(hashed_password)
 
 
+def normalize_username(value: object) -> str:
+    """Normalize ``value`` into a lowercase username string."""
+
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
 def authenticate_user(session: Session, username: str, password: str) -> Optional[User]:
     """Return the ``User`` that matches ``username``/``password`` or ``None``."""
 
-    if not username or not password:
+    normalized = normalize_username(username)
+    if not normalized or not password:
         return None
-    statement = select(User).where(User.username == username)
+    statement = select(User).where(User.username == normalized)
     user = session.exec(statement).first()
     if not user:
         return None

--- a/Server/app/auth/service.py
+++ b/Server/app/auth/service.py
@@ -10,7 +10,7 @@ from .. import node_credentials, registry
 from ..config import settings
 from .. import database
 from .models import AuditLog, House, User
-from .security import hash_password
+from .security import hash_password, normalize_username
 
 
 def init_auth_storage() -> None:
@@ -34,7 +34,7 @@ def _seed_initial_admin(session: Session) -> None:
     if existing_admin:
         return
 
-    username = settings.INITIAL_ADMIN_USERNAME
+    username = normalize_username(settings.INITIAL_ADMIN_USERNAME)
     password = settings.INITIAL_ADMIN_PASSWORD
 
     if not username or not password:
@@ -113,8 +113,12 @@ def create_user(
 ) -> User:
     """Create a new ``User`` and return it."""
 
+    normalized_username = normalize_username(username)
+    if not normalized_username:
+        raise ValueError("username cannot be empty")
+
     user = User(
-        username=username,
+        username=normalized_username,
         hashed_password=hash_password(password),
         server_admin=server_admin,
     )

--- a/Server/app/node_credentials.py
+++ b/Server/app/node_credentials.py
@@ -17,7 +17,7 @@ from .auth.models import (
     NodeRegistration,
     User,
 )
-from .auth.security import hash_password, verify_password
+from .auth.security import hash_password, normalize_username, verify_password
 
 
 @dataclass
@@ -695,7 +695,7 @@ def record_account_credentials(
 ) -> Optional[NodeRegistration]:
     """Persist account credentials observed from firmware."""
 
-    username = (username or "").strip()
+    username = normalize_username(username)
     password = password or ""
     if not username or not password:
         raise ValueError("username and password are required")

--- a/Server/tests/auth/test_auth_models.py
+++ b/Server/tests/auth/test_auth_models.py
@@ -30,7 +30,7 @@ def test_init_auth_storage_seeds_admin(tmp_path, monkeypatch) -> None:
     db_path = Path(tmp_path) / "auth.sqlite3"
     db_url = f"sqlite:///{db_path}"
 
-    monkeypatch.setattr(settings, "INITIAL_ADMIN_USERNAME", "seed-admin")
+    monkeypatch.setattr(settings, "INITIAL_ADMIN_USERNAME", "Seed-Admin")
     monkeypatch.setattr(settings, "INITIAL_ADMIN_PASSWORD", "ultra-secret")
 
     database_module.reset_session_factory(db_url)
@@ -42,8 +42,9 @@ def test_init_auth_storage_seeds_admin(tmp_path, monkeypatch) -> None:
             assert admin.hashed_password != settings.INITIAL_ADMIN_PASSWORD
             assert verify_password("ultra-secret", admin.hashed_password)
 
-            guest = create_user(session, "guest-user", "guest-pass")
+            guest = create_user(session, "Guest-User", "guest-pass")
             assert guest.id is not None
+            assert guest.username == "guest-user"
             assert verify_password("guest-pass", guest.hashed_password)
     finally:
         database_module.reset_session_factory(original_url)


### PR DESCRIPTION
## Summary
- normalize usernames through shared helper so they are stored in lowercase
- update user creation, login, and node credential flows to use the normalized form
- adjust auth tests to cover uppercase input normalization

## Testing
- pytest tests/auth/test_auth_models.py

------
https://chatgpt.com/codex/tasks/task_e_68d898eca42083269859073772deab6e