### PR TITLE
Auto-refresh admin view after unassigning nodes

### DIFF
--- a/Server/app/templates/admin.html
+++ b/Server/app/templates/admin.html
@@ -719,6 +719,7 @@ document.querySelectorAll('[data-node-unassign]').forEach((btn) => {
         btn.disabled = false;
       }, 1500);
       refreshStatuses();
+      location.reload();
     } catch (err) {
       console.error('Failed to unassign node', err);
       btn.disabled = false;


### PR DESCRIPTION
## Summary
- trigger a page reload after successfully unassigning a node so it reappears automatically in the unassigned list

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8a5ca5b9c8326a42c3117e37af61c