### PR TITLE
Support enterprise Wi-Fi credentials in provisioning

### DIFF
--- a/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
+++ b/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
@@ -117,6 +117,8 @@ typedef struct {
   char password[65];
   char user[65];
   char user_password[129];
+  char wifi_username[65];
+  char wifi_user_password[129];
 } ul_wifi_credentials_t;
 
 static inline bool ul_wifi_credentials_load(ul_wifi_credentials_t *out) {
@@ -126,6 +128,8 @@ static inline bool ul_wifi_credentials_load(ul_wifi_credentials_t *out) {
   out->password[0] = '\0';
   out->user[0] = '\0';
   out->user_password[0] = '\0';
+  out->wifi_username[0] = '\0';
+  out->wifi_user_password[0] = '\0';
   return false;
 }
 

--- a/UltraNodeV5/components/ul_provisioning/portal_index.html
+++ b/UltraNodeV5/components/ul_provisioning/portal_index.html
@@ -26,6 +26,10 @@
       <input id="showWifi" type="checkbox" /> Show Wi-Fi password
     </label>
   </div>
+  <div class="row" id="wifiUserRow" style="display: none;">
+    <label for="wifiUser">Wi-Fi Username</label>
+    <input id="wifiUser" type="text" autocomplete="off" />
+  </div>
   <h2 style="font-size: 1.2rem; margin-top: 32px;">UltraLights Account</h2>
   <p>These credentials are sent securely to UltraLights to associate this device with your account.</p>
   <div class="row">
@@ -47,9 +51,12 @@
 <script>
 const ssidSel = document.getElementById('ssid');
 const pwd = document.getElementById('pwd');
+const wifiUserRow = document.getElementById('wifiUserRow');
+const wifiUser = document.getElementById('wifiUser');
 const user = document.getElementById('user');
 const accountPassword = document.getElementById('accountPassword');
 const log = document.getElementById('log');
+let scannedAps = [];
 
 function setLog(message) {
   log.textContent = message;
@@ -65,6 +72,22 @@ document.getElementById('showAccountPassword').addEventListener('change', (ev) =
 
 document.getElementById('rescan').addEventListener('click', () => scan());
 document.getElementById('provision').addEventListener('click', () => provision());
+ssidSel.addEventListener('change', () => updateNetworkFields());
+
+function getSelectedNetwork() {
+  const selectedSsid = ssidSel.value;
+  if (!selectedSsid) return null;
+  return scannedAps.find((ap) => ap.ssid === selectedSsid) || null;
+}
+
+function updateNetworkFields() {
+  const selected = getSelectedNetwork();
+  const needsUsername = !!(selected && selected.requires_username);
+  wifiUserRow.style.display = needsUsername ? 'block' : 'none';
+  if (!needsUsername) {
+    wifiUser.value = '';
+  }
+}
 
 async function scan() {
   try {
@@ -72,16 +95,21 @@ async function scan() {
     const response = await fetch('/api/scan');
     if (!response.ok) throw new Error('scan failed');
     const data = await response.json();
+    scannedAps = Array.isArray(data.aps) ? data.aps : [];
     ssidSel.innerHTML = '';
-    (data.aps || []).sort((a, b) => b.rssi - a.rssi).forEach(ap => {
+    scannedAps.sort((a, b) => b.rssi - a.rssi).forEach(ap => {
       const opt = document.createElement('option');
       opt.value = ap.ssid;
       opt.textContent = `${ap.ssid} (${ap.rssi} dBm)`;
+      if (ap.requires_username) {
+        opt.dataset.requiresUsername = '1';
+      }
       ssidSel.appendChild(opt);
     });
-    if (!ssidSel.value && data.aps && data.aps.length) {
-      ssidSel.value = data.aps[0].ssid;
+    if (!ssidSel.value && scannedAps.length) {
+      ssidSel.value = scannedAps[0].ssid;
     }
+    updateNetworkFields();
     setLog('Ready.');
   } catch (err) {
     setLog('Scan failed. Retry.');
@@ -93,6 +121,19 @@ async function provision() {
   if (!ssid) {
     setLog('Select a network first.');
     return;
+  }
+  const selectedNetwork = getSelectedNetwork();
+  const requiresUsername = !!(selectedNetwork && selectedNetwork.requires_username);
+  if (requiresUsername) {
+    const wifiUsername = wifiUser.value.trim();
+    if (!wifiUsername) {
+      setLog('Enter your Wi-Fi username.');
+      return;
+    }
+    if (!pwd.value) {
+      setLog('Enter your Wi-Fi password.');
+      return;
+    }
   }
   const username = user.value.trim();
   const passwordValue = accountPassword.value;
@@ -106,6 +147,10 @@ async function provision() {
   }
   setLog('Sending credentials...');
   const body = { ssid, password: pwd.value, username, account_password: passwordValue };
+  if (requiresUsername) {
+    body.wifi_username = wifiUser.value.trim();
+    body.wifi_user_password = pwd.value;
+  }
   try {
     const resp = await fetch('/api/provision', {
       method: 'POST',

--- a/UltraNodeV5/components/ul_provisioning/ul_provisioning.c
+++ b/UltraNodeV5/components/ul_provisioning/ul_provisioning.c
@@ -45,6 +45,11 @@ static char s_status_ip[16];
 static bool s_wifi_started;
 static bool s_wifi_initialised;
 static bool s_handlers_registered;
+static portMUX_TYPE s_scan_lock = portMUX_INITIALIZER_UNLOCKED;
+
+#define MAX_SCAN_RESULTS 32
+static wifi_ap_record_t s_last_scan_results[MAX_SCAN_RESULTS];
+static size_t s_last_scan_count;
 
 extern const uint8_t portal_index_html_start[] asm("_binary_portal_index_html_start");
 extern const uint8_t portal_index_html_end[] asm("_binary_portal_index_html_end");
@@ -119,6 +124,88 @@ static void copy_username_lowercase(char *dest, size_t dest_size,
   }
 }
 
+static bool authmode_requires_username(wifi_auth_mode_t mode) {
+  switch (mode) {
+#ifdef WIFI_AUTH_WPA2_ENTERPRISE
+  case WIFI_AUTH_WPA2_ENTERPRISE:
+#endif
+#ifdef WIFI_AUTH_WPA3_ENTERPRISE
+  case WIFI_AUTH_WPA3_ENTERPRISE:
+#endif
+#ifdef WIFI_AUTH_WPA2_WPA3_ENTERPRISE
+  case WIFI_AUTH_WPA2_WPA3_ENTERPRISE:
+#endif
+    return true;
+  default:
+    return false;
+  }
+}
+
+static const char *authmode_to_string(wifi_auth_mode_t mode) {
+  switch (mode) {
+  case WIFI_AUTH_OPEN:
+    return "open";
+  case WIFI_AUTH_WEP:
+    return "wep";
+  case WIFI_AUTH_WPA_PSK:
+    return "wpa_psk";
+  case WIFI_AUTH_WPA2_PSK:
+    return "wpa2_psk";
+  case WIFI_AUTH_WPA_WPA2_PSK:
+    return "wpa_wpa2_psk";
+#ifdef WIFI_AUTH_WPA2_ENTERPRISE
+  case WIFI_AUTH_WPA2_ENTERPRISE:
+    return "wpa2_enterprise";
+#endif
+#ifdef WIFI_AUTH_WPA3_PSK
+  case WIFI_AUTH_WPA3_PSK:
+    return "wpa3_psk";
+#endif
+#ifdef WIFI_AUTH_WPA2_WPA3_PSK
+  case WIFI_AUTH_WPA2_WPA3_PSK:
+    return "wpa2_wpa3_psk";
+#endif
+#ifdef WIFI_AUTH_WAPI_PSK
+  case WIFI_AUTH_WAPI_PSK:
+    return "wapi_psk";
+#endif
+#ifdef WIFI_AUTH_OWE
+  case WIFI_AUTH_OWE:
+    return "owe";
+#endif
+#ifdef WIFI_AUTH_WPA3_ENTERPRISE
+  case WIFI_AUTH_WPA3_ENTERPRISE:
+    return "wpa3_enterprise";
+#endif
+#ifdef WIFI_AUTH_WPA2_WPA3_ENTERPRISE
+  case WIFI_AUTH_WPA2_WPA3_ENTERPRISE:
+    return "wpa2_wpa3_enterprise";
+#endif
+  default:
+    return "unknown";
+  }
+}
+
+static bool lookup_authmode_for_ssid(const char *ssid, wifi_auth_mode_t *out_mode) {
+  if (!ssid)
+    return false;
+  bool found = false;
+  taskENTER_CRITICAL(&s_scan_lock);
+  for (size_t i = 0; i < s_last_scan_count; ++i) {
+    char rec_ssid[sizeof(s_last_scan_results[i].ssid)];
+    memcpy(rec_ssid, s_last_scan_results[i].ssid, sizeof(rec_ssid));
+    rec_ssid[sizeof(rec_ssid) - 1] = '\0';
+    if (strcmp(rec_ssid, ssid) == 0) {
+      if (out_mode)
+        *out_mode = s_last_scan_results[i].authmode;
+      found = true;
+      break;
+    }
+  }
+  taskEXIT_CRITICAL(&s_scan_lock);
+  return found;
+}
+
 static void append_hotspot_headers(httpd_req_t *req) {
   httpd_resp_set_hdr(req, "Cache-Control", "no-cache, no-store, must-revalidate");
 }
@@ -171,8 +258,8 @@ static esp_err_t scan_handler(httpd_req_t *req) {
 
   uint16_t num = 0;
   esp_wifi_scan_get_ap_num(&num);
-  if (num > 32)
-    num = 32;
+  if (num > MAX_SCAN_RESULTS)
+    num = MAX_SCAN_RESULTS;
   wifi_ap_record_t *records = NULL;
   if (num > 0) {
     records = calloc(num, sizeof(*records));
@@ -190,6 +277,15 @@ static esp_err_t scan_handler(httpd_req_t *req) {
     return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "scan failed");
   }
 
+  taskENTER_CRITICAL(&s_scan_lock);
+  if (num > 0) {
+    memcpy(s_last_scan_results, record_buf, num * sizeof(*record_buf));
+    s_last_scan_count = num;
+  } else {
+    s_last_scan_count = 0;
+  }
+  taskEXIT_CRITICAL(&s_scan_lock);
+
   cJSON *root = cJSON_CreateObject();
   cJSON *arr = cJSON_AddArrayToObject(root, "aps");
   for (uint16_t i = 0; i < num; ++i) {
@@ -200,6 +296,9 @@ static esp_err_t scan_handler(httpd_req_t *req) {
     ssid[sizeof(ssid) - 1] = '\0';
     cJSON_AddStringToObject(item, "ssid", ssid);
     cJSON_AddNumberToObject(item, "rssi", rec->rssi);
+    cJSON_AddStringToObject(item, "auth", authmode_to_string(rec->authmode));
+    cJSON_AddBoolToObject(item, "requires_username",
+                          authmode_requires_username(rec->authmode));
     cJSON_AddItemToArray(arr, item);
   }
   char *json = cJSON_PrintUnformatted(root);
@@ -244,11 +343,22 @@ static bool parse_body(httpd_req_t *req, char *buffer, size_t buffer_len, size_t
   return true;
 }
 
-static void begin_connect(const char *ssid, const char *password) {
+static void begin_connect(const char *ssid, const char *password, bool requires_username) {
   wifi_config_t sta_cfg = {0};
   strlcpy((char *)sta_cfg.sta.ssid, ssid, sizeof(sta_cfg.sta.ssid));
   strlcpy((char *)sta_cfg.sta.password, password, sizeof(sta_cfg.sta.password));
-  sta_cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+#ifdef WIFI_AUTH_WPA2_ENTERPRISE
+  wifi_auth_mode_t threshold = WIFI_AUTH_WPA2_PSK;
+  if (requires_username) {
+    threshold = WIFI_AUTH_WPA2_ENTERPRISE;
+  } else if (!password || password[0] == '\0') {
+    threshold = WIFI_AUTH_OPEN;
+  }
+#else
+  wifi_auth_mode_t threshold = (password && password[0] != '\0') ? WIFI_AUTH_WPA2_PSK : WIFI_AUTH_OPEN;
+  (void)requires_username;
+#endif
+  sta_cfg.sta.threshold.authmode = threshold;
   esp_wifi_disconnect();
   esp_err_t err = esp_wifi_set_mode(WIFI_MODE_APSTA);
   if (err != ESP_OK) {
@@ -281,6 +391,9 @@ static esp_err_t provision_handler(httpd_req_t *req) {
       cJSON_GetObjectItem(root, "account_password");
   const cJSON *username = cJSON_GetObjectItem(root, "username");
   const cJSON *wifi_password_json = cJSON_GetObjectItem(root, "password");
+  const cJSON *wifi_user_json = cJSON_GetObjectItem(root, "wifi_username");
+  const cJSON *wifi_user_password_json =
+      cJSON_GetObjectItem(root, "wifi_user_password");
   if (!ssid || !cJSON_IsString(ssid) || ssid->valuestring[0] == '\0') {
     cJSON_Delete(root);
     return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "missing ssid");
@@ -289,6 +402,10 @@ static esp_err_t provision_handler(httpd_req_t *req) {
       (wifi_password_json && cJSON_IsString(wifi_password_json))
           ? wifi_password_json->valuestring
           : "";
+  wifi_auth_mode_t authmode = WIFI_AUTH_OPEN;
+  bool authmode_found = lookup_authmode_for_ssid(ssid->valuestring, &authmode);
+  bool network_requires_username =
+      authmode_found && authmode_requires_username(authmode);
   if (!username || !cJSON_IsString(username) || username->valuestring[0] == '\0') {
     cJSON_Delete(root);
     return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "missing username");
@@ -302,6 +419,25 @@ static esp_err_t provision_handler(httpd_req_t *req) {
     return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "missing password");
   }
 
+  const char *wifi_user_str =
+      (wifi_user_json && cJSON_IsString(wifi_user_json)) ? wifi_user_json->valuestring : "";
+  const char *wifi_user_pass_str =
+      (wifi_user_password_json && cJSON_IsString(wifi_user_password_json))
+          ? wifi_user_password_json->valuestring
+          : "";
+  if (network_requires_username) {
+    if (wifi_user_str[0] == '\0') {
+      cJSON_Delete(root);
+      return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
+                                 "missing wifi username");
+    }
+    if (wifi_user_pass_str[0] == '\0') {
+      cJSON_Delete(root);
+      return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
+                                 "missing wifi user password");
+    }
+  }
+
   ul_wifi_credentials_t creds = {0};
   strlcpy(creds.ssid, ssid->valuestring, sizeof(creds.ssid));
   strlcpy(creds.password, wifi_pass_str, sizeof(creds.password));
@@ -309,12 +445,15 @@ static esp_err_t provision_handler(httpd_req_t *req) {
                           username->valuestring);
   strlcpy(creds.user_password, account_password_str,
           sizeof(creds.user_password));
+  strlcpy(creds.wifi_username, wifi_user_str, sizeof(creds.wifi_username));
+  strlcpy(creds.wifi_user_password, wifi_user_pass_str,
+          sizeof(creds.wifi_user_password));
   esp_err_t err = ul_wifi_credentials_save(&creds);
   if (err != ESP_OK) {
     cJSON_Delete(root);
     return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "persist failed");
   }
-  begin_connect(creds.ssid, creds.password);
+  begin_connect(creds.ssid, creds.password, network_requires_username);
   cJSON_Delete(root);
   httpd_resp_set_type(req, "application/json");
   return httpd_resp_sendstr(req, "{\"ok\":true}");

--- a/UltraNodeV5/components/ul_wifi/include/ul_wifi_credentials.h
+++ b/UltraNodeV5/components/ul_wifi/include/ul_wifi_credentials.h
@@ -13,6 +13,8 @@ typedef struct {
   char password[65];
   char user[65];
   char user_password[129];
+  char wifi_username[65];
+  char wifi_user_password[129];
 } ul_wifi_credentials_t;
 
 bool ul_wifi_credentials_load(ul_wifi_credentials_t *out);


### PR DESCRIPTION
## Summary
- detect enterprise-capable Wi-Fi networks during provisioning scans and retain auth metadata
- expose Wi-Fi username inputs in the captive portal when required and forward them to the provision API
- persist Wi-Fi user credentials in NVS alongside existing account details for later use

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68db0b118c9c8326bc1a82d533743a90