### PR TITLE
Add animated gradient glow effect to preset buttons

### DIFF
--- a/Server/app/static/app.css
+++ b/Server/app/static/app.css
@@ -88,6 +88,117 @@ label { font-size: .7rem; color: var(--muted); display: block; margin-bottom: .2
   background: linear-gradient(180deg, rgba(245,158,11,.75), rgba(245,158,11,.55));
 }
 
+.glow-button {
+  --glow-button-border: 3px;
+  --glow-button-speed: 6s;
+  --glow-button-hue-a: 280;
+  --glow-button-hue-b: 200;
+  --glow-button-hue-c: 140;
+  --glow-button-fill: rgba(15,23,42,.88);
+  --glow-button-text: #e8ecff;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .4rem;
+  padding: var(--glow-button-padding-y, 0.55rem) var(--glow-button-padding-x, 1.1rem);
+  border: none;
+  background: var(--glow-button-fill);
+  color: var(--glow-button-text);
+  font-weight: 600;
+  text-decoration: none;
+  isolation: isolate;
+  overflow: hidden;
+  cursor: pointer;
+  transition: filter .18s ease, transform .1s ease;
+  z-index: 0;
+}
+
+.glow-button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    conic-gradient(
+      from 0turn,
+      hsl(var(--glow-button-hue-a) 90% 60%),
+      hsl(var(--glow-button-hue-b) 90% 60%),
+      hsl(var(--glow-button-hue-c) 90% 60%),
+      hsl(var(--glow-button-hue-a) 90% 60%)
+    );
+  -webkit-mask:
+    radial-gradient(closest-side, transparent calc(100% - (var(--glow-button-border) + 1px)), #000 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask:
+    radial-gradient(closest-side, transparent calc(100% - (var(--glow-button-border) + 1px)), #000 0) content-box,
+    linear-gradient(#000 0 0);
+          mask-composite: exclude;
+  padding: var(--glow-button-border);
+  animation: glow-rotate var(--glow-button-speed) linear infinite;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.glow-button::after {
+  content: "";
+  position: absolute;
+  inset: -35%;
+  border-radius: inherit;
+  background:
+    conic-gradient(
+      from 0turn,
+      hsl(var(--glow-button-hue-a) 90% 60% / .5),
+      hsl(var(--glow-button-hue-b) 90% 60% / .5),
+      hsl(var(--glow-button-hue-c) 90% 60% / .5),
+      hsl(var(--glow-button-hue-a) 90% 60% / .5)
+    );
+  filter: blur(28px) saturate(120%);
+  animation: glow-rotate var(--glow-button-speed) linear infinite reverse;
+  z-index: -2;
+  pointer-events: none;
+}
+
+.glow-button:hover {
+  filter: brightness(1.05);
+}
+
+.glow-button:active {
+  transform: translateY(1px);
+}
+
+.glow-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(129,140,248,.45);
+}
+
+.glow-button[disabled] {
+  opacity: .6;
+  cursor: not-allowed;
+  filter: none;
+  transform: none;
+}
+
+.preset-button {
+  font-size: .75rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+@keyframes glow-rotate {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glow-button::before,
+  .glow-button::after {
+    animation: none;
+  }
+}
+
 .grid-nodes {
   display: grid; gap: .75rem; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
 }

--- a/Server/app/static/presets.js
+++ b/Server/app/static/presets.js
@@ -232,7 +232,7 @@ if (container) {
       wrapper.dataset.custom = isCustomPreset(preset) ? 'true' : 'false';
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'preset preset-button glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400';
+      button.className = 'preset preset-button glow-button rounded-lg';
       button.dataset.presetId = id;
       button.dataset.custom = wrapper.dataset.custom;
       button.textContent = name;

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -19,15 +19,15 @@
   <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
     <h2 class="text-2xl font-semibold">Presets</h2>
     <div class="flex items-center gap-2">
-      <button id="presetSaveButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400">Save Preset</button>
-      <button id="presetEditButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400" aria-pressed="false" aria-controls="presetList">Edit</button>
+      <button id="presetSaveButton" type="button" class="glow-button rounded-lg text-sm font-semibold tracking-wide uppercase">Save Preset</button>
+      <button id="presetEditButton" type="button" class="glow-button rounded-lg text-sm font-semibold tracking-wide uppercase" aria-pressed="false" aria-controls="presetList">Edit</button>
     </div>
   </div>
   <div id="presetStatus" class="text-sm mb-3 opacity-80" role="status" aria-live="polite"></div>
   <div id="presetList" class="flex flex-wrap gap-2" data-editing="false" data-house-id="{{ house_public_id }}" data-room-id="{{ room.id }}" data-api-base="/api/house/{{ house_public_id }}/room/{{ room.id }}" data-initial-presets='{{ presets|tojson }}'>
     {% for p in presets %}
     <div class="preset-item" data-preset-id="{{ p.id }}" data-custom="{{ 'true' if p.source == 'custom' else 'false' }}">
-      <button class="preset preset-button glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400" type="button" data-preset-id="{{ p.id }}">{{ p.name or p.id }}</button>
+      <button class="preset preset-button glow-button rounded-lg" type="button" data-preset-id="{{ p.id }}">{{ p.name or p.id }}</button>
       {% if p.source == 'custom' %}
       <button class="preset-delete" type="button" aria-hidden="true" tabindex="-1" hidden aria-label="Delete preset {{ p.name or p.id }}" data-preset-id="{{ p.id }}">✕</button>
       {% endif %}


### PR DESCRIPTION
## Summary
- add a reusable glow-button style that renders the rotating conic-gradient border and soft glow
- apply the new glow-button styling to preset management controls and keep preset editor JS in sync

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68db25ccfed083268da6cd50ade532c6