### PR TITLE
Refine glow-button styling to match animated halo design

### DIFF
--- a/Server/app/static/app.css
+++ b/Server/app/static/app.css
@@ -88,6 +88,142 @@ label { font-size: .7rem; color: var(--muted); display: block; margin-bottom: .2
   background: linear-gradient(180deg, rgba(245,158,11,.75), rgba(245,158,11,.55));
 }
 
+.glow-button {
+  --glow-button-border: 3px;
+  --glow-button-speed: 6s;
+  --glow-button-radius: 9999px;
+  --glow-button-hue-a: 280;
+  --glow-button-hue-b: 200;
+  --glow-button-hue-c: 140;
+  --glow-button-fill: linear-gradient(180deg, rgba(17, 23, 40, 0.95), rgba(11, 15, 28, 0.92));
+  --glow-button-text: #e8ecff;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .45rem;
+  padding: var(--glow-button-padding-y, 0.6rem) var(--glow-button-padding-x, 1.35rem);
+  border: none;
+  border-radius: var(--glow-button-radius);
+  background: var(--glow-button-fill);
+  color: var(--glow-button-text);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 2.5rem;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 10px 30px rgba(15, 23, 42, 0.35);
+  transition: filter .18s ease, transform .12s ease, box-shadow .18s ease;
+}
+
+.glow-button::before,
+.glow-button::after {
+  content: "";
+  position: absolute;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.glow-button::before {
+  inset: 0;
+  background:
+    conic-gradient(
+      from 0turn,
+      hsl(var(--glow-button-hue-a) 90% 60%),
+      hsl(var(--glow-button-hue-b) 90% 60%),
+      hsl(var(--glow-button-hue-c) 90% 60%),
+      hsl(var(--glow-button-hue-a) 90% 60%)
+    );
+  padding: var(--glow-button-border);
+  -webkit-mask:
+    radial-gradient(closest-side, transparent calc(100% - (var(--glow-button-border) + 1px)), #000 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask:
+    radial-gradient(closest-side, transparent calc(100% - (var(--glow-button-border) + 1px)), #000 0) content-box,
+    linear-gradient(#000 0 0);
+          mask-composite: exclude;
+  animation: glow-spin var(--glow-button-speed) linear infinite;
+  z-index: -1;
+}
+
+.glow-button::after {
+  inset: -28%;
+  background:
+    conic-gradient(
+      from 0turn,
+      hsl(var(--glow-button-hue-a) 90% 60% / .52),
+      hsl(var(--glow-button-hue-b) 90% 60% / .52),
+      hsl(var(--glow-button-hue-c) 90% 60% / .52),
+      hsl(var(--glow-button-hue-a) 90% 60% / .52)
+    );
+  filter: blur(32px) saturate(120%);
+  opacity: .9;
+  animation: glow-spin var(--glow-button-speed) linear infinite reverse;
+  z-index: -2;
+}
+
+.glow-button > span,
+.glow-button > svg {
+  position: relative;
+  z-index: 1;
+}
+
+.glow-button:hover {
+  filter: brightness(1.05);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 16px 36px rgba(56, 189, 248, 0.22),
+    0 0 24px rgba(129, 140, 248, 0.35);
+}
+
+.glow-button:active {
+  transform: translateY(1px);
+}
+
+.glow-button:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(99, 102, 241, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 10px 30px rgba(15, 23, 42, 0.35);
+}
+
+.glow-button[disabled] {
+  opacity: .6;
+  cursor: not-allowed;
+  filter: none;
+  transform: none;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 8px 20px rgba(15, 23, 42, 0.2);
+}
+
+.preset-button {
+  font-size: .75rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+@keyframes glow-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glow-button {
+    animation: none;
+  }
+  .glow-button::before,
+  .glow-button::after {
+    animation: none;
+  }
+}
+
 .grid-nodes {
   display: grid; gap: .75rem; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
 }

--- a/Server/app/static/presets.js
+++ b/Server/app/static/presets.js
@@ -232,7 +232,7 @@ if (container) {
       wrapper.dataset.custom = isCustomPreset(preset) ? 'true' : 'false';
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'preset preset-button glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400';
+      button.className = 'preset preset-button glow-button';
       button.dataset.presetId = id;
       button.dataset.custom = wrapper.dataset.custom;
       button.textContent = name;

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -19,15 +19,15 @@
   <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
     <h2 class="text-2xl font-semibold">Presets</h2>
     <div class="flex items-center gap-2">
-      <button id="presetSaveButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400">Save Preset</button>
-      <button id="presetEditButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400" aria-pressed="false" aria-controls="presetList">Edit</button>
+      <button id="presetSaveButton" type="button" class="glow-button text-sm font-semibold tracking-wide uppercase">Save Preset</button>
+      <button id="presetEditButton" type="button" class="glow-button text-sm font-semibold tracking-wide uppercase" aria-pressed="false" aria-controls="presetList">Edit</button>
     </div>
   </div>
   <div id="presetStatus" class="text-sm mb-3 opacity-80" role="status" aria-live="polite"></div>
   <div id="presetList" class="flex flex-wrap gap-2" data-editing="false" data-house-id="{{ house_public_id }}" data-room-id="{{ room.id }}" data-api-base="/api/house/{{ house_public_id }}/room/{{ room.id }}" data-initial-presets='{{ presets|tojson }}'>
     {% for p in presets %}
     <div class="preset-item" data-preset-id="{{ p.id }}" data-custom="{{ 'true' if p.source == 'custom' else 'false' }}">
-      <button class="preset preset-button glass px-4 py-2 rounded-lg hover:ring-2 hover:ring-indigo-400" type="button" data-preset-id="{{ p.id }}">{{ p.name or p.id }}</button>
+      <button class="preset preset-button glow-button" type="button" data-preset-id="{{ p.id }}">{{ p.name or p.id }}</button>
       {% if p.source == 'custom' %}
       <button class="preset-delete" type="button" aria-hidden="true" tabindex="-1" hidden aria-label="Delete preset {{ p.name or p.id }}" data-preset-id="{{ p.id }}">✕</button>
       {% endif %}


### PR DESCRIPTION
## Summary
- replace the glow-button background-clip treatment with a masked conic-gradient ring so the buttons match the provided animated glow
- add the blurred halo, updated hover/focus shadows, and reduced-motion handling in the shared glow-button styles

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68db25ccfed083268da6cd50ade532c6