### PR TITLE
Add animated gradient borders to room and node controls

### DIFF
--- a/Server/app/static/app.css
+++ b/Server/app/static/app.css
@@ -10,6 +10,66 @@
   --glow: 0 0 30px rgba(120, 70, 255, .35);
 }
 
+@property --border-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+.animated-border {
+  position: relative;
+  border-radius: inherit;
+  z-index: 0;
+  --border-angle: 0deg;
+}
+
+.animated-border::before,
+.animated-border::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: conic-gradient(
+    from var(--border-angle),
+    #0ea5e9,
+    #8b5cf6,
+    #ec4899,
+    #f97316,
+    #0ea5e9
+  );
+  animation: animated-border-rotate 8s linear infinite;
+}
+
+.animated-border::before {
+  padding: 2px;
+  z-index: -1;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+}
+
+.animated-border::after {
+  inset: -8px;
+  filter: blur(20px);
+  opacity: .45;
+  z-index: -2;
+}
+
+@keyframes animated-border-rotate {
+  from {
+    --border-angle: 0deg;
+  }
+  to {
+    --border-angle: 360deg;
+  }
+}
+
 * { box-sizing: border-box; }
 
 html, body {

--- a/Server/app/templates/house.html
+++ b/Server/app/templates/house.html
@@ -60,7 +60,7 @@
 {% if house.rooms %}
 <div class="grid md:grid-cols-3 gap-4" data-room-grid data-can-manage="{{ 'true' if can_manage_house else 'false' }}">
   {% for r in house.rooms %}
-  <a href="/house/{{ house_public_id }}/room/{{ r.id }}" data-room-card data-room-id="{{ r.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400{% if can_manage_house %} cursor-move{% endif %}">
+  <a href="/house/{{ house_public_id }}/room/{{ r.id }}" data-room-card data-room-id="{{ r.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400 animated-border{% if can_manage_house %} cursor-move{% endif %}">
     <div class="text-xl font-semibold">{{ r.name }}</div>
     <div class="opacity-60 text-xs mt-2">ID: {{ r.id }}</div>
     <div class="text-sm mt-2">{{ r.nodes|length }} node{% if r.nodes|length != 1 %}s{% endif %}</div>

--- a/Server/app/templates/modules/motion.html
+++ b/Server/app/templates/modules/motion.html
@@ -1,4 +1,4 @@
-<section class="glass rounded-2xl p-6">
+<section class="glass rounded-2xl p-6 animated-border">
   <h3 class="text-lg font-semibold mb-3">Motion Sensor</h3>
   <label class="flex items-center gap-3">
     <input id="motion" type="checkbox" class="w-5 h-5">

--- a/Server/app/templates/modules/rgb.html
+++ b/Server/app/templates/modules/rgb.html
@@ -1,4 +1,4 @@
-<section class="glass rounded-2xl p-6" data-module-root>
+<section class="glass rounded-2xl p-6 animated-border" data-module-root>
   <header class="mb-4">
     <h3 class="text-lg font-semibold">RGB Strips</h3>
     <p class="mt-2 text-sm text-slate-400 hidden" data-module-empty-message>

--- a/Server/app/templates/modules/white.html
+++ b/Server/app/templates/modules/white.html
@@ -1,4 +1,4 @@
-<section class="glass rounded-2xl p-6" data-module-root>
+<section class="glass rounded-2xl p-6 animated-border" data-module-root>
   <header class="mb-4">
     <h3 class="text-lg font-semibold">White Channels</h3>
     <p class="mt-2 text-sm text-slate-400 hidden" data-module-empty-message>

--- a/Server/app/templates/modules/ws.html
+++ b/Server/app/templates/modules/ws.html
@@ -1,4 +1,4 @@
-<section class="glass rounded-2xl p-6" data-module-root>
+<section class="glass rounded-2xl p-6 animated-border" data-module-root>
   <header class="mb-4">
     <h3 class="text-lg font-semibold">Addressable Strips</h3>
     <p class="mt-2 text-sm text-slate-400 hidden" data-module-empty-message>

--- a/Server/app/templates/room.html
+++ b/Server/app/templates/room.html
@@ -8,7 +8,7 @@
 </div>
 <div class="grid md:grid-cols-3 gap-4">
   {% for n in room.nodes %}
-  <a href="/node/{{ n.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400">
+  <a href="/node/{{ n.id }}" class="glass rounded-xl p-4 block hover:ring-2 hover:ring-indigo-400 animated-border">
     <div class="text-sm opacity-70 uppercase tracking-wide">{{ n.kind|upper }}</div>
     <div class="text-xl font-semibold">{{ n.name }}</div>
     <div class="opacity-60 text-xs mt-2">ID: {{ n.id }}</div>
@@ -20,7 +20,7 @@
     <h2 class="text-2xl font-semibold">Presets</h2>
     <div class="flex items-center gap-2">
       <button id="presetSaveButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400">Save Preset</button>
-      <button id="presetEditButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400" aria-pressed="false" aria-controls="presetList">Edit</button>
+      <button id="presetEditButton" type="button" class="glass px-4 py-2 rounded-lg text-sm font-semibold tracking-wide uppercase hover:ring-2 hover:ring-indigo-400 animated-border" aria-pressed="false" aria-controls="presetList">Edit</button>
     </div>
   </div>
   <div id="presetStatus" class="text-sm mb-3 opacity-80" role="status" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- add reusable animated-border utility with rotating conic gradient glow
- apply animated border styling to room and node cards plus node module panels
- highlight the room preset edit control with the animated border treatment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db4e79f8188326827bb8b151ef166b