### PR TITLE
Migrate legacy node credentials to registrations

### DIFF
--- a/Server/app/auth/models.py
+++ b/Server/app/auth/models.py
@@ -196,6 +196,18 @@ class NodeRegistration(SQLModel, table=True):
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),
     )
+    certificate_fingerprint: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(128), nullable=True),
+    )
+    certificate_pem_path: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    private_key_pem_path: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
 
 
 class NodeCredential(SQLModel, table=True):
@@ -222,6 +234,18 @@ class NodeCredential(SQLModel, table=True):
     provisioned_at: Optional[datetime] = Field(
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    certificate_fingerprint: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(128), nullable=True),
+    )
+    certificate_pem_path: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    private_key_pem_path: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
     )
 
 

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -741,6 +741,9 @@ def server_admin_panel(
             "assigned": registration.assigned_at is not None,
             "house": registration.house_slug,
             "room": registration.room_id,
+            "certificateFingerprint": registration.certificate_fingerprint,
+            "certificatePath": registration.certificate_pem_path,
+            "privateKeyAvailable": bool(registration.private_key_pem_path),
         }
 
     node_factory_context = {

--- a/Server/app/routes_server_admin.py
+++ b/Server/app/routes_server_admin.py
@@ -198,6 +198,15 @@ class NodeFactoryCreatedNode(BaseModel):
     ota_token: str = Field(..., alias="otaToken")
     manifest_url: str = Field(..., alias="manifestUrl")
     metadata: Dict[str, Any]
+    certificate_fingerprint: Optional[str] = Field(
+        default=None, alias="certificateFingerprint"
+    )
+    certificate_path: Optional[str] = Field(
+        default=None, alias="certificatePath"
+    )
+    private_key_available: bool = Field(
+        default=False, alias="privateKeyAvailable"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -214,6 +223,15 @@ class NodeFactoryRegistrationInfo(BaseModel):
     assigned: bool
     house_slug: Optional[str] = Field(default=None, alias="houseSlug")
     room_id: Optional[str] = Field(default=None, alias="roomId")
+    certificate_fingerprint: Optional[str] = Field(
+        default=None, alias="certificateFingerprint"
+    )
+    certificate_path: Optional[str] = Field(
+        default=None, alias="certificatePath"
+    )
+    private_key_available: bool = Field(
+        default=False, alias="privateKeyAvailable"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -236,6 +254,9 @@ def _registration_summary(registration: NodeRegistration) -> NodeFactoryRegistra
         if isinstance(raw_board, str):
             board = raw_board
     assigned = bool(registration.room_id)
+    certificate_fingerprint = registration.certificate_fingerprint
+    certificate_path = registration.certificate_pem_path
+    private_key_available = bool(registration.private_key_pem_path)
     return NodeFactoryRegistrationInfo(
         node_id=registration.node_id,
         download_id=registration.download_id,
@@ -244,6 +265,9 @@ def _registration_summary(registration: NodeRegistration) -> NodeFactoryRegistra
         assigned=assigned,
         house_slug=registration.house_slug,
         room_id=registration.room_id,
+        certificate_fingerprint=certificate_fingerprint,
+        certificate_path=certificate_path,
+        private_key_available=private_key_available,
     )
 
 
@@ -586,6 +610,9 @@ def create_node_factory_registrations(
             session.add(registration)
 
         manifest_url = f"{settings.PUBLIC_BASE}/firmware/{registration.download_id}/manifest.json"
+        certificate_fingerprint = registration.certificate_fingerprint
+        certificate_path = registration.certificate_pem_path
+        private_key_available = bool(registration.private_key_pem_path)
         created_nodes.append(
             NodeFactoryCreatedNode(
                 nodeId=registration.node_id,
@@ -593,6 +620,9 @@ def create_node_factory_registrations(
                 otaToken=entry.plaintext_token,
                 manifestUrl=manifest_url,
                 metadata=metadata.copy(),
+                certificateFingerprint=certificate_fingerprint,
+                certificatePath=certificate_path,
+                privateKeyAvailable=private_key_available,
             )
         )
         node_ids.append(registration.node_id)

--- a/Server/tests/test_management_cli.py
+++ b/Server/tests/test_management_cli.py
@@ -10,6 +10,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from app import database
 from app.auth.models import AuditLog, House, HouseMembership, HouseRole, User
+from app.auth.security import normalize_username
 from app.config import settings
 
 
@@ -97,7 +98,7 @@ def test_seed_sample_data_creates_demo_users(cli_db):
         houses = session.exec(select(House).order_by(House.id)).all()
         assert houses
         for house in houses:
-            username = f"sample-{house.external_id}"
+            username = normalize_username(f"sample-{house.external_id}")
             user = session.exec(select(User).where(User.username == username)).first()
             assert user is not None
             membership = session.exec(

--- a/Server/tests/test_node_registration_migration.py
+++ b/Server/tests/test_node_registration_migration.py
@@ -1,0 +1,144 @@
+import sys
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import database, node_credentials
+import app.registry as registry_module
+from app.auth.models import NodeCredential as NodeCredentialModel, NodeRegistration
+from app.auth.service import init_auth_storage
+from app.config import settings
+
+
+@pytest.fixture()
+def auth_db(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    original_registry = deepcopy(settings.DEVICE_REGISTRY)
+    original_db_url = settings.AUTH_DB_URL
+    original_registry_file = settings.REGISTRY_FILE
+
+    original_save_registry = registry_module.save_registry
+
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", [])
+    registry_file = tmp_path / "registry.json"
+    monkeypatch.setattr(settings, "REGISTRY_FILE", registry_file)
+    monkeypatch.setattr(registry_module.settings, "DEVICE_REGISTRY", [])
+    monkeypatch.setattr(registry_module.settings, "REGISTRY_FILE", registry_file)
+    monkeypatch.setattr(registry_module, "save_registry", lambda: None)
+
+    db_path = tmp_path / "auth.sqlite3"
+    db_url = f"sqlite:///{db_path}"
+    database.reset_session_factory(db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", db_url)
+
+    init_auth_storage()
+
+    yield
+
+    database.reset_session_factory(original_db_url)
+    monkeypatch.setattr(settings, "AUTH_DB_URL", original_db_url)
+    monkeypatch.setattr(settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(registry_module.settings, "DEVICE_REGISTRY", original_registry)
+    monkeypatch.setattr(settings, "REGISTRY_FILE", original_registry_file)
+    monkeypatch.setattr(registry_module.settings, "REGISTRY_FILE", original_registry_file)
+    monkeypatch.setattr(registry_module, "save_registry", original_save_registry)
+
+
+def test_migrate_credentials_creates_registration(auth_db):
+    created_at = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    token_issued_at = datetime(2024, 1, 2, 8, 30, tzinfo=timezone.utc)
+
+    with database.SessionLocal() as session:
+        credential = NodeCredentialModel(
+            node_id="legacy-node",
+            house_slug="alpha",
+            room_id="living",
+            display_name="Legacy Node",
+            download_id="download-123",
+            token_hash="hash-abc",
+            created_at=created_at,
+            token_issued_at=token_issued_at,
+            provisioned_at=None,
+            certificate_fingerprint="ff:aa",
+            certificate_pem_path="/data/certs/legacy-node.pem",
+            private_key_pem_path="/data/keys/legacy-node.key",
+        )
+        session.add(credential)
+        session.commit()
+
+        created = node_credentials.migrate_credentials_to_registrations(session)
+        assert created == 1
+
+        registration = node_credentials.get_registration_by_node_id(session, "legacy-node")
+        assert registration is not None
+        assert registration.download_id == "download-123"
+        assert registration.token_hash == "hash-abc"
+        assert registration.token_issued_at == _naive(token_issued_at)
+        assert registration.house_slug == "alpha"
+        assert registration.room_id == "living"
+        assert registration.display_name == "Legacy Node"
+        assert registration.assigned_at == _naive(created_at)
+        assert registration.provisioned_at is None
+        assert registration.certificate_fingerprint == "ff:aa"
+        assert registration.certificate_pem_path == "/data/certs/legacy-node.pem"
+        assert registration.private_key_pem_path == "/data/keys/legacy-node.key"
+
+
+def test_migrate_credentials_updates_existing_registration(auth_db):
+    created_at = datetime(2024, 3, 5, 9, 15, tzinfo=timezone.utc)
+    token_issued_at = datetime(2024, 3, 5, 10, 0, tzinfo=timezone.utc)
+
+    with database.SessionLocal() as session:
+        registration = NodeRegistration(
+            node_id="existing-node",
+            download_id="old-download",
+            token_hash="old-hash",
+            hardware_metadata={},
+        )
+        session.add(registration)
+        session.commit()
+
+        credential = NodeCredentialModel(
+            node_id="existing-node",
+            house_slug="beta",
+            room_id="den",
+            display_name="Existing Node",
+            download_id="new-download",
+            token_hash="new-hash",
+            created_at=created_at,
+            token_issued_at=token_issued_at,
+            provisioned_at=created_at,
+            certificate_fingerprint="11:22",
+            certificate_pem_path="/data/certs/existing.pem",
+            private_key_pem_path="/data/keys/existing.key",
+        )
+        session.add(credential)
+        session.commit()
+
+        created = node_credentials.migrate_credentials_to_registrations(session)
+        assert created == 0
+
+        updated = node_credentials.get_registration_by_node_id(session, "existing-node")
+        assert updated is not None
+        assert updated.download_id == "new-download"
+        assert updated.token_hash == "new-hash"
+        assert updated.token_issued_at == _naive(token_issued_at)
+        assert updated.provisioned_at == _naive(created_at)
+        assert updated.house_slug == "beta"
+        assert updated.room_id == "den"
+        assert updated.display_name == "Existing Node"
+        assert updated.assigned_at == _naive(created_at)
+        assert updated.certificate_fingerprint == "11:22"
+        assert updated.certificate_pem_path == "/data/certs/existing.pem"
+        assert updated.private_key_pem_path == "/data/keys/existing.key"
+def _naive(dt: datetime) -> datetime:
+    """Return a naive datetime for SQLite comparisons."""
+
+    return dt.replace(tzinfo=None)
+
+


### PR DESCRIPTION
## Summary
- add a migration helper that backfills node_registrations rows from existing node_credentials entries and invoke it during auth storage initialization
- cover the migration with dedicated tests and align admin API and management CLI tests with the new pre-registered node workflow

## Testing
- pytest Server

------
https://chatgpt.com/codex/tasks/task_e_68dc02085b888326a2102f43c4323236