### PR TITLE
Issue per-node client certificates and secure delivery

### DIFF
--- a/Server/app/auth/models.py
+++ b/Server/app/auth/models.py
@@ -208,6 +208,10 @@ class NodeRegistration(SQLModel, table=True):
         default=None,
         sa_column=Column(String(255), nullable=True),
     )
+    certificate_bundle_path: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
 
 
 class NodeCredential(SQLModel, table=True):
@@ -244,6 +248,10 @@ class NodeCredential(SQLModel, table=True):
         sa_column=Column(String(255), nullable=True),
     )
     private_key_pem_path: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    certificate_bundle_path: Optional[str] = Field(
         default=None,
         sa_column=Column(String(255), nullable=True),
     )

--- a/Server/app/auth/service.py
+++ b/Server/app/auth/service.py
@@ -84,11 +84,13 @@ def _ensure_node_registration_columns() -> None:
             "certificate_fingerprint": "ALTER TABLE node_registrations ADD COLUMN certificate_fingerprint VARCHAR(128)",
             "certificate_pem_path": "ALTER TABLE node_registrations ADD COLUMN certificate_pem_path VARCHAR(255)",
             "private_key_pem_path": "ALTER TABLE node_registrations ADD COLUMN private_key_pem_path VARCHAR(255)",
+            "certificate_bundle_path": "ALTER TABLE node_registrations ADD COLUMN certificate_bundle_path VARCHAR(255)",
         },
         "node_credentials": {
             "certificate_fingerprint": "ALTER TABLE node_credentials ADD COLUMN certificate_fingerprint VARCHAR(128)",
             "certificate_pem_path": "ALTER TABLE node_credentials ADD COLUMN certificate_pem_path VARCHAR(255)",
             "private_key_pem_path": "ALTER TABLE node_credentials ADD COLUMN private_key_pem_path VARCHAR(255)",
+            "certificate_bundle_path": "ALTER TABLE node_credentials ADD COLUMN certificate_bundle_path VARCHAR(255)",
         },
     }
 

--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -35,6 +35,30 @@ class Settings:
     )
     FIRMWARE_DIR.mkdir(parents=True, exist_ok=True)
 
+    _cert_root_env = os.getenv("NODE_CERT_ROOT", "")
+    if _cert_root_env:
+        _cert_root = Path(_cert_root_env)
+        if not _cert_root.is_absolute():
+            _cert_root = DATA_DIR / _cert_root
+    else:
+        _cert_root = DATA_DIR / "node_certs"
+    NODE_CERT_ROOT = _cert_root.expanduser().resolve()
+    NODE_CERT_ROOT.mkdir(parents=True, exist_ok=True)
+    NODE_CERT_CA_CERT = os.getenv("NODE_CERT_CA_CERT", "")
+    NODE_CERT_CA_KEY = os.getenv("NODE_CERT_CA_KEY", "")
+    NODE_CERT_CA_KEY_PASSPHRASE = os.getenv("NODE_CERT_CA_KEY_PASSPHRASE", "")
+    NODE_CERT_VALID_DAYS = int(os.getenv("NODE_CERT_VALID_DAYS", "365"))
+    NODE_CERT_KEY_BITS = int(os.getenv("NODE_CERT_KEY_BITS", "3072"))
+    NODE_CERT_SUBJECT_TEMPLATE = os.getenv(
+        "NODE_CERT_SUBJECT_TEMPLATE", "/CN={node_id}"
+    )
+    NODE_CERT_SAN_TEMPLATE = os.getenv(
+        "NODE_CERT_SAN_TEMPLATE", "DNS:{node_id}"
+    )
+    NODE_CERT_BUNDLE_NAME = os.getenv(
+        "NODE_CERT_BUNDLE_NAME", "credentials.tar.gz"
+    )
+
     API_BEARER = os.getenv("API_BEARER", "")
     MANIFEST_HMAC_SECRET = os.getenv("MANIFEST_HMAC_SECRET", "")
 

--- a/Server/app/routes_pages.py
+++ b/Server/app/routes_pages.py
@@ -744,6 +744,7 @@ def server_admin_panel(
             "certificateFingerprint": registration.certificate_fingerprint,
             "certificatePath": registration.certificate_pem_path,
             "privateKeyAvailable": bool(registration.private_key_pem_path),
+            "certificateBundlePath": registration.certificate_bundle_path,
         }
 
     node_factory_context = {

--- a/Server/tests/test_firmware_cli.py
+++ b/Server/tests/test_firmware_cli.py
@@ -91,6 +91,7 @@ def test_cli_build_invokes_builder_and_archiver(cli_environment, monkeypatch: py
         return _make_build_result(node_id_arg, download_id)
 
     def fake_store(**kwargs):
+        assert "certificate_bundle" in kwargs
         calls.setdefault("store", []).append(kwargs)
         return _make_artifact(kwargs["node_id"], kwargs["download_id"])
 
@@ -124,6 +125,8 @@ def test_cli_build_invokes_builder_and_archiver(cli_environment, monkeypatch: py
     assert calls["store"][0]["node_id"] == node_id
     assert Path(calls["store"][0]["firmware_dir"]) == firmware_dir
     assert Path(calls["store"][0]["archive_root"]) == archive_dir
+    assert "certificate_bundle" in calls["store"][0]
+    assert calls["store"][0]["certificate_bundle"] is None
 
 
 def test_cli_update_all_builds_every_registration(cli_environment, monkeypatch: pytest.MonkeyPatch):
@@ -151,6 +154,7 @@ def test_cli_update_all_builds_every_registration(cli_environment, monkeypatch: 
         return _make_build_result(node_id_arg, download)
 
     def fake_store(**kwargs):
+        assert "certificate_bundle" in kwargs
         stored_nodes.append(kwargs["node_id"])
         return _make_artifact(kwargs["node_id"], kwargs["download_id"])
 

--- a/tools/firmware_cli/cli.py
+++ b/tools/firmware_cli/cli.py
@@ -228,9 +228,14 @@ def _handle_build(args, firmware_dir: Path, archive_dir: Path) -> int:
             firmware_version=args.firmware_version,
             firmware_dir=firmware_dir,
             archive_root=archive_dir,
+            certificate_bundle=result.certificate_bundle_path,
         )
         print(f"Built {result.node_id} -> {artifact.manifest_path}")
         print(f"Binary SHA256: {artifact.sha256_hex}")
+        if result.certificate and result.certificate.fingerprint:
+            print(f"Certificate fingerprint: {result.certificate.fingerprint}")
+        if artifact.certificate_bundle_path:
+            print(f"Credential bundle: {artifact.certificate_bundle_path}")
         if result.project_configs:
             print("Updated configuration files:")
             for cfg in result.project_configs:
@@ -273,9 +278,14 @@ def _handle_flash(args, firmware_dir: Path, archive_dir: Path) -> int:
             firmware_version=args.firmware_version,
             firmware_dir=firmware_dir,
             archive_root=archive_dir,
+            certificate_bundle=result.certificate_bundle_path,
         )
         print(f"Flashed {result.node_id} ({port}) -> {artifact.manifest_path}")
         print(f"Binary SHA256: {artifact.sha256_hex}")
+        if result.certificate and result.certificate.fingerprint:
+            print(f"Certificate fingerprint: {result.certificate.fingerprint}")
+        if artifact.certificate_bundle_path:
+            print(f"Credential bundle: {artifact.certificate_bundle_path}")
         if result.project_configs:
             print("Updated configuration files:")
             for cfg in result.project_configs:
@@ -322,6 +332,7 @@ def _handle_update_all(args, firmware_dir: Path, archive_dir: Path) -> int:
                 firmware_version=args.firmware_version,
                 firmware_dir=firmware_dir,
                 archive_root=archive_dir,
+                certificate_bundle=result.certificate_bundle_path,
             )
             print(f"Built {result.node_id} -> {artifact.manifest_path}")
         return exit_code


### PR DESCRIPTION
## Summary
- add certificate issuance and bundling to the firmware builder, copying bundles alongside artifacts and refreshing credential metadata
- extend scripts, CLI tooling, and admin views to surface certificate fingerprints and bundle paths without exposing private keys
- expose a protected credentials download endpoint and track rotations in the audit log

## Testing
- pytest Server/tests/test_firmware_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dc092518a883269a2633d2f3cb4b0d