### PR TITLE
Enable MQTT mTLS provisioning and update docs

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -88,6 +88,13 @@ The broker is configured with Let's Encrypt certificates at
 connections. Clients rely on the system CA bundle, so additional certificate
 paths are unnecessary unless a custom trust store is desired.
 
+When migrating to mutual TLS, populate `BROKER_TLS_CA_FILE` with the
+UltraLights root CA and provide `BROKER_TLS_CERTFILE`/`BROKER_TLS_KEYFILE` so the
+server authenticates with its own client certificate. This identity is separate
+from the per-node certificates issued through the provisioning portal.
+Coordinate CA enrolment with the Mosquitto runbook in `docs/mqtt-broker-tls.md`
+so the broker trusts the same CA hierarchy used by the firmware.
+
 ## Operational notes
 
 - Authentication and administrative actions are persisted to the `audit_logs`
@@ -101,3 +108,7 @@ paths are unnecessary unless a custom trust store is desired.
   environment so it connects over MQTTs when enabled. If no terminal emulator is
   available, the script falls back to a background `mosquitto_sub` subscriber so
   message logging continues without blocking the server startup.
+- Track per-node certificate rotations in the operations log. Revoke the old
+  certificate in Mosquitto, update any ACL entries that reference the certificate
+  subject, and re-run the provisioning portal to deliver the new bundle to the
+  node.

--- a/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
+++ b/UltraNodeV5/components/ul_mqtt/test/ul_mqtt_test_stubs.h
@@ -18,9 +18,14 @@ typedef int esp_err_t;
 #define CONFIG_UL_MQTT_URI "test://broker"
 #define CONFIG_UL_MQTT_USER "test_user"
 #define CONFIG_UL_MQTT_PASS "test_pass"
+#define CONFIG_UL_MQTT_LEGACY_USERPASS_COMPAT 1
 #define CONFIG_UL_MQTT_DIAL_HOST ""
 #define CONFIG_UL_MQTT_DIAL_PORT 0
 #define CONFIG_UL_MQTT_USE_TLS 1
+#define CONFIG_UL_MQTT_REQUIRE_CLIENT_CERT 1
+#define CONFIG_UL_MQTT_PROVISION_CERTS 1
+#define CONFIG_UL_MQTT_CLIENT_CERT_MAX_LEN 1024
+#define CONFIG_UL_MQTT_CLIENT_KEY_MAX_LEN 1024
 #define CONFIG_UL_MQTT_TLS_SKIP_COMMON_NAME_CHECK 0
 #define CONFIG_UL_MQTT_TLS_COMMON_NAME "test-broker"
 #define CONFIG_UL_MQTT_CONNECT_TIMEOUT_MS 20000
@@ -90,6 +95,10 @@ typedef struct {
     const char *username;
     struct {
       const char *password;
+      const char *certificate;
+      size_t certificate_len;
+      const char *key;
+      size_t key_len;
     } authentication;
   } credentials;
   struct {
@@ -119,18 +128,20 @@ typedef struct {
   char user_password[129];
   char wifi_username[65];
   char wifi_user_password[129];
+  unsigned char mqtt_client_cert[CONFIG_UL_MQTT_CLIENT_CERT_MAX_LEN];
+  size_t mqtt_client_cert_len;
+  unsigned char mqtt_client_key[CONFIG_UL_MQTT_CLIENT_KEY_MAX_LEN];
+  size_t mqtt_client_key_len;
 } ul_wifi_credentials_t;
+
+extern bool g_stub_credentials_available;
+extern ul_wifi_credentials_t g_stub_credentials;
 
 static inline bool ul_wifi_credentials_load(ul_wifi_credentials_t *out) {
   if (!out)
     return false;
-  out->ssid[0] = '\0';
-  out->password[0] = '\0';
-  out->user[0] = '\0';
-  out->user_password[0] = '\0';
-  out->wifi_username[0] = '\0';
-  out->wifi_user_password[0] = '\0';
-  return false;
+  *out = g_stub_credentials;
+  return g_stub_credentials_available;
 }
 
 bool ul_core_is_connected(void);
@@ -149,4 +160,5 @@ esp_mqtt_client_handle_t ul_mqtt_test_get_client_handle(void);
 bool ul_mqtt_test_retry_pending(void);
 uint32_t ul_mqtt_test_consecutive_failures(void);
 bool ul_mqtt_test_restart_pending(void);
+const esp_mqtt_client_config_t *ul_mqtt_test_get_last_config(void);
 

--- a/UltraNodeV5/components/ul_wifi/include/ul_wifi_credentials.h
+++ b/UltraNodeV5/components/ul_wifi/include/ul_wifi_credentials.h
@@ -3,6 +3,21 @@
 #include "esp_err.h"
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+
+#if defined(__has_include)
+#if __has_include("sdkconfig.h")
+#include "sdkconfig.h"
+#endif
+#endif
+
+#ifndef CONFIG_UL_MQTT_CLIENT_CERT_MAX_LEN
+#define CONFIG_UL_MQTT_CLIENT_CERT_MAX_LEN 3072
+#endif
+
+#ifndef CONFIG_UL_MQTT_CLIENT_KEY_MAX_LEN
+#define CONFIG_UL_MQTT_CLIENT_KEY_MAX_LEN 2048
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,6 +30,10 @@ typedef struct {
   char user_password[129];
   char wifi_username[65];
   char wifi_user_password[129];
+  uint8_t mqtt_client_cert[CONFIG_UL_MQTT_CLIENT_CERT_MAX_LEN];
+  size_t mqtt_client_cert_len;
+  uint8_t mqtt_client_key[CONFIG_UL_MQTT_CLIENT_KEY_MAX_LEN];
+  size_t mqtt_client_key_len;
 } ul_wifi_credentials_t;
 
 bool ul_wifi_credentials_load(ul_wifi_credentials_t *out);

--- a/UltraNodeV5/docs/mqtt.md
+++ b/UltraNodeV5/docs/mqtt.md
@@ -31,6 +31,29 @@ Leaving `UL_MQTT_TLS_COMMON_NAME` blank reuses the hostname from
 `UL_MQTT_URI`, which is useful when the certificate already matches the broker
 URI and only the dial host differs.
 
+## Mutual TLS provisioning
+
+Nodes now support mutual TLS when `CONFIG_UL_MQTT_REQUIRE_CLIENT_CERT=y`. The
+MQTT configuration menu exposes two new toggles:
+
+* `CONFIG_UL_MQTT_LEGACY_USERPASS_COMPAT` keeps the historical
+  username/password authentication enabled while migrating to per-node client
+  certificates. Disable it once every device has been re-provisioned.
+* `CONFIG_UL_MQTT_PROVISION_CERTS` enables the captive portal flow for
+  provisioning the certificate bundle. The portal expects base64-encoded fields
+  named `mqtt_client_certificate` and `mqtt_client_key` in the provisioning POST
+  body after the user authenticates with their UltraLights account.
+
+The decoded blobs are stored in NVS and injected into
+`esp_mqtt_client_config_t.credentials.authentication.certificate` / `key`
+before the MQTT client starts. When `CONFIG_UL_MQTT_REQUIRE_CLIENT_CERT` is
+enabled the node refuses to connect until both blobs are present, preventing
+plaintext or anonymous fallbacks.
+
+Set `CONFIG_UL_MQTT_CLIENT_CERT_MAX_LEN` /
+`CONFIG_UL_MQTT_CLIENT_KEY_MAX_LEN` if your certificate chain or encrypted key
+material exceeds the defaults (3 KiB and 2 KiB respectively).
+
 ## Topic scheme
 
 All topics are rooted at `ul/<node-id>/`. The node subscribes to commands addressed to itself and to the broadcast topic `ul/+/cmd/#`.

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -69,12 +69,23 @@ menu "MQTT"
     config UL_MQTT_URI
         string "MQTT URI"
         default "mqtts://lights.evm100.org:8883"
-    config UL_MQTT_USER
-        string "MQTT Username"
-        default "uluser"
-    config UL_MQTT_PASS
-        string "MQTT Password"
-        default "ulpwd"
+    config UL_MQTT_LEGACY_USERPASS_COMPAT
+        bool "Enable legacy MQTT username/password authentication"
+        default y
+        help
+            The UltraLights MQTT stack historically authenticated with a shared
+            username/password pair. Enable this option to continue seeding the
+            client configuration with UL_MQTT_USER / UL_MQTT_PASS while rolling
+            out mutual TLS. Disable once every node has a provisioned client
+            certificate.
+    if UL_MQTT_LEGACY_USERPASS_COMPAT
+        config UL_MQTT_USER
+            string "MQTT Username"
+            default "uluser"
+        config UL_MQTT_PASS
+            string "MQTT Password"
+            default "ulpwd"
+    endif
     config UL_MQTT_DIAL_HOST
         string "Override MQTT dial host/IP"
         default ""
@@ -97,6 +108,35 @@ menu "MQTT"
         help
             Enable TLS when connecting to the MQTT broker.
     if UL_MQTT_USE_TLS
+        config UL_MQTT_REQUIRE_CLIENT_CERT
+            bool "Require provisioned MQTT client certificate"
+            default y
+            help
+                Enforce mutual TLS when connecting to the MQTT broker. The node
+                refuses to start MQTT until a client certificate and encrypted
+                private key have been provisioned and stored in NVS.
+        config UL_MQTT_PROVISION_CERTS
+            bool "Provision client certificates via captive portal"
+            default y
+            help
+                Accept a base64 encoded client certificate/key bundle from the
+                provisioning server after authenticating with the node owner.
+                Disable when certificates are injected through another secure
+                channel.
+        config UL_MQTT_CLIENT_CERT_MAX_LEN
+            int "Maximum MQTT client certificate size (bytes)"
+            range 512 8192
+            default 3072
+            help
+                Upper bound on the decoded client certificate stored in NVS.
+                Increase this limit if using unusually large PEM chains.
+        config UL_MQTT_CLIENT_KEY_MAX_LEN
+            int "Maximum MQTT client private key size (bytes)"
+            range 512 8192
+            default 2048
+            help
+                Upper bound on the encrypted private key blob stored in NVS.
+                Increase when deploying longer RSA keys or custom key wrappers.
         config UL_MQTT_TLS_COMMON_NAME
             string "MQTT TLS common name"
             default "lights.evm100.org"


### PR DESCRIPTION
## Summary
- persist the MQTT client certificate and encrypted key in NVS and provision them via the captive portal
- load the stored certificate/key when starting the MQTT client, gating legacy user/password auth behind a compatibility flag
- document the new mTLS workflow for nodes, the broker, and deployment operations

## Testing
- python UltraNodeV5/components/ul_mqtt/test/test_ul_mqtt_retry.py

------
https://chatgpt.com/codex/tasks/task_e_68dc0ed3137483268c09ff63578a3cd0