### PR TITLE
Flip modern rainbow effect channels with RG swap option

### DIFF
--- a/Server/app/node_builder.py
+++ b/Server/app/node_builder.py
@@ -377,6 +377,11 @@ def normalize_hardware_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
         return {}
 
     normalized = copy.deepcopy(metadata)
+
+    if "ws2812FlipRG" in normalized and "ws2812_flip_rg" not in normalized:
+        normalized["ws2812_flip_rg"] = normalized.pop("ws2812FlipRG")
+
+    normalized["ws2812_flip_rg"] = bool(normalized.get("ws2812_flip_rg"))
     board = str(normalized.get("board", "esp32")).lower()
     normalized["board"] = board
 
@@ -470,6 +475,7 @@ def _ws_overrides(metadata: Dict[str, Any]) -> Dict[str, Tuple[Any, bool]]:
     channels = metadata.get("ws2812") or []
     overrides: Dict[str, Tuple[Any, bool]] = {}
     indexed = {int(entry.get("index", -1)): entry for entry in channels if isinstance(entry, dict)}
+    overrides["CONFIG_UL_WS_FLIP_RG"] = _bool_flag(bool(metadata.get("ws2812_flip_rg")))
     for idx in range(2):
         entry = indexed.get(idx) or {}
         enabled = bool(entry.get("enabled"))

--- a/Server/app/routes_server_admin.py
+++ b/Server/app/routes_server_admin.py
@@ -153,13 +153,14 @@ class PirSensorConfig(BaseModel):
 
 class NodeHardwareConfig(BaseModel):
     board: str = Field(default="esp32")
+    ws2812_flip_rg: bool = Field(default=False, alias="ws2812FlipRG")
     ws2812: List[Ws2812ChannelConfig] = Field(default_factory=list)
     white: List[WhiteChannelConfig] = Field(default_factory=list)
     rgb: List[RgbChannelConfig] = Field(default_factory=list)
     pir: Optional[PirSensorConfig] = None
     overrides: Dict[str, Any] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     @field_validator("board")
     @classmethod

--- a/Server/app/templates/server_admin.html
+++ b/Server/app/templates/server_admin.html
@@ -134,6 +134,13 @@
             </label>
           </div>
           {% endfor %}
+          <label class="flex items-start gap-3 text-xs font-semibold">
+            <input type="checkbox" data-ws-flip-rg>
+            <span>
+              Flip red/green values for WS MQTT payloads
+              <span class="block font-normal opacity-60">Enable when using WS2815 strips with reversed wiring.</span>
+            </span>
+          </label>
         </div>
         <div class="grid gap-4" data-channel-group="white" data-channel-type="white">
           <div class="text-sm font-semibold">White channels</div>
@@ -543,6 +550,7 @@ function collectHardwarePayload(root) {
   const wsGroup = root.querySelector('[data-channel-group="ws"]');
   const whiteGroup = root.querySelector('[data-channel-group="white"]');
   const rgbGroup = root.querySelector('[data-channel-group="rgb"]');
+  const wsFlipInput = root.querySelector('[data-ws-flip-rg]');
   const overridesText = root.querySelector('[data-overrides]')?.value || '';
   const pirEnabled = root.querySelector('[data-pir-enabled]')?.checked || false;
   const pirGpioRaw = root.querySelector('[data-pir-gpio]')?.value || '';
@@ -561,6 +569,7 @@ function collectHardwarePayload(root) {
 
   const hardware = {
     board,
+    ws2812FlipRG: wsFlipInput?.checked || false,
     ws2812: wsGroup ? collectChannels(wsGroup) : [],
     white: whiteGroup ? collectChannels(whiteGroup) : [],
     rgb: rgbGroup ? collectChannels(rgbGroup) : [],

--- a/Server/tests/test_node_builder_metadata.py
+++ b/Server/tests/test_node_builder_metadata.py
@@ -59,6 +59,19 @@ def test_ws2812_channel_values_are_copied():
     assert overrides["CONFIG_UL_WS0_PIXELS"][0] == 120
 
 
+def test_ws2812_flip_rg_override_flag():
+    metadata = {"board": "esp32", "ws2812_flip_rg": True}
+
+    overrides = node_builder.metadata_to_overrides(metadata)
+
+    assert overrides["CONFIG_UL_WS_FLIP_RG"][0] is True
+
+    disabled_metadata = {"board": "esp32", "ws2812_flip_rg": False}
+    disabled_overrides = node_builder.metadata_to_overrides(disabled_metadata)
+
+    assert disabled_overrides["CONFIG_UL_WS_FLIP_RG"][0] is False
+
+
 def test_project_sdkconfig_updates_include_metadata(tmp_path, monkeypatch: pytest.MonkeyPatch, auth_db):
     project_config = tmp_path / "sdkconfig"
     project_config.write_text("CONFIG_UL_NODE_ID=\"default\"\n", encoding="utf-8")
@@ -110,6 +123,7 @@ def test_project_sdkconfig_updates_include_metadata(tmp_path, monkeypatch: pytes
     assert captured["CONFIG_UL_WS0_ENABLED"][0] is True
     assert captured["CONFIG_UL_WS0_GPIO"][0] == 6
     assert captured["CONFIG_UL_WS0_PIXELS"][0] == 150
+    assert captured["CONFIG_UL_WS_FLIP_RG"][0] is False
     assert captured["CONFIG_UL_RGB0_ENABLED"][0] is True
     assert captured["CONFIG_UL_RGB0_R_GPIO"][0] == 18
     assert captured["CONFIG_UL_RGB0_G_GPIO"][0] == 19

--- a/Server/tests/test_node_factory.py
+++ b/Server/tests/test_node_factory.py
@@ -89,6 +89,7 @@ def test_create_node_registrations(admin_client: TestClient):
         "displayName": "Batch Node",
         "hardware": {
             "board": "esp32c3",
+            "ws2812FlipRG": True,
             "ws2812": [
                 {"index": 0, "enabled": True, "gpio": 6, "pixels": 60},
             ],
@@ -114,6 +115,7 @@ def test_create_node_registrations(admin_client: TestClient):
         assert all(reg.display_name.startswith("Batch Node") for reg in regs)
 
         expected_metadata = node_builder.normalize_hardware_metadata(payload["hardware"])
+        assert expected_metadata["ws2812_flip_rg"] is True
         for reg in regs:
             assert reg.hardware_metadata == expected_metadata
 

--- a/UltraNodeV5/components/ul_ws_engine/effects_ws/modern_rainbow.c
+++ b/UltraNodeV5/components/ul_ws_engine/effects_ws/modern_rainbow.c
@@ -32,8 +32,13 @@ void modern_rainbow_render(uint8_t *frame_rgb, int pixels, int frame_idx) {
         uint8_t hue = (uint8_t)((i * 256 / cycle + frame_idx) & 0xFF);
         uint8_t r, g, b;
         hsv_to_rgb(hue, &r, &g, &b);
+#if CONFIG_UL_WS_FLIP_RG
+        frame_rgb[3 * i + 0] = g;
+        frame_rgb[3 * i + 1] = r;
+#else
         frame_rgb[3 * i + 0] = r;
         frame_rgb[3 * i + 1] = g;
+#endif
         frame_rgb[3 * i + 2] = b;
     }
 }

--- a/UltraNodeV5/main/Kconfig.projbuild
+++ b/UltraNodeV5/main/Kconfig.projbuild
@@ -323,6 +323,14 @@ menu "RGB Strips (LEDC)"
 endmenu
 
 menu "WS2812 Strips"
+    config UL_WS_FLIP_RG
+        bool "Flip red/green values in MQTT payloads"
+        default n
+        help
+            Some WS2815 LED strips are wired with the red and green channels
+            reversed relative to WS2812 ordering. Enable this option to flip
+            the red and green values from incoming MQTT payloads before they
+            are applied to the strips.
     menu "Strip 0"
         config UL_WS0_ENABLED
             bool "Enabled"


### PR DESCRIPTION
## Summary
- update the modern_rainbow effect to swap red and green outputs when UL_WS_FLIP_RG is enabled so the animation respects WS2815 wiring

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4f418c5c8326b170c661deaee664